### PR TITLE
Cluster DPUL-Collections nodes w/ DNS

### DIFF
--- a/config/deploy/staging.hcl
+++ b/config/deploy/staging.hcl
@@ -40,6 +40,11 @@ job "dpulc-staging" {
         timeout = "1s"
       }
     }
+    affinity {
+      attribute = "${meta.node_type}"
+      value = "default"
+      weight = 100
+    }
     task "release-migrate" {
       # The dbmigrate task will run BEFORE the puma task in this group.
       lifecycle {
@@ -109,6 +114,11 @@ job "dpulc-staging" {
     network {
       port "http" { to = 4000 }
       port "epmd" { static = 6789 }
+    }
+    affinity {
+      attribute = "${meta.node_type}"
+      value = "worker"
+      weight = 100
     }
     service {
       name = "dpulc-staging-web"

--- a/config/deploy/staging.hcl
+++ b/config/deploy/staging.hcl
@@ -65,6 +65,7 @@ job "dpulc-staging" {
         SECRET_KEY_BASE = {{ .SECRET_KEY_BASE }}
         CACHE_VERSION = ${var.cache_version}
         PHX_HOST = ${var.host}
+        DNS_CLUSTER_QUERY = "dpulc-staging-web.service.consul"
         {{- end -}}
         EOF
       }
@@ -107,6 +108,7 @@ job "dpulc-staging" {
     count = 1
     network {
       port "http" { to = 4000 }
+      port "epmd" { static = 6789 }
     }
     service {
       name = "dpulc-staging-web"

--- a/config/deploy/staging.hcl
+++ b/config/deploy/staging.hcl
@@ -126,6 +126,10 @@ job "dpulc-staging" {
         ports = ["http"]
         force_pull = true
       }
+      env {
+        RELEASE_IP = "${NOMAD_IP_http}"
+        ERL_DIST_PORT = 6789
+      }
       # Save a bunch of CPU and RAM to run indexing.
       resources {
         cores = 6

--- a/config/deploy/staging.hcl
+++ b/config/deploy/staging.hcl
@@ -136,7 +136,7 @@ job "dpulc-staging" {
       driver = "podman"
       config {
         image = "ghcr.io/pulibrary/dpul-collections:${ var.branch_or_sha }"
-        ports = ["http"]
+        ports = ["http", "epmd"]
         force_pull = true
       }
       env {

--- a/config/deploy/staging.hcl
+++ b/config/deploy/staging.hcl
@@ -97,6 +97,7 @@ job "dpulc-staging" {
         SECRET_KEY_BASE = {{ .SECRET_KEY_BASE }}
         CACHE_VERSION = ${var.cache_version}
         PHX_HOST = ${var.host}
+        DNS_CLUSTER_QUERY = "dpulc-staging-web.service.consul"
         {{- end -}}
         EOF
       }

--- a/config/deploy/staging.hcl
+++ b/config/deploy/staging.hcl
@@ -25,7 +25,7 @@ job "dpulc-staging" {
       port "epmd" { static = 6789 }
       # Add the consul DNS loopback, so we can use consul queries.
       dns {
-        servers = ["10.88.0.1", "128.112.129.209", "8.8.8.8", "8.8.4.4"]
+        servers = ["10.88.0.1", "128.112.129.209"]
       }
     }
     service {

--- a/config/deploy/staging.hcl
+++ b/config/deploy/staging.hcl
@@ -22,6 +22,11 @@ job "dpulc-staging" {
     count = 2
     network {
       port "http" { to = 4000 }
+      port "epmd" { static = 6789 }
+      # Add the consul DNS loopback, so we can use consul queries.
+      dns {
+        servers = ["10.88.0.1", "128.112.129.209", "8.8.8.8", "8.8.4.4"]
+      }
     }
     service {
       port = "http"
@@ -68,14 +73,18 @@ job "dpulc-staging" {
       driver = "podman"
       config {
         image = "ghcr.io/pulibrary/dpul-collections:${ var.branch_or_sha }"
-        ports = ["http"]
+        ports = ["http", "epmd"]
         force_pull = true
       }
-      # Doesn't take much just to run a webserver.
       resources {
         cpu    = 2000
         memory = 1000
       }
+      env {
+        RELEASE_IP = "${NOMAD_IP_http}"
+        ERL_DIST_PORT = 6789
+      }
+
       template {
         destination = "${NOMAD_SECRETS_DIR}/env.vars"
         env = true
@@ -135,6 +144,7 @@ job "dpulc-staging" {
         CACHE_VERSION = ${var.cache_version}
         PHX_HOST = ${var.host}
         INDEXER = true
+        DNS_CLUSTER_QUERY = "dpulc-staging-web.service.consul"
         {{- end -}}
         EOF
       }

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# # Sets and enables heart (recommended only in daemon mode)
+# case $RELEASE_COMMAND in
+#   daemon*)
+#     HEART_COMMAND="$RELEASE_ROOT/bin/$RELEASE_NAME $RELEASE_COMMAND"
+#     export HEART_COMMAND
+#     export ELIXIR_ERL_OPTIONS="-heart"
+#     ;;
+#   *)
+#     ;;
+# esac
+
+# # Set the release to load code on demand (interactive) instead of preloading (embedded).
+# export RELEASE_MODE=interactive
+
+# # Set the release to work across nodes.
+# # RELEASE_DISTRIBUTION must be "sname" (local), "name" (distributed) or "none".
+export RELEASE_DISTRIBUTION=name
+export RELEASE_NODE="<%= @release.name %>@${RELEASE_IP}"
+export ERL_DIST_PORT=6789
+# export RELEASE_NODE="<%= @release.name %>@127.0.0.1"

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -18,5 +18,3 @@
 # # RELEASE_DISTRIBUTION must be "sname" (local), "name" (distributed) or "none".
 export RELEASE_DISTRIBUTION=name
 export RELEASE_NODE="<%= @release.name %>@${RELEASE_IP}"
-export ERL_DIST_PORT=6789
-# export RELEASE_NODE="<%= @release.name %>@127.0.0.1"

--- a/rel/remote.vm.args.eex
+++ b/rel/remote.vm.args.eex
@@ -1,0 +1,11 @@
+## Customize flags given to the VM: https://www.erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10
+## Enable deployment without epmd
+## (requires changing both vm.args and remote.vm.args)
+-start_epmd false -erl_epmd_port 6789 -dist_listen false

--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -1,0 +1,10 @@
+## Customize flags given to the VM: https://www.erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10
+-start_epmd false -erl_epmd_port 6789
+## -env ERL_DIST_PORT 6789


### PR DESCRIPTION
This does the following:

1. Disables EPMD (Erlang Port Mapper Daemon)
2. Makes all distribution traffic go through a known port (6789).
3. Forwards that port for each web instance.
4. Uses the DNS server on the host so it can run consul queries.
5. Uses a consul DNS query to get all hosts running DPUL-C.
6. Configures dns_cluster to query those hosts.

Companion PR: https://github.com/pulibrary/princeton_ansible/pull/5424

Closes #118