### PR TITLE
Descriptions w/ Language Detection

### DIFF
--- a/lib/dpul_collections/indexing_pipeline/figgy/transformation_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/transformation_consumer.ex
@@ -88,11 +88,13 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationConsumer do
   @spec transform_to_solr_document(%Figgy.HydrationCacheEntry{}) :: %{}
   defp transform_to_solr_document(hydration_cache_entry) do
     %{record_id: id} = hydration_cache_entry
-    %{data: %{"metadata" => %{"title" => title}}} = hydration_cache_entry
+    %{data: %{"metadata" => metadata = %{"title" => title}}} = hydration_cache_entry
+    description = get_in(metadata, ["description"])
 
     %{
       id: id,
-      title_ss: title
+      title_ss: title,
+      description_txtm: description
     }
   end
 end

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -143,7 +143,41 @@
       "*_itsi" => "*_i"
     -->
 
-    <dynamicField name="*_txt_ens" type="text_en"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm" type="text_general" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_nolang" type="text_general" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_en" type="text_en"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_ar" type="text_ar"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_bg" type="text_bg"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_ca" type="text_ca"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_cjk" type="text_cjk" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_cz" type="text_cz"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_da" type="text_da"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_de" type="text_de"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_el" type="text_el"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_es" type="text_es"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_et" type="text_et"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_eu" type="text_eu"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_fa" type="text_fa"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_fi" type="text_fi"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_fr" type="text_fr"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_ga" type="text_ga"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_gl" type="text_gl"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_hi" type="text_hi"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_hu" type="text_hu"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_hy" type="text_hy"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_id" type="text_id"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_it" type="text_it"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_ja" type="text_ja"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_ko" type="text_ko"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_lv" type="text_lv"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_nl" type="text_nl"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_no" type="text_no"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_pt" type="text_pt"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_ro" type="text_ro"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_ru" type="text_ru"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_sv" type="text_sv"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_th" type="text_th"  indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_txtm_tr" type="text_tr"  indexed="true"  stored="true" multiValued="true"/>
 
     <dynamicField name="*_i"  type="pint"    indexed="true"  stored="true"/>
     <dynamicField name="*_is" type="pints"    indexed="true"  stored="true"/>

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -91,6 +91,7 @@
        configuration.
     -->
   <dataDir>${solr.data.dir:}</dataDir>
+  <schemaFactory class="ClassicIndexSchemaFactory"/>
 
 
   <!-- The DirectoryFactory to use for indexes.

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -1094,8 +1094,8 @@
   <updateProcessor class="org.apache.solr.update.processor.LangDetectLanguageIdentifierUpdateProcessorFactory" name="lang-detection">
     <str name="langid">true</str>
     <str name="langid.fl">description_txtm</str>
-    <str name="langid.langField">language_s</str>
-    <str name="langid.langsField">language_ss</str>
+    <str name="langid.langField">detectlang_s</str>
+    <str name="langid.langsField">detectlang_ss</str>
     <str name="langid.fallback">nolang</str>
     <str name="langid.map">true</str>
     <str name="langid.map.keepOrig">true</str>

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -1106,6 +1106,8 @@
     </lst>
   </updateProcessor>
 
+  <!-- Language detection and indexing for descriptions -->
+
   <!-- The update.autoCreateFields property can be turned to false to disable schemaless mode -->
   <updateRequestProcessorChain name="add-unknown-fields-to-the-schema" default="${update.autoCreateFields:true}"
            processor="uuid,remove-blank,field-name-mutating,parse-boolean,parse-long,parse-double,parse-date,add-schema-fields">

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -72,7 +72,8 @@
        The example below can be used to load a solr-contrib along
        with their external dependencies.
     -->
-    <!-- <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-ltr-\d.*\.jar" /> -->
+    <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-.*\.jar" />
+    <lib dir="${solr.install.dir:../../../..}/contrib/langid/lib/" regex=".*\.jar" />
 
   <!-- an exact 'path' can be used instead of a 'dir' to specify a
        specific jar file.  This will cause a serious error to be logged
@@ -776,6 +777,12 @@
     </lst>
   </initParams>
 
+  <initParams path="/update/**">
+    <lst name="defaults">
+      <str name="update.chain">langdetect</str>
+    </lst>
+  </initParams>
+
   <!-- Search Components
 
        Search components are registered to SolrCore and used by
@@ -1042,6 +1049,13 @@
 
     -->
 
+  <updateRequestProcessorChain name="langdetect"
+           processor="lang-detection">
+    <processor class="solr.LogUpdateProcessorFactory"/>
+    <processor class="solr.DistributedUpdateProcessorFactory"/>
+    <processor class="solr.RunUpdateProcessorFactory"/>
+  </updateRequestProcessorChain>
+
   <!-- Add unknown fields to the schema
 
        Field type guessing update processors that will
@@ -1075,6 +1089,17 @@
       <str>EEEE, dd-MMM-yy HH:mm:ss z</str>
       <str>EEE MMM ppd HH:mm:ss [z ]yyyy</str>
     </arr>
+  </updateProcessor>
+  <updateProcessor class="org.apache.solr.update.processor.LangDetectLanguageIdentifierUpdateProcessorFactory" name="lang-detection">
+    <str name="langid">true</str>
+    <str name="langid.fl">description_txtm</str>
+    <str name="langid.langField">language_s</str>
+    <str name="langid.langsField">language_ss</str>
+    <str name="langid.fallback">nolang</str>
+    <str name="langid.map">true</str>
+    <str name="langid.map.keepOrig">true</str>
+    <str name="langid.map.individual">true</str>
+    <str name="langid.whitelist">en,ar,bg,ca,cj,cz,da,de,el,es,et,eu,fa,fi,fr,ga,gl,hi,hu,hy,id,it,ja,ko,lv,nl,no,pt,ro,ru,sv,th,tr</str>
   </updateProcessor>
   <updateProcessor class="solr.AddSchemaFieldsUpdateProcessorFactory" name="add-schema-fields">
     <lst name="typeMapping">

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -87,7 +87,7 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
     # Language detection
     assert %{"description_txtm_en" => [first_description | _tail]} = document
     assert first_description |> String.starts_with?("Asra-Panahi") == true
-    assert %{"language_ss" => ["en"]} = document
+    assert %{"detectlang_ss" => ["en"]} = document
 
     hydrator |> Broadway.stop(:normal)
     transformer |> Broadway.stop(:normal)

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -27,6 +27,17 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
     continue || (:timer.sleep(100) && wait_for_index_completion())
   end
 
+  def wait_for_indexed_count(count) do
+    DpulCollections.Solr.commit()
+    continue =
+        if DpulCollections.Solr.document_count() == count do
+          true
+        else
+          false
+        end
+    continue || (:timer.sleep(100) && wait_for_indexed_count(count))
+  end
+
   test "a full hydrator and transformer run" do
     # Start the figgy producer
     {:ok, indexer} = Figgy.IndexingConsumer.start_link(cache_version: 1, batch_size: 50)
@@ -60,6 +71,54 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
     assert transformation_processor_marker.cache_version == 1
     assert indexing_processor_marker.cache_version == 1
 
+    hydrator |> Broadway.stop(:normal)
+    transformer |> Broadway.stop(:normal)
+    indexer |> Broadway.stop(:normal)
+  end
+
+  def index_record_id(id) do
+    # Get record with a description.
+    record = IndexingPipeline.get_figgy_resource!(id)
+    # Write a current hydration marker right before that marker.
+    marker = IndexingPipeline.DatabaseProducer.CacheEntryMarker.from(record)
+    earlier_marker = %IndexingPipeline.DatabaseProducer.CacheEntryMarker{id: marker.id, timestamp: DateTime.add(marker.timestamp, -1, :microsecond)}
+      IndexingPipeline.write_processor_marker(%{
+        type: IndexingPipeline.Figgy.HydrationProducerSource.processor_marker_key(),
+        cache_version: 1,
+        cache_location: earlier_marker.timestamp,
+        cache_record_id: earlier_marker.id
+      })
+
+    # Start the figgy producer
+    {:ok, indexer} = Figgy.IndexingConsumer.start_link(cache_version: 1, batch_size: 50)
+    {:ok, transformer} = Figgy.TransformationConsumer.start_link(cache_version: 1, batch_size: 50)
+
+    # Control hydration indexing.
+    {:ok, hydrator} =
+      Figgy.HydrationConsumer.start_link(
+        cache_version: 1,
+        batch_size: 50,
+        producer_module: MockFiggyHydrationProducer,
+        producer_options: {self(), 1},
+      )
+
+    # Index one.
+    MockFiggyHydrationProducer.process(1)
+    task =
+      Task.async(fn -> wait_for_indexed_count(1) end)
+
+    Task.await(task, 15000)
+    document = Solr.find_by_id(id)
+    IO.inspect(Solr.document_count())
+    { hydrator, transformer, indexer, document }
+  end
+
+  test "indexes description" do
+    { hydrator, transformer, indexer, document } = index_record_id("26713a31-d615-49fd-adfc-93770b4f66b3")
+
+    assert %{"description_txt" => [first_description | _tail]} = document
+    assert first_description |> String.starts_with?("Asra-Panahi") == true
+    IO.inspect(document)
     hydrator |> Broadway.stop(:normal)
     transformer |> Broadway.stop(:normal)
     indexer |> Broadway.stop(:normal)

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -78,51 +78,9 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
     indexer |> Broadway.stop(:normal)
   end
 
-  def index_record_id(id) do
-    # Get record with a description.
-    record = IndexingPipeline.get_figgy_resource!(id)
-    # Write a current hydration marker right before that marker.
-    marker = IndexingPipeline.DatabaseProducer.CacheEntryMarker.from(record)
-
-    earlier_marker = %IndexingPipeline.DatabaseProducer.CacheEntryMarker{
-      id: marker.id,
-      timestamp: DateTime.add(marker.timestamp, -1, :microsecond)
-    }
-
-    IndexingPipeline.write_processor_marker(%{
-      type: IndexingPipeline.Figgy.HydrationProducerSource.processor_marker_key(),
-      cache_version: 1,
-      cache_location: earlier_marker.timestamp,
-      cache_record_id: earlier_marker.id
-    })
-
-    # Start the figgy producer
-    {:ok, indexer} = Figgy.IndexingConsumer.start_link(cache_version: 1, batch_size: 50)
-    {:ok, transformer} = Figgy.TransformationConsumer.start_link(cache_version: 1, batch_size: 50)
-
-    # Control hydration indexing.
-    {:ok, hydrator} =
-      Figgy.HydrationConsumer.start_link(
-        cache_version: 1,
-        batch_size: 50,
-        producer_module: MockFiggyHydrationProducer,
-        producer_options: {self(), 1}
-      )
-
-    # Index one.
-    MockFiggyHydrationProducer.process(1)
-
-    task =
-      Task.async(fn -> wait_for_indexed_count(1) end)
-
-    Task.await(task, 15000)
-    document = Solr.find_by_id(id)
-    {hydrator, transformer, indexer, document}
-  end
-
   test "indexes description" do
     {hydrator, transformer, indexer, document} =
-      index_record_id("26713a31-d615-49fd-adfc-93770b4f66b3")
+      FiggyTestSupport.index_record_id("26713a31-d615-49fd-adfc-93770b4f66b3")
 
     assert %{"description_txtm" => [first_description | _tail]} = document
     assert first_description |> String.starts_with?("Asra-Panahi") == true

--- a/test/support/figgy_test_support.ex
+++ b/test/support/figgy_test_support.ex
@@ -1,6 +1,7 @@
 defmodule FiggyTestSupport do
   import Ecto.Query, warn: false
 
+  alias DpulCollections.{IndexingPipeline, Solr}
   alias DpulCollections.IndexingPipeline.Figgy
 
   alias DpulCollections.FiggyRepo
@@ -19,5 +20,60 @@ defmodule FiggyTestSupport do
         where: r.internal_resource == "EphemeraFolder"
 
     FiggyRepo.aggregate(query, :count)
+  end
+
+  def index_record_id(id) do
+    # Get record with a description.
+    record = IndexingPipeline.get_figgy_resource!(id)
+    # Write a current hydration marker right before that marker.
+    marker = IndexingPipeline.DatabaseProducer.CacheEntryMarker.from(record)
+
+    earlier_marker = %IndexingPipeline.DatabaseProducer.CacheEntryMarker{
+      id: marker.id,
+      timestamp: DateTime.add(marker.timestamp, -1, :microsecond)
+    }
+
+    IndexingPipeline.write_processor_marker(%{
+      type: IndexingPipeline.Figgy.HydrationProducerSource.processor_marker_key(),
+      cache_version: 1,
+      cache_location: earlier_marker.timestamp,
+      cache_record_id: earlier_marker.id
+    })
+
+    # Start the figgy producer
+    {:ok, indexer} = Figgy.IndexingConsumer.start_link(cache_version: 1, batch_size: 50)
+    {:ok, transformer} = Figgy.TransformationConsumer.start_link(cache_version: 1, batch_size: 50)
+
+    # Control hydration indexing.
+    {:ok, hydrator} =
+      Figgy.HydrationConsumer.start_link(
+        cache_version: 1,
+        batch_size: 50,
+        producer_module: MockFiggyHydrationProducer,
+        producer_options: {self(), 1}
+      )
+
+    # Index one.
+    MockFiggyHydrationProducer.process(1)
+
+    task =
+      Task.async(fn -> wait_for_indexed_count(1) end)
+
+    Task.await(task, 15000)
+    document = Solr.find_by_id(id)
+    {hydrator, transformer, indexer, document}
+  end
+
+  def wait_for_indexed_count(count) do
+    DpulCollections.Solr.commit()
+
+    continue =
+      if DpulCollections.Solr.document_count() == count do
+        true
+      else
+        false
+      end
+
+    continue || (:timer.sleep(100) && wait_for_indexed_count(count))
   end
 end


### PR DESCRIPTION
This uses Solr's language detection features to generate a description field for every language it could be, so we can hopefully improve searching for that field, given that we know it's going to be in multiple languages.

I do not know how we'll actually enable search for all these languages, but at least this would get us them separated out.

Solr language detection: https://solr.apache.org/guide/7_2/detecting-languages-during-indexing.html

Closes #111