### PR TITLE
Set up search tests individually

### DIFF
--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -5,7 +5,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
   alias DpulCollections.Solr
   @endpoint DpulCollectionsWeb.Endpoint
 
-  setup_all do
+  setup do
     Solr.add(SolrTestSupport.mock_solr_documents(), active_collection())
     Solr.commit(active_collection())
     on_exit(fn -> Solr.delete_all(active_collection()) end)


### PR DESCRIPTION
So that you can index extra records if needed and have them cleaned up
before the next test run

closes #280
