### PR TITLE
[Prometheus] Add Figgy Staging & Nomad Metrics to Prometheus

### DIFF
--- a/config/deploy/prometheus.hcl
+++ b/config/deploy/prometheus.hcl
@@ -83,6 +83,12 @@ scrape_configs:
         labels:
           env: qa
           service: bibdata
+      - targets:
+        - dpul-staging3.princeton.edu:9100
+        - dpul-staging4.princeton.edu:9100
+        labels:
+          env: staging
+          service: dpul
   - job_name: 'nomad_server_metrics'
     scrape_interval: 5s
     metrics_path: /v1/metrics

--- a/config/deploy/prometheus.hcl
+++ b/config/deploy/prometheus.hcl
@@ -118,6 +118,10 @@ scrape_configs:
       action: keep
     - source_labels: ['__meta_consul_service']
       target_label: instance
+    - source_labels: ['__meta_consul_service']
+      regex: '.*(staging|production).*'
+      replacement: '$${1}'
+      target_label: env
     params:
       format: ['prometheus']
 EOH

--- a/config/deploy/prometheus.hcl
+++ b/config/deploy/prometheus.hcl
@@ -54,7 +54,7 @@ job "prometheus" {
         read_only   = false
       }
       template {
-        change_mode = "noop"
+        change_mode = "restart"
         destination = "local/prometheus.yml"
         data = <<EOH
 ---
@@ -63,6 +63,32 @@ global:
   evaluation_interval: 5s
 
 scrape_configs:
+  - job_name: 'node'
+    scrape_interval: 5s
+    basic_auth:
+      username: metrics_user
+      password: '{{with nomadVar "nomad/jobs/prometheus"}}{{ .METRICS_BASIC_PASSWORD }}{{end}}'
+    static_configs:
+      - targets:
+        - figgy-web-staging1.princeton.edu:9100
+        - figgy-web-staging2.princeton.edu:9100
+        labels:
+          env: staging
+          service: figgy
+  - job_name: 'nomad_server_metrics'
+    scrape_interval: 5s
+    metrics_path: /v1/metrics
+    params:
+      format: ['prometheus']
+    consul_sd_configs:
+    - server: '{{ env "NOMAD_IP_prometheus_ui" }}:8500'
+      services: ['nomad-clients', 'nomad-servers']
+      authorization:
+        credentials: '{{with nomadVar "nomad/jobs/prometheus"}}{{ .CONSUL_ACL_TOKEN }}{{end}}'
+    relabel_configs:
+    - source_labels: ['__meta_consul_tags']
+      regex: '(.*)http(.*)'
+      action: keep
   - job_name: 'nomad_metrics'
     scrape_interval: 5s
     authorization:

--- a/config/deploy/prometheus.hcl
+++ b/config/deploy/prometheus.hcl
@@ -75,6 +75,14 @@ scrape_configs:
         labels:
           env: staging
           service: figgy
+      - targets:
+        - bibdata-qa1.princeton.edu:9100
+        - bibdata-qa2.princeton.edu:9100
+        - bibdata-worker-qa1.princeton.edu:9100
+        - bibdata-worker-qa2.princeton.edu:9100
+        labels:
+          env: qa
+          service: bibdata
   - job_name: 'nomad_server_metrics'
     scrape_interval: 5s
     metrics_path: /v1/metrics


### PR DESCRIPTION
I needed metrics on the NFS mount to watch for latency problems, given CheckMK alerts that it's stalling.

Refs pulibrary/figgy#6671

This also adds a cool new Nomad dashboard:

https://grafana-nomad.lib.princeton.edu/d/masiNomadCluster/cluster-overview?from=now-15m&to=now&var-datacenter=dc1&var-host=$__all&refresh=1m