### PR TITLE
Title language detection & Tokenized Search

### DIFF
--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry.ex
@@ -25,7 +25,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntry do
 
     %{
       id: id,
-      title_ss: get_in(metadata, ["title"]),
+      title_txtm: get_in(metadata, ["title"]),
       description_txtm: get_in(metadata, ["description"]),
       years_is: extract_years(metadata),
       display_date_s: format_date(metadata)

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -222,6 +222,7 @@
 
     <copyField source="sourceFieldName" dest="destinationFieldName"/>
     -->
+    <copyField source="title_txtm" dest="title_ss"/>
 
     <!-- field type definitions. The "name" attribute is
        just a label to be used by field definitions.  The "class"

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -707,7 +707,7 @@
       <str name="q.alt">*:*</str>
       <str name="qf">
         id
-        title_ss
+        title_txtm
         description_txtm
         years_is
       </str>
@@ -1096,13 +1096,14 @@
   </updateProcessor>
   <updateProcessor class="org.apache.solr.update.processor.LangDetectLanguageIdentifierUpdateProcessorFactory" name="lang-detection">
     <str name="langid">true</str>
-    <str name="langid.fl">description_txtm</str>
+    <str name="langid.fl">description_txtm,title_txtm</str>
     <str name="langid.langField">detectlang_s</str>
     <str name="langid.langsField">detectlang_ss</str>
     <str name="langid.fallback">nolang</str>
     <str name="langid.map">true</str>
     <str name="langid.map.keepOrig">true</str>
     <str name="langid.map.individual">true</str>
+    <str name="langid.threshold">0.8</str>
     <str name="langid.whitelist">en,ar,bg,ca,cj,cz,da,de,el,es,et,eu,fa,fi,fr,ga,gl,hi,hu,hy,id,it,ja,ko,lv,nl,no,pt,ro,ru,sv,th,tr</str>
   </updateProcessor>
   <updateProcessor class="solr.AddSchemaFieldsUpdateProcessorFactory" name="add-schema-fields">

--- a/test/dpul_collections/indexing_pipeline/integration/figgy/transformation_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/figgy/transformation_integration_test.exs
@@ -41,7 +41,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationIntegrationTest d
 
     assert %{
              "id" => ^marker_1_id,
-             "title_ss" => ["test title 1"]
+             "title_txtm" => ["test title 1"]
            } = cache_entry.data
 
     transformer |> Broadway.stop(:normal)
@@ -63,7 +63,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationIntegrationTest d
 
     assert %{
              "id" => ^marker_1_id,
-             "title_ss" => ["test title 1"]
+             "title_txtm" => ["test title 1"]
            } = cache_entry.data
 
     processor_marker = IndexingPipeline.get_processor_marker!("figgy_transformer", 1)

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -1,4 +1,5 @@
 defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
+  alias Phoenix.LiveDashboard.TitleBarComponent
   use DpulCollections.DataCase
 
   alias DpulCollections.Repo
@@ -147,13 +148,18 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
     {hydrator, transformer, indexer, document} =
       FiggyTestSupport.index_record_id("26713a31-d615-49fd-adfc-93770b4f66b3")
 
+    assert document["title_txtm"] == ["Ali Bagheri"]
+    # Language Detection
+    assert document["title_txtm_de"] == ["Ali Bagheri"]
+    # Copy Field
+    assert document["title_ss"] == ["Ali Bagheri"]
     # Description
     assert %{"description_txtm" => [first_description | _tail]} = document
     assert first_description |> String.starts_with?("Asra-Panahi") == true
     # Language detection
     assert %{"description_txtm_en" => [first_description | _tail]} = document
     assert first_description |> String.starts_with?("Asra-Panahi") == true
-    assert %{"detectlang_ss" => ["en"]} = document
+    assert %{"detectlang_ss" => ["de", "en"]} = document
 
     # Date fields
     assert document["years_is"] == [2022]

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -1,5 +1,4 @@
 defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
-  alias Phoenix.LiveDashboard.TitleBarComponent
   use DpulCollections.DataCase
 
   alias DpulCollections.Repo

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -7,15 +7,20 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
   setup do
     doc1 = %{
       "id" => "ce6aa6c7-623f-4398-ba04-ba542a858e4f",
-      "title_ss" => ["Mehrdad"]
+      "title_txtm" => ["Mehrdad"]
     }
 
     doc2 = %{
       "id" => "6c3367b1-344c-4dde-868e-c71192757c4a",
-      "title_ss" => ["Masih"]
+      "title_txtm" => ["Masih"]
     }
 
-    Solr.add([doc1, doc2])
+    doc3 = %{
+      "id" => "097263fb-5beb-407b-ab36-b468e0489792",
+      "title_txtm" => ["Hamed Javadzadeh"]
+    }
+
+    Solr.add([doc1, doc2, doc3])
     Solr.commit()
     on_exit(fn -> Solr.delete_all() end)
   end
@@ -40,9 +45,8 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
     response =
       view
       |> element("form")
-      |> render_submit(%{"q" => "Masih"})
+      |> render_submit(%{"q" => "Hamed"})
 
-    assert response =~ "<div class=\"font-bold text-lg\">Masih</div>"
-    assert !(response =~ "<div class=\"font-bold text-lg\">Mehrdad</div>")
+    assert response =~ "<div class=\"font-bold text-lg\">Hamed Javadzadeh</div>"
   end
 end

--- a/test/support/fixtures/figgy_test_fixtures.ex
+++ b/test/support/fixtures/figgy_test_fixtures.ex
@@ -135,7 +135,7 @@ defmodule FiggyTestFixtures do
         source_cache_order: ~U[2018-03-09 20:19:33.414040Z],
         data: %{
           "id" => "3cb7627b-defc-401b-9959-42ebc4488f74",
-          "title_ss" => ["test title 1"]
+          "title_txtm" => ["test title 1"]
         }
       })
 
@@ -146,7 +146,7 @@ defmodule FiggyTestFixtures do
         source_cache_order: ~U[2018-03-09 20:19:34.465203Z],
         data: %{
           "id" => "69990556-434c-476a-9043-bbf9a1bda5a4",
-          "title_ss" => ["test title 2"]
+          "title_txtm" => ["test title 2"]
         }
       })
 
@@ -157,7 +157,7 @@ defmodule FiggyTestFixtures do
         source_cache_order: ~U[2018-03-09 20:19:34.486004Z],
         data: %{
           "id" => "47276197-e223-471c-99d7-405c5f6c5285",
-          "title_ss" => ["test title 3"]
+          "title_txtm" => ["test title 3"]
         }
       })
 


### PR DESCRIPTION
Notes:

1. Language detection doesn't work on copied fields, so we need to index title_txtm, then copy to title_ss.
2. Language detection on short strings is a little wonky, but that's probably fine. For instance, it really thinks 'Ali Bagheri' is German.

Closes #142