### PR TITLE
Filter related resource ids with empty strings

### DIFF
--- a/lib/dpul_collections/indexing_pipeline/figgy/resource.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/resource.ex
@@ -112,8 +112,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.Resource do
     |> Enum.concat()
     # If the value has the form `%{"id" => id}`, then extract the id string from map
     |> Enum.map(&extract_ids_from_value/1)
-    # Remove nil values
-    |> Enum.filter(fn id -> id end)
+    # Remove nil and empty string values
+    |> Enum.filter(fn id -> !is_nil(id) and id != "" end)
     # Query figgy using the resulting list of ids
     |> IndexingPipeline.get_figgy_resources()
     # Map the returned Figgy.Resources into tuples of this form:

--- a/test/dpul_collections/indexing_pipeline/figgy/resource_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/resource_test.exs
@@ -1,0 +1,20 @@
+defmodule DpulCollections.IndexingPipeline.Figgy.ResourceTest do
+  use DpulCollections.DataCase
+  alias DpulCollections.IndexingPipeline.Figgy.Resource
+
+  describe "to_hydration_cache_attrs/1" do
+    test "can handle an related resource id with an empty string" do
+      folder = FiggyTestSupport.first_ephemera_folder()
+
+      related_resource_count =
+        %Resource{folder | metadata: %{folder.metadata | "genre" => [%{"id" => ""}]}}
+        |> Resource.to_hydration_cache_attrs()
+        |> get_in([:related_data])
+        |> get_in(["resources"])
+        |> Map.keys()
+        |> length()
+
+      assert(related_resource_count == 20)
+    end
+  end
+end


### PR DESCRIPTION
Closes #403 