### PR TITLE
Improve language selection by setting cookie with current locale

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -33,6 +33,15 @@ topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
 window.addEventListener("phx:page-loading-start", _info => topbar.show(300))
 window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
 
+// Event to change locale cookie from Language drop down and reload page so
+// LiveView components are remounted with new langauge setting.
+window.addEventListener("setLocale", e => {
+    const maxAge = 365 * 24 * 60 * 60
+    document.cookie = `locale=${e.detail.locale}; max-age=${maxAge}; path=/`
+    location.reload()
+  }
+)
+
 // connect if there are any LiveViews on the page
 liveSocket.connect()
 

--- a/lib/dpul_collections_web/components/header_component.ex
+++ b/lib/dpul_collections_web/components/header_component.ex
@@ -1,6 +1,7 @@
 # lib/my_app_web/components/header_component.ex
 defmodule DpulCollectionsWeb.HeaderComponent do
   use DpulCollectionsWeb, :html
+  use Phoenix.Component
   import DpulCollectionsWeb.Gettext
 
   def header(assigns) do
@@ -36,13 +37,15 @@ defmodule DpulCollectionsWeb.HeaderComponent do
             aria-hidden="true"
           >
             <li role="menuitem" tabindex="-1" class="p-2 hover:bg-stone-200 focus:bg-stone-200">
-              <a href="?locale=en">English</a>
+              <div phx-click={JS.dispatch("setLocale", detail: %{locale: "en"})}>English</div>
             </li>
             <li role="menuitem" tabindex="-1" class="p-2 hover:bg-stone-200 focus:bg-stone-200">
-              <a href="?locale=es">Español</a>
+              <div phx-click={JS.dispatch("setLocale", detail: %{locale: "es"})}>Español</div>
             </li>
             <li role="menuitem" tabindex="-1" class="p-2 hover:bg-stone-200 focus:bg-stone-200">
-              <a href="?locale=pt-BR">Português do Brasil</a>
+              <div phx-click={JS.dispatch("setLocale", detail: %{locale: "pt-BR"})}>
+                Português do Brasil
+              </div>
             </li>
           </ul>
         </div>

--- a/lib/plug/locale_plug.ex
+++ b/lib/plug/locale_plug.ex
@@ -24,10 +24,9 @@ defmodule DpulCollectionsWeb.LocalePlug do
         Gettext.put_locale(backend, locale)
 
         conn
-        # |> assign(conn, :locale, locale)
         |> put_resp_header("content-language", locale_to_language(locale))
-        |> put_resp_cookie("locale", locale, max_age: @max_age)
         |> put_session(:locale, locale)
+        |> put_resp_cookie("locale", locale, max_age: @max_age, http_only: false)
     end
   end
 

--- a/test/dpul_collections_web/features/locale_test.exs
+++ b/test/dpul_collections_web/features/locale_test.exs
@@ -9,9 +9,23 @@ defmodule DpulCollectionsWeb.Features.LocaleTest do
     |> visit("/")
     |> assert_has(css("h3", text: "Explore Our Digital Collections"))
     |> click(button("Language"))
-    |> click(link("Español"))
+    |> click(Query.text("Español"))
     |> assert_has(css("h3", text: "Explora nuestras colecciones"))
     |> click(button("Buscar"))
     |> assert_has(css("div#filters", text: "Relevancia"))
+  end
+
+  feature "existing params are preserved when locale is changed", %{session: session} do
+    session =
+      session
+      |> visit("/")
+      |> fill_in(text_field("q"), with: "foo")
+      |> click(button("Search"))
+      |> click(button("Language"))
+      |> click(Query.text("Español"))
+      |> assert_has(css("div#filters", text: "Relevancia"))
+
+    field = find(session, text_field("q"))
+    assert Element.value(field) == "foo"
   end
 end


### PR DESCRIPTION
Instead of relying on a locale parameter to set language, set enable the language dropdown to set the locale cookie and reload. Avoids removing parameters from url when changing language.

Closes #265 