### PR TITLE
Use pattern matching to set initial_state variable

### DIFF
--- a/test/dpul_collections/indexing_pipeline/figgy_producer_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy_producer_test.exs
@@ -7,7 +7,7 @@ defmodule DpulCollections.IndexingPipeline.FiggyProducerTest do
   describe "FiggyProducer" do
     test "handle_demand/2 with initial state and demand > 1 returns figgy resources" do
       {marker1, marker2, _marker3} = FiggyTestSupport.markers()
-      initial_state = FiggyProducer.init(0) |> elem(1)
+      {:producer, initial_state} = FiggyProducer.init(0)
       {:noreply, messages, new_state} = FiggyProducer.handle_demand(2, initial_state)
 
       ids = Enum.map(messages, fn %Broadway.Message{data: %FiggyResource{id: id}} -> id end)


### PR DESCRIPTION
rather than piping to `elem`