### PR TITLE
Add Search Bar as a component

### DIFF
--- a/lib/dpul_collections_web/components/layouts/app.html.heex
+++ b/lib/dpul_collections_web/components/layouts/app.html.heex
@@ -1,3 +1,4 @@
+<.live_component module={DpulCollectionsWeb.SearchBarComponent} id="search-bar" />
 <main id="main-content" class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
   <.flash_group flash={@flash} />
   {@inner_content}

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -1,0 +1,27 @@
+defmodule DpulCollectionsWeb.SearchBarComponent do
+  use DpulCollectionsWeb, :live_component
+  import DpulCollectionsWeb.Gettext
+  alias DpulCollectionsWeb.Live.Helpers
+
+  def render(assigns) do
+    ~H"""
+    <div class="search-bar grid grid-flow-row auto-rows-max gap-20">
+      <form id="search-form" phx-submit="search" phx-target={@myself}>
+        <div class="grid grid-cols-4">
+          <label for="q" class="sr-only">Search</label>
+          <input class="col-span-4 md:col-span-3" type="text" id="q" name="q" />
+          <button class="col-span-4 md:col-span-1 btn-primary" type="submit">
+            {gettext("Search")}
+          </button>
+        </div>
+      </form>
+    </div>
+    """
+  end
+
+  def handle_event("search", %{"q" => q}, socket) do
+    params = %{q: q} |> Helpers.clean_params()
+    socket = push_navigate(socket, to: ~p"/search?#{params}")
+    {:noreply, socket}
+  end
+end

--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -20,16 +20,6 @@ defmodule DpulCollectionsWeb.HomeLive do
   def render(assigns) do
     ~H"""
     <div class="grid grid-flow-row auto-rows-max gap-20">
-      <div>
-        <form phx-submit="search">
-          <div class="grid grid-cols-4">
-            <input class="col-span-4 md:col-span-3" type="text" name="q" value={@q} />
-            <button class="col-span-4 md:col-span-1 btn-primary" type="submit">
-              {gettext("Search")}
-            </button>
-          </div>
-        </form>
-      </div>
       <div id="welcome" class="grid place-self-center gap-10 max-w-prose">
         <h3 class="text-5xl text-center">{gettext("Explore Our Digital Collections")}</h3>
         <p class="text-xl text-center">
@@ -51,11 +41,5 @@ defmodule DpulCollectionsWeb.HomeLive do
       </div>
     </div>
     """
-  end
-
-  def handle_event("search", %{"q" => q}, socket) do
-    params = %{q: q} |> Helpers.clean_params()
-    socket = push_navigate(socket, to: ~p"/search?#{params}")
-    {:noreply, socket}
   end
 end

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -89,7 +89,8 @@ defmodule DpulCollectionsWeb.SearchLive do
     <div class="my-5 grid grid-flow-row auto-rows-max gap-10">
       <form id="search-form" phx-submit="search">
         <div class="grid grid-cols-4">
-          <input class="col-span-4 md:col-span-3" type="text" name="q" value={@search_state.q} />
+          <label for="q" class="sr-only">Search</label>
+          <input class="col-span-4 md:col-span-3" type="text" id="q" name="q" value={@search_state.q} />
           <button class="col-span-4 md:col-span-1 btn-primary" type="submit">
             {gettext("Search")}
           </button>

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -85,17 +85,10 @@ defmodule DpulCollectionsWeb.SearchLive do
 
   def render(assigns) do
     ~H"""
-    <h1 class="sr-only">{gettext("Search Results")}</h1>
+    <h1 class="text-4xl font-bold">
+      {gettext("Search Results for")}: {@search_state.q}
+    </h1>
     <div class="my-5 grid grid-flow-row auto-rows-max gap-10">
-      <form id="search-form" phx-submit="search">
-        <div class="grid grid-cols-4">
-          <label for="q" class="sr-only">Search</label>
-          <input class="col-span-4 md:col-span-3" type="text" id="q" name="q" value={@search_state.q} />
-          <button class="col-span-4 md:col-span-1 btn-primary" type="submit">
-            {gettext("Search")}
-          </button>
-        </div>
-      </form>
       <div id="filters" class="grid md:grid-cols-[auto_300px] gap-2">
         <form
           id="date-filter"
@@ -269,21 +262,6 @@ defmodule DpulCollectionsWeb.SearchLive do
       </.link>
     </nav>
     """
-  end
-
-  def handle_event("search", params, socket) do
-    params =
-      %{
-        socket.assigns.search_state
-        | q: params["q"],
-          date_to: params["date-to"],
-          date_from: params["date-from"],
-          sort_by: params["sort_by"]
-      }
-      |> Helpers.clean_params([:page, :per_page])
-
-    socket = push_patch(socket, to: ~p"/search?#{params}")
-    {:noreply, socket}
   end
 
   def handle_event("filter-date", params, socket) do

--- a/test/dpul_collections_web/features/search_bar_test.exs
+++ b/test/dpul_collections_web/features/search_bar_test.exs
@@ -11,11 +11,14 @@ defmodule DpulCollectionsWeb.Features.SearchBarTest do
     on_exit(fn -> Solr.delete_all(active_collection()) end)
   end
 
-  test "submitting a search on the search page", %{conn: conn} do
+  test "submitting a search via the search bar component on the search page", %{conn: conn} do
     conn
     |> visit("/search")
     |> fill_in("Search", with: "Document-3")
-    |> click_button("Search")
+    |> within(".search-bar", fn session ->
+      session
+      |> click_button("Search")
+    end)
     |> assert_has("#item-counter", text: "1 - 1 of 1")
   end
 

--- a/test/dpul_collections_web/features/search_bar_test.exs
+++ b/test/dpul_collections_web/features/search_bar_test.exs
@@ -1,0 +1,29 @@
+defmodule DpulCollectionsWeb.Features.SearchBarTest do
+  use ExUnit.Case, async: true
+  use PhoenixTest.Playwright.Case, async: true
+  import SolrTestSupport
+  alias DpulCollections.Solr
+  alias PhoenixTest.Playwright
+
+  setup do
+    Solr.add(SolrTestSupport.mock_solr_documents(), active_collection())
+    Solr.commit(active_collection())
+    on_exit(fn -> Solr.delete_all(active_collection()) end)
+  end
+
+  test "submitting a search on the search page", %{conn: conn} do
+    conn
+    |> visit("/search")
+    |> fill_in("Search", with: "Document-3")
+    |> click_button("Search")
+    |> assert_has("#item-counter", text: "1 - 1 of 1")
+  end
+
+  test "submitting a search on the home page", %{conn: conn} do
+    conn
+    |> visit("/")
+    |> fill_in("Search", with: "Document-3")
+    |> click_button("Search")
+    |> assert_has("#item-counter", text: "1 - 1 of 1")
+  end
+end

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -94,6 +94,8 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
       view
       |> element("#search-form")
       |> render_submit(%{"q" => "Document-2"})
+      |> follow_redirect(conn)
+      |> elem(2)
       |> Floki.parse_document()
 
     assert document
@@ -145,7 +147,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
     |> element("#search-form")
     |> render_submit(%{"q" => "Document"})
 
-    assert_patched(view, "/search?q=Document")
+    assert_redirected(view, "/search?q=Document")
   end
 
   test "when sorting by date, a nil date always sorts last", %{conn: conn} do
@@ -283,6 +285,8 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
       view
       |> element("#search-form")
       |> render_submit(%{"q" => "Document*"})
+      |> follow_redirect(conn)
+      |> elem(2)
       |> Floki.parse_document()
 
     assert document
@@ -300,6 +304,8 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
       view
       |> element("#search-form")
       |> render_submit(%{"date-from" => "1900", "date-to" => "2025"})
+      |> follow_redirect(conn)
+      |> elem(2)
       |> Floki.parse_document()
 
     assert document


### PR DESCRIPTION
closes #230

Home Page with new Search Bar component:

<img width="1443" alt="image" src="https://github.com/user-attachments/assets/d6d1f51f-de48-433b-a128-d9c500475581" />


Also replaces the search input on the results page with a header showing the given search term. This seemed in line with the decision made in https://github.com/pulibrary/dpul-collections/issues/264#issuecomment-2634578111 to prioritize the "new search" use case over the "adjust that search I just did" use case. Results page after this PR:

![Screenshot 2025-04-02 at 12 48 43 PM](https://github.com/user-attachments/assets/c89f058f-04f2-4f1e-af61-3354cd35ec45)
