### PR TITLE
Extract parent from related_data resources instead of separate list

### DIFF
--- a/lib/dpul_collections/indexing_pipeline.ex
+++ b/lib/dpul_collections/indexing_pipeline.ex
@@ -207,14 +207,6 @@ defmodule DpulCollections.IndexingPipeline do
   """
   def get_figgy_resource!(id), do: FiggyRepo.get!(Figgy.Resource, id)
 
-  def get_figgy_parents(id) do
-    json = %{"member_ids" => [%{"id" => id}]}
-
-    Figgy.Resource
-    |> where([resource], fragment("? @> ?", resource.metadata, ^json))
-    |> FiggyRepo.all()
-  end
-
   @doc """
   Gets multiple resources by id from the Figgy Database
   Note: Postgress IN() clause allows a maximum of 32,767 parameters. Items with

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry.ex
@@ -167,9 +167,9 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntry do
   defp extract_service_url(nil), do: nil
 
   defp extract_parent_metadata(%{"cached_parent_id" => [%{"id" => cached_parent_id}]}, %{
-         "parent_ids" => parent_data
+         "resources" => resources
        }) do
-    parent_data
+    resources
     |> get_in([cached_parent_id])
     |> get_in(["metadata"])
   end

--- a/lib/dpul_collections/indexing_pipeline/figgy/resource.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/resource.ex
@@ -53,7 +53,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.Resource do
 
   def extract_related_data(resource) do
     %{
-      "parent_ids" => extract_parents(resource),
       "resources" => fetch_related(resource)
     }
   end
@@ -76,19 +75,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.Resource do
   defp extract_ids_from_value(value = %{"id" => id}) when map_size(value) == 1, do: id
 
   defp extract_ids_from_value(_), do: nil
-
-  @spec extract_parents(resource :: %__MODULE__{}) :: related_resource_map()
-  defp extract_parents(resource = %{:metadata => %{"cached_parent_id" => _cached_parent_id}}) do
-    # turn it into a map of id => FiggyResource
-    IndexingPipeline.get_figgy_parents(resource.id)
-    |> Enum.map(fn m -> {m.id, to_map(m)} end)
-    |> Map.new()
-  end
-
-  # there isn't a parent
-  defp extract_parents(_resource) do
-    %{}
-  end
 
   @spec to_map(resource :: %__MODULE__{}) :: map()
   defp to_map(resource = %__MODULE__{internal_resource: "DeletionMarker"}) do

--- a/test/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry_test.exs
@@ -138,7 +138,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntryTest do
           record_id: "0cff895a-01ea-4895-9c3d-a8c6eaab4013",
           source_cache_order: ~U[2018-03-09 20:19:35.465203Z],
           related_data: %{
-            "parent_ids" => %{
+            "resources" => %{
               "82624edb-c360-4d8a-b202-f103ee639e8e" => %{
                 "id" => "82624edb-c360-4d8a-b202-f103ee639e8e",
                 "internal_resource" => "EphemeraBox",

--- a/test/dpul_collections/indexing_pipeline/integration/figgy/hydration_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/figgy/hydration_integration_test.exs
@@ -71,9 +71,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationIntegrationTest do
              "resources" => %{
                "06838583-59a4-4ab8-ac65-2b5ea9ee6425" => %{
                  "internal_resource" => "FileSet"
-               }
-             },
-             "parent_ids" => %{
+               },
                "82624edb-c360-4d8a-b202-f103ee639e8e" => %{
                  "internal_resource" => "EphemeraBox"
                }


### PR DESCRIPTION
Proposal to not use separate query just for parent. How sure are we that `cached_parent_id` has issues? This is a simpler option.