### PR TITLE
Use solr cloud in local tests, add additional collection and alias

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,7 @@ executors:
         environment:
           TEST_POSTGRES_PORT: 5432
           TEST_POSTGRES_FIGGY_HOST: figgy_database
-          SOLR_URL: http://localhost:8983/solr/dpulc-test
-          SOLR_USERNAME: solr
-          SOLR_PASSWORD: SolrRocks
+          SOLR_URL: http://localhost:8983/solr/dpulc
       - image: cimg/postgres:15.2
       - image: ghcr.io/pulibrary/dpul-collections:figgy-fixtures
         name: figgy_database
@@ -104,8 +102,10 @@ jobs:
           command: |
             cd solr/conf
             zip -1 -r solr_config.zip ./*
-            curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://solr:SolrRocks@localhost:8983/solr/admin/configs?action=UPLOAD&name=dpulc-test"
-            curl -H 'Content-type: application/json' http://solr:SolrRocks@localhost:8983/api/collections/ -d '{create: {name: dpulc-test, config: dpulc-test, numShards: 1}}'
+            curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://solr:SolrRocks@localhost:8983/solr/admin/configs?action=UPLOAD&name=dpul-collections"
+            curl -X POST http://solr:SolrRocks@localhost:8983/api/collections/ -H 'Content-type: application/json' -d '{create: {name: dpulc1, config: dpul-collections, numShards: 1}}'
+            curl -X POST http://solr:SolrRocks@localhost:8983/api/collections/ -H 'Content-type: application/json' -d '{create: {name: dpulc2, config: dpul-collections, numShards: 1}}'
+            curl -X POST http://solr:SolrRocks@localhost:8983/api/c -H 'Content-Type: application/json' -d '{create-alias: {name: dpulc, collections:[dpulc1]}}'
       - mix-test
       - store_artifacts:
           path: cover

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ npm-debug.log
 /assets/node_modules/
 figgy-fixture-container/fixture-exports/*.binary
 figgy-fixture-container/fixture-exports/*.sql
+solr/conf/solr_config.zip

--- a/.lando.yml
+++ b/.lando.yml
@@ -15,14 +15,26 @@ services:
       # This comes from the base image ENTRYPOINT + CMD
       command: "docker-entrypoint.sh postgres"
   test_solr:
-    type: solr:8
-    portforward: 8984
-    core: dpulc-test
-    config:
-      dir: solr/conf
+    type: lando
+    build_as_root:
+      - apt-get update -y && apt-get install -y zip
+    healthcheck: "curl http://solr:SolrRocks@localhost:8983/solr/admin/info/health"
+    run:
+      - /app/bin/setup_solr.sh
+    services:
+      image: pulibrary/ci-solr:8.4-v1.0.0
+      ports:
+        - "8984:8983"
+      command: bin/solr -cloud -noprompt -f -p 8983
   development_solr:
-    type: solr:8
-    portforward: 8985
-    core: dpulc-dev
-    config:
-      dir: solr/conf
+    type: lando
+    build_as_root:
+      - apt-get update -y && apt-get install -y zip
+    healthcheck: "curl http://solr:SolrRocks@localhost:8983/solr/admin/info/health"
+    run:
+      - /app/bin/setup_solr.sh
+    services:
+      image: pulibrary/ci-solr:8.4-v1.0.0
+      ports:
+        - "8985:8983"
+      command: bin/solr -cloud -noprompt -f -p 8983

--- a/bin/setup_solr.sh
+++ b/bin/setup_solr.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+cd /opt/solr
+server/scripts/cloud-scripts/zkcli.sh -zkhost localhost:9983 -cmd putfile /security.json /opt/solr/security.json
+
+cd /app/solr/conf
+zip -1 -r solr_config.zip ./*
+
+# since we have to log in to the UI, add a user that's simpler to type
+curl --user solr:SolrRocks http://localhost:8983/solr/admin/authentication -H 'Content-type:application/json' -d '{"set-user": {"user":"pass"}}'
+
+# these use solr api v2 which is not stable and changes between solr8 and solr 9
+curl -X POST "http://solr:SolrRocks@localhost:8983/solr/admin/configs?action=UPLOAD&name=dpul-collections" -H "Content-type:application/octet-stream" --data-binary @solr_config.zip
+curl -X POST http://solr:SolrRocks@localhost:8983/api/collections/ -H 'Content-type: application/json' -d '{create: {name: dpulc1, config: dpul-collections, numShards: 1}}'
+curl -X POST http://solr:SolrRocks@localhost:8983/api/collections/ -H 'Content-type: application/json' -d '{create: {name: dpulc2, config: dpul-collections, numShards: 1}}'
+curl -X POST http://solr:SolrRocks@localhost:8983/api/c -H 'Content-Type: application/json' -d '{create-alias: {name: dpulc, collections:[dpulc1]}}'

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -104,7 +104,7 @@ config :swoosh, :api_client, false
 
 # Configure Solr connection
 config :dpul_collections, :solr, %{
-  url: System.get_env("SOLR_URL") || "http://localhost:8985/solr/dpulc-dev",
-  username: System.get_env("SOLR_USERNAME"),
-  password: System.get_env("SOLR_PASSWORD")
+  url: System.get_env("SOLR_URL") || "http://localhost:8985/solr/dpulc",
+  username: System.get_env("SOLR_USERNAME") || "user",
+  password: System.get_env("SOLR_PASSWORD") || "pass"
 }

--- a/config/test.exs
+++ b/config/test.exs
@@ -54,9 +54,9 @@ config :phoenix_live_view,
 
 # Configure Solr connection
 config :dpul_collections, :solr, %{
-  url: System.get_env("SOLR_URL") || "http://localhost:8984/solr/dpulc-test",
-  username: System.get_env("SOLR_USERNAME"),
-  password: System.get_env("SOLR_PASSWORD")
+  url: System.get_env("SOLR_URL") || "http://localhost:8984/solr/dpulc",
+  username: "solr",
+  password: "SolrRocks"
 }
 
 # Set this poll interval really small so it triggers in test.


### PR DESCRIPTION
- **Update lando to use solr cloud**
- **Replicate new solr test setup in ci**

advances #104 

Implications of this PR are that in development and test solr instances, there is now basic auth in place. I added a credential "user:pass" to make logging in slightly simpler than it is in the container's default settings.