### PR TITLE
Remove client-error flash

### DIFF
--- a/lib/dpul_collections_web/components/core_components.ex
+++ b/lib/dpul_collections_web/components/core_components.ex
@@ -80,18 +80,6 @@ defmodule DpulCollectionsWeb.CoreComponents do
       <.flash kind={:info} title={gettext("Success!")} flash={@flash} />
       <.flash kind={:error} title={gettext("Error!")} flash={@flash} />
       <.flash
-        id="client-error"
-        kind={:error}
-        title={gettext("We can't find the internet")}
-        phx-disconnected={show(".phx-client-error #client-error")}
-        phx-connected={hide("#client-error")}
-        hidden
-      >
-        <%= gettext("Attempting to reconnect") %>
-        <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
-      </.flash>
-
-      <.flash
         id="server-error"
         kind={:error}
         title={gettext("Something went wrong!")}


### PR DESCRIPTION
Closes #275 

Removes "We can't find the internet" flash message. Removing that specific flash component does not create other errors.