### PR TITLE
Speed up Figgy Resources query.

### DIFF
--- a/lib/dpul_collections/indexing_pipeline.ex
+++ b/lib/dpul_collections/indexing_pipeline.ex
@@ -100,6 +100,7 @@ defmodule DpulCollections.IndexingPipeline do
     Repo.all(query)
   end
 
+
   @spec get_hydration_cache_entries_since!(
           nil,
           count :: integer
@@ -255,7 +256,7 @@ defmodule DpulCollections.IndexingPipeline do
       from r in Figgy.Resource,
         where:
           r.internal_resource != "Event" and r.internal_resource != "PreservationObject" and
-            ((r.updated_at == ^updated_at and r.id > ^id) or r.updated_at > ^updated_at),
+            (r.updated_at >= ^updated_at and (r.updated_at > ^updated_at or r.id > ^id)),
         limit: ^count,
         order_by: [asc: r.updated_at, asc: r.id]
 

--- a/lib/dpul_collections/indexing_pipeline.ex
+++ b/lib/dpul_collections/indexing_pipeline.ex
@@ -100,7 +100,6 @@ defmodule DpulCollections.IndexingPipeline do
     Repo.all(query)
   end
 
-
   @spec get_hydration_cache_entries_since!(
           nil,
           count :: integer


### PR DESCRIPTION
We found out that asking for an exact updated_at date was doing a full index scan of all of Figgy, timing out queries. This should be equivalent, and performs better.

Closes #165