### PR TITLE
small refactors for language consistency

### DIFF
--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_producer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_producer.ex
@@ -21,7 +21,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationProducer do
           stored_demand: Integer
         }
   def init(cache_version) do
-    last_queried_marker = IndexingPipeline.get_processor_marker!("hydrator", cache_version)
+    last_queried_marker = IndexingPipeline.get_processor_marker!("figgy_hydrator", cache_version)
 
     initial_state = %{
       last_queried_marker: last_queried_marker |> Figgy.ResourceMarker.from(),
@@ -112,7 +112,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationProducer do
       %Figgy.ResourceMarker{timestamp: cache_location, id: cache_record_id} = last_removed_marker
 
       IndexingPipeline.write_processor_marker(%{
-        type: "hydrator",
+        type: "figgy_hydrator",
         cache_version: state.cache_version,
         cache_location: cache_location,
         cache_record_id: cache_record_id

--- a/lib/dpul_collections/indexing_pipeline/figgy/transformation_producer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/transformation_producer.ex
@@ -101,7 +101,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationProducer do
   @impl GenStage
   @spec handle_info({atom(), atom(), list(%Figgy.HydrationCacheEntryMarker{})}, state()) ::
           {:noreply, list(Broadway.Message.t()), state()}
-  def handle_info({:ack, :transformer_producer_ack, pending_markers}, state) do
+  def handle_info({:ack, :transformation_producer_ack, pending_markers}, state) do
     messages = []
 
     sorted_markers =
@@ -182,10 +182,10 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationProducer do
 
   @impl Broadway.Acknowledger
   @spec ack({pid(), atom()}, list(Broadway.Message.t()), list(Broadway.Message.t())) :: any()
-  def ack({transformer_producer_pid, :transformer_producer_ack}, successful, failed) do
+  def ack({transformation_producer_pid, :transformation_producer_ack}, successful, failed) do
     # TODO: Do some error handling
     acked_markers = (successful ++ failed) |> Enum.map(&Figgy.HydrationCacheEntryMarker.from/1)
-    send(transformer_producer_pid, {:ack, :transformer_producer_ack, acked_markers})
+    send(transformation_producer_pid, {:ack, :transformation_producer_ack, acked_markers})
   end
 
   # This happens when ack is finished, we listen to this telemetry event in
@@ -193,17 +193,17 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationProducer do
   @spec notify_ack(integer()) :: any()
   defp notify_ack(acked_message_count) do
     :telemetry.execute(
-      [:transformer_producer, :ack, :done],
+      [:transformation_producer, :ack, :done],
       %{},
       %{acked_count: acked_message_count}
     )
   end
 
-  @spec wrap_record(record :: HydratorCacheEntry) :: Broadway.Message.t()
+  @spec wrap_record(record :: HydrationCacheEntry) :: Broadway.Message.t()
   defp wrap_record(record) do
     %Broadway.Message{
       data: record,
-      acknowledger: {__MODULE__, {self(), :transformer_producer_ack}, nil}
+      acknowledger: {__MODULE__, {self(), :transformation_producer_ack}, nil}
     }
   end
 end

--- a/test/dpul_collections/indexing_pipeline/figgy/hydration_producer_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/hydration_producer_test.exs
@@ -182,7 +182,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationProducerTest do
         )
 
       assert new_state == expected_state
-      processor_marker = IndexingPipeline.get_processor_marker!("hydrator", cache_version)
+      processor_marker = IndexingPipeline.get_processor_marker!("figgy_hydrator", cache_version)
 
       assert marker1 == %Figgy.ResourceMarker{
                timestamp: processor_marker.cache_location,
@@ -208,7 +208,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationProducerTest do
 
       assert new_state == expected_state
 
-      processor_marker = IndexingPipeline.get_processor_marker!("hydrator", cache_version)
+      processor_marker = IndexingPipeline.get_processor_marker!("figgy_hydrator", cache_version)
 
       assert marker3 == %Figgy.ResourceMarker{
                timestamp: processor_marker.cache_location,
@@ -258,7 +258,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationProducerTest do
         )
 
       assert new_state == expected_state
-      processor_marker = IndexingPipeline.get_processor_marker!("hydrator", 1)
+      processor_marker = IndexingPipeline.get_processor_marker!("figgy_hydrator", 1)
       assert processor_marker == nil
     end
 
@@ -294,7 +294,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationProducerTest do
         )
 
       assert new_state == expected_state
-      processor_marker = IndexingPipeline.get_processor_marker!("hydrator", 1)
+      processor_marker = IndexingPipeline.get_processor_marker!("figgy_hydrator", 1)
       assert processor_marker == nil
     end
 
@@ -340,7 +340,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationProducerTest do
         )
 
       assert new_state == expected_state
-      processor_marker = IndexingPipeline.get_processor_marker!("hydrator", 1)
+      processor_marker = IndexingPipeline.get_processor_marker!("figgy_hydrator", 1)
       assert processor_marker == nil
     end
 
@@ -401,7 +401,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationProducerTest do
       assert new_state == expected_state
 
       processor_marker =
-        IndexingPipeline.get_processor_marker!("hydrator", 1) |> Figgy.ResourceMarker.from()
+        IndexingPipeline.get_processor_marker!("figgy_hydrator", 1) |> Figgy.ResourceMarker.from()
 
       assert processor_marker == marker2
     end

--- a/test/dpul_collections/indexing_pipeline/figgy/transformation_producer_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/transformation_producer_test.exs
@@ -1,4 +1,4 @@
-defmodule DpulCollections.IndexingPipeline.Figgy.TransformerProducerTest do
+defmodule DpulCollections.IndexingPipeline.Figgy.TransformationProducerTest do
   use DpulCollections.DataCase
 
   alias DpulCollections.IndexingPipeline.Figgy
@@ -151,7 +151,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformerProducerTest do
 
       {:noreply, [], new_state} =
         Figgy.TransformationProducer.handle_info(
-          {:ack, :transformer_producer_ack, acked_hydration_cache_markers},
+          {:ack, :transformation_producer_ack, acked_hydration_cache_markers},
           initial_state
         )
 
@@ -178,7 +178,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformerProducerTest do
 
       {:noreply, [], new_state} =
         Figgy.TransformationProducer.handle_info(
-          {:ack, :transformer_producer_ack, acked_hydration_cache_markers},
+          {:ack, :transformation_producer_ack, acked_hydration_cache_markers},
           initial_state
         )
 
@@ -230,7 +230,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformerProducerTest do
 
       {:noreply, [], new_state} =
         Figgy.TransformationProducer.handle_info(
-          {:ack, :transformer_producer_ack, acked_hydration_cache_markers},
+          {:ack, :transformation_producer_ack, acked_hydration_cache_markers},
           initial_state
         )
 
@@ -266,7 +266,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformerProducerTest do
 
       {:noreply, [], new_state} =
         Figgy.TransformationProducer.handle_info(
-          {:ack, :transformer_producer_ack, acked_hydration_cache_markers},
+          {:ack, :transformation_producer_ack, acked_hydration_cache_markers},
           initial_state
         )
 
@@ -312,7 +312,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformerProducerTest do
 
       {:noreply, [], new_state} =
         Figgy.TransformationProducer.handle_info(
-          {:ack, :transformer_producer_ack, acked_hydration_cache_markers},
+          {:ack, :transformation_producer_ack, acked_hydration_cache_markers},
           initial_state
         )
 
@@ -355,7 +355,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformerProducerTest do
 
       {:noreply, [], new_state} =
         Figgy.TransformationProducer.handle_info(
-          {:ack, :transformer_producer_ack, first_ack},
+          {:ack, :transformation_producer_ack, first_ack},
           initial_state
         )
 
@@ -377,7 +377,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformerProducerTest do
 
       {:noreply, [], new_state} =
         Figgy.TransformationProducer.handle_info(
-          {:ack, :transformer_producer_ack, second_ack},
+          {:ack, :transformation_producer_ack, second_ack},
           new_state
         )
 

--- a/test/dpul_collections/indexing_pipeline/integration/figgy/hydration_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/figgy/hydration_integration_test.exs
@@ -64,7 +64,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HyrdationIntegrationTest do
              "internal_resource" => "EphemeraTerm"
            } = cache_entry.data
 
-    processor_marker = IndexingPipeline.get_processor_marker!("hydrator", 1)
+    processor_marker = IndexingPipeline.get_processor_marker!("figgy_hydrator", 1)
     assert processor_marker.cache_version == 1
 
     hydrator |> Broadway.stop(:normal)
@@ -121,7 +121,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HyrdationIntegrationTest do
     {marker1, marker2, _marker3} = FiggyTestFixtures.markers()
     # Create a marker
     IndexingPipeline.write_processor_marker(%{
-      type: "hydrator",
+      type: "figgy_hydrator",
       cache_version: 0,
       cache_location: marker1.timestamp,
       cache_record_id: marker1.id

--- a/test/dpul_collections/indexing_pipeline/integration/figgy/transformation_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/figgy/transformation_integration_test.exs
@@ -4,12 +4,12 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationIntegrationTest d
   alias DpulCollections.IndexingPipeline.Figgy
   alias DpulCollections.IndexingPipeline
 
-  def start_transformer_producer(cache_version \\ 0) do
+  def start_transformation_producer(cache_version \\ 0) do
     pid = self()
 
     :telemetry.attach(
       "ack-handler-#{pid |> :erlang.pid_to_list()}",
-      [:transformer_producer, :ack, :done],
+      [:transformation_producer, :ack, :done],
       fn _event, _, _, _ -> send(pid, {:ack_done}) end,
       nil
     )
@@ -28,7 +28,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationIntegrationTest d
   test "transformation cache entry creation" do
     {marker1, _marker2, _marker3} = FiggyTestFixtures.hydration_cache_markers()
 
-    transformer = start_transformer_producer()
+    transformer = start_transformation_producer()
 
     MockFiggyTransformationProducer.process(1)
     assert_receive {:ack_done}
@@ -50,7 +50,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationIntegrationTest d
   test "transformation cache entry creation with cache version > 0" do
     {marker1, _marker2, _marker3} = FiggyTestFixtures.hydration_cache_markers()
 
-    transformer = start_transformer_producer(1)
+    transformer = start_transformation_producer(1)
 
     MockFiggyTransformationProducer.process(1)
     assert_receive {:ack_done}
@@ -88,7 +88,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationIntegrationTest d
     })
 
     # Process that past record.
-    transformer = start_transformer_producer()
+    transformer = start_transformation_producer()
     MockFiggyTransformationProducer.process(1)
     assert_receive {:ack_done}
     transformer |> Broadway.stop(:normal)
@@ -116,7 +116,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationIntegrationTest d
     })
 
     # Process that past record.
-    transformer = start_transformer_producer()
+    transformer = start_transformation_producer()
     MockFiggyTransformationProducer.process(1)
     assert_receive {:ack_done}
     transformer |> Broadway.stop(:normal)
@@ -140,7 +140,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationIntegrationTest d
     })
 
     # Start the producer
-    transformer = start_transformer_producer()
+    transformer = start_transformation_producer()
     MockFiggyTransformationProducer.process(1)
     assert_receive {:ack_done}
     # Make sure the first record that comes back is what we expect
@@ -162,7 +162,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationIntegrationTest d
     })
 
     # Process that past record.
-    transformer = start_transformer_producer()
+    transformer = start_transformation_producer()
     MockFiggyTransformationProducer.process(1)
     assert_receive {:ack_done}
     transformer |> Broadway.stop(:normal)

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -51,7 +51,10 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
 
     # Ensure that the processor markers have the correct cache version
     hydration_processor_marker = IndexingPipeline.get_processor_marker!("figgy_hydrator", 1)
-    transformation_processor_marker = IndexingPipeline.get_processor_marker!("figgy_transformer", 1)
+
+    transformation_processor_marker =
+      IndexingPipeline.get_processor_marker!("figgy_transformer", 1)
+
     indexing_processor_marker = IndexingPipeline.get_processor_marker!("figgy_indexer", 1)
     assert hydration_processor_marker.cache_version == 1
     assert transformation_processor_marker.cache_version == 1

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -12,14 +12,14 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
   end
 
   def wait_for_index_completion() do
-    transformer_cache_entries = IndexingPipeline.list_transformation_cache_entries() |> length
+    transformation_cache_entries = IndexingPipeline.list_transformation_cache_entries() |> length
     ephemera_folder_count = FiggyTestSupport.ephemera_folder_count()
 
     continue =
-      if transformer_cache_entries == ephemera_folder_count do
+      if transformation_cache_entries == ephemera_folder_count do
         DpulCollections.Solr.commit()
 
-        if DpulCollections.Solr.document_count() == transformer_cache_entries do
+        if DpulCollections.Solr.document_count() == transformation_cache_entries do
           true
         end
       end
@@ -50,11 +50,11 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
     assert Solr.document_count() == transformation_cache_entry_count
 
     # Ensure that the processor markers have the correct cache version
-    hydrator_processor_marker = IndexingPipeline.get_processor_marker!("figgy_hydrator", 1)
-    transformer_processor_marker = IndexingPipeline.get_processor_marker!("figgy_transformer", 1)
+    hydration_processor_marker = IndexingPipeline.get_processor_marker!("figgy_hydrator", 1)
+    transformation_processor_marker = IndexingPipeline.get_processor_marker!("figgy_transformer", 1)
     indexing_processor_marker = IndexingPipeline.get_processor_marker!("figgy_indexer", 1)
-    assert hydrator_processor_marker.cache_version == 1
-    assert transformer_processor_marker.cache_version == 1
+    assert hydration_processor_marker.cache_version == 1
+    assert transformation_processor_marker.cache_version == 1
     assert indexing_processor_marker.cache_version == 1
 
     hydrator |> Broadway.stop(:normal)

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -50,7 +50,7 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
     assert Solr.document_count() == transformation_cache_entry_count
 
     # Ensure that the processor markers have the correct cache version
-    hydrator_processor_marker = IndexingPipeline.get_processor_marker!("hydrator", 1)
+    hydrator_processor_marker = IndexingPipeline.get_processor_marker!("figgy_hydrator", 1)
     transformer_processor_marker = IndexingPipeline.get_processor_marker!("figgy_transformer", 1)
     indexing_processor_marker = IndexingPipeline.get_processor_marker!("figgy_indexer", 1)
     assert hydrator_processor_marker.cache_version == 1

--- a/test/support/mock_figgy_transformation_producer.ex
+++ b/test/support/mock_figgy_transformation_producer.ex
@@ -13,7 +13,11 @@ defmodule MockFiggyTransformationProducer do
   use GenStage
 
   @impl GenStage
-  @type state :: %{consumer_pid: pid(), test_runner_pid: pid(), transformation_producer_pid: pid()}
+  @type state :: %{
+          consumer_pid: pid(),
+          test_runner_pid: pid(),
+          transformation_producer_pid: pid()
+        }
   @spec init({pid(), Integer}) :: {:producer, state()}
   def init({test_runner_pid, cache_version}) do
     {:ok, transformation_producer_pid} = Figgy.TransformationProducer.start_link(cache_version)

--- a/test/support/mock_figgy_transformation_producer.ex
+++ b/test/support/mock_figgy_transformation_producer.ex
@@ -13,17 +13,17 @@ defmodule MockFiggyTransformationProducer do
   use GenStage
 
   @impl GenStage
-  @type state :: %{consumer_pid: pid(), test_runner_pid: pid(), transformer_producer_pid: pid()}
+  @type state :: %{consumer_pid: pid(), test_runner_pid: pid(), transformation_producer_pid: pid()}
   @spec init({pid(), Integer}) :: {:producer, state()}
   def init({test_runner_pid, cache_version}) do
-    {:ok, transformer_producer_pid} = Figgy.TransformationProducer.start_link(cache_version)
-    {:ok, consumer_pid} = MockConsumer.start_link(transformer_producer_pid)
+    {:ok, transformation_producer_pid} = Figgy.TransformationProducer.start_link(cache_version)
+    {:ok, consumer_pid} = MockConsumer.start_link(transformation_producer_pid)
 
     {:producer,
      %{
        consumer_pid: consumer_pid,
        test_runner_pid: test_runner_pid,
-       transformer_producer_pid: transformer_producer_pid
+       transformation_producer_pid: transformation_producer_pid
      }}
   end
 


### PR DESCRIPTION
Use "figgy_hydrator" instead of "hydrator" for processor marker.

Use transformation_* instead of transformer_* and hydration_* instead of hydrator_*.
