### PR TITLE
Use full docker.io address for promtail.

### DIFF
--- a/config/deploy/log-shipping.hcl
+++ b/config/deploy/log-shipping.hcl
@@ -56,7 +56,7 @@ job "log-shipping" {
     task "promtail" {
       driver = "podman"
       config {
-        image = "grafana/promtail:2.2.1"
+        image = "docker.io/grafana/promtail:2.2.1"
         args = [
           "-config.file",
           "local/config.yaml",


### PR DESCRIPTION
It was failing because podman needs a full address, not a shortname.

Closes #296