### PR TITLE
104 followup

### DIFF
--- a/config/deploy/staging.hcl
+++ b/config/deploy/staging.hcl
@@ -16,7 +16,7 @@ variable "solr_read_collection" {
 }
 variable "index_cache_collections" {
   type = string
-  default = "[{\"cache_version\": 1, \"write_collection\": \"dpulc-staging\"}]"
+  default = "cache_version:1,write_collection:dpulc-staging"
 }
 
 job "dpulc-staging" {


### PR DESCRIPTION
I would have broken this out into other functions but you can't define a function inside the runtime because it's not a module.

follow up to #188 which fails to deploy due to a json parsing error; I couldn't find an effective way to pass those escaped quotes through hcl into the env var.