### PR TITLE
updates random values from 3000 to 1000000 for the item browse

### DIFF
--- a/lib/dpul_collections_web/live/browse_live.ex
+++ b/lib/dpul_collections_web/live/browse_live.ex
@@ -21,12 +21,12 @@ defmodule DpulCollectionsWeb.BrowseLive do
 
       {:noreply, socket}
     else
-      {:noreply, push_patch(socket, to: "/browse?r=#{Enum.random(1..1000000)}", replace: true)}
+      {:noreply, push_patch(socket, to: "/browse?r=#{Enum.random(1..1_000_000)}", replace: true)}
     end
   end
 
   def handle_event("randomize", _map, socket) do
-    {:noreply, push_patch(socket, to: "/browse?r=#{Enum.random(1..1000000)}")}
+    {:noreply, push_patch(socket, to: "/browse?r=#{Enum.random(1..1_000_000)}")}
   end
 
   def render(assigns) do

--- a/lib/dpul_collections_web/live/browse_live.ex
+++ b/lib/dpul_collections_web/live/browse_live.ex
@@ -21,12 +21,12 @@ defmodule DpulCollectionsWeb.BrowseLive do
 
       {:noreply, socket}
     else
-      {:noreply, push_patch(socket, to: "/browse?r=#{Enum.random(1..3000)}", replace: true)}
+      {:noreply, push_patch(socket, to: "/browse?r=#{Enum.random(1..1000000)}", replace: true)}
     end
   end
 
   def handle_event("randomize", _map, socket) do
-    {:noreply, push_patch(socket, to: "/browse?r=#{Enum.random(1..3000)}")}
+    {:noreply, push_patch(socket, to: "/browse?r=#{Enum.random(1..1000000)}")}
   end
 
   def render(assigns) do


### PR DESCRIPTION
Question before merging:

I noticed that I could modify the URL in the following way: "/browse?r=1000abc" and results would still be generated (no button press involved).

<img width="1359" alt="image" src="https://github.com/user-attachments/assets/0c05170a-cd67-4532-85f3-be4f9821f0a7" />

Depending on how result sets are currently stored on the server-side, I was wondering if allowing for this functionality enables a malicious user to consume lots of memory in the event they repeatedly automatically generate their own queries. (e.g.) "/browse?r=1000abcd", "/browse?r=1000abcde", "/browse?r=1000abcdee" ...

If this is the case, should a ticket for cleaning the input and ensuring only numbers between the specified range can actually be queried be made?