### PR TITLE
Updated show page.

### DIFF
--- a/lib/dpul_collections/item.ex
+++ b/lib/dpul_collections/item.ex
@@ -7,7 +7,8 @@ defmodule DpulCollections.Item do
     :date,
     :page_count,
     :url,
-    :image_service_urls
+    :image_service_urls,
+    :description
   ]
 
   def from_solr(nil), do: nil
@@ -23,7 +24,8 @@ defmodule DpulCollections.Item do
       date: doc["display_date_s"],
       page_count: doc["page_count_i"],
       url: generate_url(id, slug),
-      image_service_urls: doc["image_service_urls_ss"] || []
+      image_service_urls: doc["image_service_urls_ss"] || [],
+      description: doc["description_txtm"] || []
     }
   end
 

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -31,16 +31,16 @@ defmodule DpulCollectionsWeb.ItemLive do
 
   def description(assigns) do
     ~H"""
-    <div class="pb-4"><%= @description %></div>
+    <div class="pb-4 leading-relaxed text-lg"><%= @description %></div>
     """
   end
 
   def render(assigns) do
     ~H"""
     <div class="my-5 grid grid-flow-row auto-rows-max md:grid-cols-5 gap-4">
-      <div class="item md:col-span-3">
+      <div class="item md:col-span-3 md:pl-6">
         <h1 class="text-4xl font-bold pb-2"><%= @item.title %></h1>
-        <div class="pb-6"><%= @item.date %></div>
+        <div class="pb-6 text-xl"><%= @item.date %></div>
         <div class="md:block hidden">
           <.description :for={description <- @item.description} description={description} />
         </div>

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -38,7 +38,7 @@ defmodule DpulCollectionsWeb.ItemLive do
   def render(assigns) do
     ~H"""
     <div class="my-5 grid grid-flow-row auto-rows-max md:grid-cols-5 gap-4">
-      <div class="item md:col-span-3 md:pl-6">
+      <div class="item md:col-span-3 md:pl-8">
         <h1 class="text-4xl font-bold pb-2"><%= @item.title %></h1>
         <div class="pb-6 text-xl"><%= @item.date %></div>
         <div class="md:block hidden">

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -29,12 +29,21 @@ defmodule DpulCollectionsWeb.ItemLive do
     """
   end
 
+  def description(assigns) do
+    ~H"""
+    <div class="pb-4"><%= @description %></div>
+    """
+  end
+
   def render(assigns) do
     ~H"""
     <div class="my-5 grid grid-flow-row auto-rows-max md:grid-cols-5 gap-4">
       <div class="item md:col-span-3">
-        <h1 class="text-xl font-bold py-2"><%= @item.title %></h1>
-        <div class="pb-4"><%= @item.date %></div>
+        <h1 class="text-4xl font-bold pb-2"><%= @item.title %></h1>
+        <div class="pb-6"><%= @item.date %></div>
+        <div class="md:block hidden">
+          <.description :for={description <- @item.description} description={description} />
+        </div>
       </div>
       <div class="md:col-span-2 md:order-first">
         <img
@@ -50,8 +59,11 @@ defmodule DpulCollectionsWeb.ItemLive do
           Download
         </button>
       </div>
+      <div class="md:hidden block">
+        <.description :for={description <- @item.description} description={description} />
+      </div>
       <section class="md:col-span-5 m:order-last py-4">
-        <h2 class="text-l font-bold py-4">Pages (<%= @item.page_count %>)</h2>
+        <h2 class="text-xl font-bold py-4">Pages (<%= @item.page_count %>)</h2>
         <div class="flex flex-wrap gap-5 justify-center md:justify-start">
           <.thumbs
             :for={{thumb, thumb_num} <- Enum.with_index(@item.image_service_urls)}

--- a/test/dpul_collections_web/live/item_live_test.exs
+++ b/test/dpul_collections_web/live/item_live_test.exs
@@ -18,7 +18,8 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
           image_service_urls_ss: [
             "https://example.com/iiif/2/image1",
             "https://example.com/iiif/2/image2"
-          ]
+          ],
+          description_txtm: ["This is a test description"]
         },
         %{
           id: 2,
@@ -87,6 +88,7 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
     assert response =~ "Învăţămîntul trebuie să urmărească dezvoltarea deplină a personalităţii"
     assert response =~ "2022"
     assert response =~ "17"
+    assert response =~ "This is a test description"
     # Thumbnails render.
     assert view
            |> has_element?(
@@ -116,6 +118,11 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
            |> has_element?(
              "img[src='https://example.com/iiif/2/image2/full/350,465/0/default.jpg']"
            )
+
+    # Renders when there's no description
+    {:ok, view, _html} = live(conn, "/i/زلزلہ/item/2")
+    response = render(view)
+    assert response =~ "زلزلہ"
   end
 
   test "/i/{:slug}/item/{:id} does not redirect with a bad id", %{conn: conn} do


### PR DESCRIPTION
* Adds description
  - We said we'd add ellipses, but the CSS for this turned out to be pretty impossible - CSS ellipses is mostly for single-lines, and requires an absolute width.
  - This makes two divs for description so that in mobile it's below the image, but in desktop it's below the title. It's not the cleanest thing, but it works pretty effectively.
* Increases header sizes for the show page.

Closes #124

Increased headers:
![Screen Shot 2024-11-08 at 1 00 06 PM](https://github.com/user-attachments/assets/87048681-2a23-45f8-a396-20dba84f099a)

Mobile description after thumbnail:
![Screen Shot 2024-11-08 at 1 00 21 PM](https://github.com/user-attachments/assets/ff3e700c-7cc0-4f37-bd7e-68c22b53ca6b)

Long description:
![Screen Shot 2024-11-08 at 12 59 51 PM](https://github.com/user-attachments/assets/c160cd33-7196-412a-a914-63f6ae39b358)
