### PR TITLE
Use Amazon for Trivy's DB.

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -77,6 +77,8 @@ jobs:
         uses: aquasecurity/trivy-action@0.20.0
         id: runscanner
         continue-on-error: true
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         with:
           image-ref: 'ghcr.io/pulibrary/dpul-collections:${{ steps.meta.outputs.version }}'
           format: 'table'

--- a/.github/workflows/nightly-vuln-scanning.yml
+++ b/.github/workflows/nightly-vuln-scanning.yml
@@ -20,6 +20,8 @@ jobs:
         uses: aquasecurity/trivy-action@0.20.0
         id: runscanner
         continue-on-error: true
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         with:
           image-ref: 'ghcr.io/pulibrary/dpul-collections:main'
           format: 'table'


### PR DESCRIPTION
Workaround for https://github.com/aquasecurity/trivy-action/issues/389