### PR TITLE
Update bin/console to be able to connect to indexer reliably.

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -25,4 +25,4 @@ if [ "$TYPE" = "repl" ]
 then
   COMMAND=$CONSOLE_COMMAND
 fi
-ssh -t deploy@nomad-host-prod1.lib.princeton.edu "nomad alloc exec -task ${JOB_TASK} -job ${JOB_NAME}-${ENV} ${COMMAND}"
+ssh -t deploy@nomad-host-prod1.lib.princeton.edu "nomad alloc exec -task ${JOB_TASK} \$(nomad job allocs -json ${JOB_NAME}-${ENV} | jq -r -c '[.[] | select(.TaskStates | keys | contains([\"${JOB_TASK}\"]))][0].ID') ${COMMAND}"


### PR DESCRIPTION
This searches `nomad job allocs` for the correct allocation ID for a given task name, then executes the command on that allocation.

Now `JOBTASK=indexer ./bin/console staging repl` will connect to the indexer repl.

Closes #193