### PR TITLE
Add an integration test that hydrates the full data set.

### DIFF
--- a/test/dpul_collections/indexing_pipeline/integration/figgy_hydrator_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/figgy_hydrator_integration_test.exs
@@ -1,10 +1,11 @@
 defmodule DpulCollections.IndexingPipeline.FiggyHydratorIntegrationTest do
   use DpulCollections.DataCase
 
-  alias DpulCollections.IndexingPipeline.FiggyHydrator
+  alias DpulCollections.FiggyRepo
+  alias DpulCollections.IndexingPipeline.{FiggyHydrator, FiggyResource}
   alias DpulCollections.IndexingPipeline
 
-  def start_producer do
+  def start_producer(batch_size \\ 1) do
     pid = self()
 
     :telemetry.attach(
@@ -19,7 +20,7 @@ defmodule DpulCollections.IndexingPipeline.FiggyHydratorIntegrationTest do
         cache_version: 0,
         producer_module: FiggyTestProducer,
         producer_options: {self()},
-        batch_size: 1
+        batch_size: batch_size
       )
 
     hydrator
@@ -111,6 +112,30 @@ defmodule DpulCollections.IndexingPipeline.FiggyHydratorIntegrationTest do
     assert cache_entry.record_id == marker2.id
     assert cache_entry.cache_version == 0
     assert cache_entry.source_cache_order == marker2.timestamp
+    hydrator |> Broadway.stop(:normal)
+  end
+
+  def wait_for_hydrated_id(id, cache_version \\ 0) do
+    case IndexingPipeline.get_hydrator_marker(0) do
+      %{cache_record_id: ^id} ->
+        true
+
+      _ ->
+        :timer.sleep(50)
+        wait_for_hydrated_id(id, cache_version)
+    end
+  end
+
+  test "a full hydration run" do
+    # Start the producer
+    hydrator = start_producer(50)
+    # Demand all of them.
+    count = FiggyRepo.aggregate(FiggyResource, :count)
+    FiggyTestProducer.process(count)
+    # Wait for the last ID to show up.
+    task = Task.async(fn -> wait_for_hydrated_id(FiggyTestSupport.last_marker().id) end)
+    Task.await(task, 5000)
+
     hydrator |> Broadway.stop(:normal)
   end
 end

--- a/test/support/figgy_test_support.ex
+++ b/test/support/figgy_test_support.ex
@@ -1,5 +1,7 @@
 defmodule FiggyTestSupport do
-  alias DpulCollections.IndexingPipeline.ResourceMarker
+  import Ecto.Query, warn: false
+  alias DpulCollections.IndexingPipeline.{ResourceMarker, FiggyResource}
+  alias DpulCollections.FiggyRepo
 
   # @spec markers :: {ProcessorMarker.marker(), ProcessorMarker.marker(), ProcessorMarker.marker()}
   # These are the first three known resource markers in the test database.
@@ -22,5 +24,15 @@ defmodule FiggyTestSupport do
     }
 
     {marker1, marker2, marker3}
+  end
+
+  # Get the last marker from the figgy repo.
+  def last_marker do
+    query =
+      from r in FiggyResource,
+        limit: 1,
+        order_by: [desc: r.updated_at, desc: r.id]
+
+    FiggyRepo.all(query) |> hd |> ResourceMarker.from()
   end
 end


### PR DESCRIPTION
This adds an integration test that does everything by kicking off all resources and waiting for the last one to show up in the database. It spawns a process with `Task.async` so we can set a timeout, so if it's too slow it crashes.

This test takes something like three seconds, so either we have to be okay with that for now, or find a way to be happy with unit tests for this filtering functionality somehow.