### PR TITLE
Sort nil dates last in both directions

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -181,7 +181,7 @@
     <dynamicField name="*_txtm_tr" type="text_tr"  indexed="true"  stored="true" multiValued="true"/>
 
     <dynamicField name="*_i"  type="pint"    indexed="true"  stored="true"/>
-    <dynamicField name="*_is" type="pints"    indexed="true"  stored="true"/>
+    <dynamicField name="*_is" type="pints"    indexed="true"  stored="true" sortMissingLast="true" />
     <dynamicField name="*_s"  type="string"  indexed="true"  stored="true" />
     <dynamicField name="*_ss" type="strings"  indexed="true"  stored="true"/>
     <dynamicField name="*_l"  type="plong"   indexed="true"  stored="true"/>

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -114,6 +114,41 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
            |> Enum.empty?()
   end
 
+  test "when sorting by date, a nil date always sorts last", %{conn: conn} do
+    Solr.add(
+      [
+        %{
+          id: "nildate",
+          title_txtm: "Document-nildate"
+        },
+        %{
+          id: "emptydate",
+          title_txtm: "Document-emptydate",
+          years_is: []
+        }
+      ],
+      active_collection()
+    )
+
+    Solr.commit()
+
+    {:ok, view, _html} = live(conn, "/search?sort_by=date_desc&page=11")
+
+    assert view
+           |> has_element?(~s{a[href="/i/documentnildate/item/nildate"]})
+
+    assert view
+           |> has_element?(~s{a[href="/i/documentemptydate/item/emptydate"]})
+
+    {:ok, view, _document} = live(conn, "/search?sort_by=date_asc&page=11")
+
+    assert view
+           |> has_element?(~s{a[href="/i/documentnildate/item/nildate"]})
+
+    assert view
+           |> has_element?(~s{a[href="/i/documentemptydate/item/emptydate"]})
+  end
+
   test "items can be filtered by date range", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/search")
 


### PR DESCRIPTION
companion PR: pulibrary/pul_solr#445

This will probably require a reindex (via `DpulCollections.IndexingPipeline.Figgy.IndexingConsumer.start_over!(n)`)

advances #272