### PR TITLE
Add recently added to sort_by

### DIFF
--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -1,5 +1,6 @@
 defmodule DpulCollections.Solr do
   require Logger
+  use DpulCollections.Solr.Constants
 
   @spec document_count(String.t()) :: integer()
   def document_count(collection \\ read_collection()) do
@@ -96,11 +97,7 @@ defmodule DpulCollections.Solr do
   end
 
   defp sort_param(%{sort_by: sort_by}) do
-    case sort_by do
-      :relevance -> "score desc"
-      :date_desc -> "years_is desc"
-      :date_asc -> "years_is asc"
-    end
+    @valid_sort_by[sort_by][:solr_param]
   end
 
   defp pagination_offset(%{page: page, per_page: per_page}) do

--- a/lib/dpul_collections/solr/constants.ex
+++ b/lib/dpul_collections/solr/constants.ex
@@ -1,0 +1,15 @@
+defmodule DpulCollections.Solr.Constants do
+  defmacro __using__(_) do
+    quote do
+      # List of valid sort_by, keys are URL params in DPUL-C, values are solr params.
+      require Gettext.Macros
+      @valid_sort_by %{
+        relevance:  %{solr_param: "score desc", label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Relevance")},
+        date_desc: %{solr_param: "years_is desc", label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Year (newest first)")},
+        date_asc: %{solr_param: "years_is asc", label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Year (oldest first)")},
+        recently_added: %{solr_param: "digitized_at_dt desc", label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Recently Added")}
+      }
+      @sort_by_keys Enum.map(Map.keys(@valid_sort_by), &to_string/1)
+    end
+  end
+end

--- a/lib/dpul_collections/solr/constants.ex
+++ b/lib/dpul_collections/solr/constants.ex
@@ -3,11 +3,26 @@ defmodule DpulCollections.Solr.Constants do
     quote do
       # List of valid sort_by, keys are URL params in DPUL-C, values are solr params.
       require Gettext.Macros
+
       @valid_sort_by %{
-        relevance:  %{solr_param: "score desc", label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Relevance")},
-        date_desc: %{solr_param: "years_is desc", label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Year (newest first)")},
-        date_asc: %{solr_param: "years_is asc", label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Year (oldest first)")},
-        recently_added: %{solr_param: "digitized_at_dt desc", label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Recently Added")}
+        relevance: %{
+          solr_param: "score desc",
+          label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Relevance")
+        },
+        date_desc: %{
+          solr_param: "years_is desc",
+          label:
+            Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Year (newest first)")
+        },
+        date_asc: %{
+          solr_param: "years_is asc",
+          label:
+            Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Year (oldest first)")
+        },
+        recently_added: %{
+          solr_param: "digitized_at_dt desc",
+          label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Recently Added")
+        }
       }
       @sort_by_keys Enum.map(Map.keys(@valid_sort_by), &to_string/1)
     end

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -27,6 +27,7 @@ defmodule DpulCollectionsWeb.SearchLive do
 
   defmodule SearchState do
     use Solr.Constants
+
     def from_params(params) do
       %{
         q: params["q"],
@@ -40,7 +41,7 @@ defmodule DpulCollectionsWeb.SearchLive do
 
     defp valid_sort_by(%{"sort_by" => sort_by})
          when sort_by in @sort_by_keys do
-           String.to_existing_atom(sort_by)
+      String.to_existing_atom(sort_by)
     end
 
     defp valid_sort_by(_), do: :relevance
@@ -89,8 +90,8 @@ defmodule DpulCollectionsWeb.SearchLive do
   def sort_by_params do
     @valid_sort_by
     # Don't include things without labels.
-    |> Enum.filter(fn({k, v}) -> v[:label] end)
-    |> Enum.map(fn({k, v}) -> {v[:label], k} end)
+    |> Enum.filter(fn {k, v} -> v[:label] end)
+    |> Enum.map(fn {k, v} -> {v[:label], k} end)
   end
 
   def render(assigns) do

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -21,8 +21,9 @@ msgstr ""
 msgid "Hang in there while we get back on track"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:14
-#: lib/dpul_collections_web/components/search_bar_component.ex:20
+#: lib/dpul_collections_web/components/search_bar_component.ex:16
+#: lib/dpul_collections_web/components/search_bar_component.ex:22
+#: lib/dpul_collections_web/components/search_bar_component.ex:29
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
@@ -47,48 +48,48 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:120
+#: lib/dpul_collections_web/live/search_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Apply"
 msgstr ""
 
-#: lib/dpul_collections_web/components/header_component.ex:30
+#: lib/dpul_collections_web/components/header_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:249
+#: lib/dpul_collections_web/live/search_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:60
-#: lib/dpul_collections_web/live/search_live.ex:171
+#: lib/dpul_collections_web/live/search_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Pages"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:206
+#: lib/dpul_collections_web/live/search_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:101
+#: lib/dpul_collections_web/live/search_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "filter by date"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:125
+#: lib/dpul_collections_web/live/search_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "sort by"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:106
+#: lib/dpul_collections_web/live/search_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:114
+#: lib/dpul_collections_web/live/search_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr ""
@@ -118,42 +119,48 @@ msgstr ""
 msgid "Page not found"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:71
+#: lib/dpul_collections_web/live/search_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "No items found"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:83
+#: lib/dpul_collections_web/live/search_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "of"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:130
+#: lib/dpul_collections/solr.ex:3
+#: lib/dpul_collections_web/live/search_live.ex:25
+#: lib/dpul_collections_web/live/search_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Relevance"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:131
+#: lib/dpul_collections/solr.ex:3
+#: lib/dpul_collections_web/live/search_live.ex:25
+#: lib/dpul_collections_web/live/search_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Year (newest first)"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:132
+#: lib/dpul_collections/solr.ex:3
+#: lib/dpul_collections_web/live/search_live.ex:25
+#: lib/dpul_collections_web/live/search_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Year (oldest first)"
 msgstr ""
 
-#: lib/dpul_collections_web/live/browse_live.ex:66
+#: lib/dpul_collections_web/live/browse_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Browse"
 msgstr ""
 
-#: lib/dpul_collections_web/components/header_component.ex:18
+#: lib/dpul_collections_web/components/header_component.ex:26
 #, elixir-autogen, elixir-format
 msgid "Digital Collections"
 msgstr ""
 
-#: lib/dpul_collections_web/live/browse_live.ex:71
+#: lib/dpul_collections_web/live/browse_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Randomize"
 msgstr ""
@@ -163,22 +170,29 @@ msgstr ""
 msgid "The Trustees of Princeton University"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:30
+#: lib/dpul_collections_web/components/search_bar_component.ex:39
 #, elixir-autogen, elixir-format
 msgid "Browse all items"
 msgstr ""
 
-#: lib/dpul_collections_web/live/browse_live.ex:59
+#: lib/dpul_collections_web/live/browse_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:26
-#, elixir-autogen, elixir-format
-msgid "Recent Items"
-msgstr ""
-
-#: lib/dpul_collections_web/live/search_live.ex:91
+#: lib/dpul_collections_web/live/search_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Search Results for"
+msgstr ""
+
+#: lib/dpul_collections/solr.ex:3
+#: lib/dpul_collections_web/live/search_live.ex:25
+#: lib/dpul_collections_web/live/search_live.ex:29
+#, elixir-autogen, elixir-format
+msgid "Recently Added"
+msgstr ""
+
+#: lib/dpul_collections_web/live/home_live.ex:175
+#, elixir-autogen, elixir-format
+msgid "Recently Added Items"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -21,8 +21,9 @@ msgstr ""
 msgid "Hang in there while we get back on track"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:14
-#: lib/dpul_collections_web/components/search_bar_component.ex:20
+#: lib/dpul_collections_web/components/search_bar_component.ex:16
+#: lib/dpul_collections_web/components/search_bar_component.ex:22
+#: lib/dpul_collections_web/components/search_bar_component.ex:29
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
@@ -47,48 +48,48 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:120
+#: lib/dpul_collections_web/live/search_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Apply"
 msgstr ""
 
-#: lib/dpul_collections_web/components/header_component.ex:30
+#: lib/dpul_collections_web/components/header_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:249
+#: lib/dpul_collections_web/live/search_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:60
-#: lib/dpul_collections_web/live/search_live.ex:171
+#: lib/dpul_collections_web/live/search_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Pages"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:206
+#: lib/dpul_collections_web/live/search_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:101
+#: lib/dpul_collections_web/live/search_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "filter by date"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:125
+#: lib/dpul_collections_web/live/search_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "sort by"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:106
+#: lib/dpul_collections_web/live/search_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:114
+#: lib/dpul_collections_web/live/search_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr ""
@@ -118,42 +119,48 @@ msgstr ""
 msgid "Page not found"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:71
+#: lib/dpul_collections_web/live/search_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "No items found"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:83
+#: lib/dpul_collections_web/live/search_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "of"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:130
+#: lib/dpul_collections/solr.ex:3
+#: lib/dpul_collections_web/live/search_live.ex:25
+#: lib/dpul_collections_web/live/search_live.ex:29
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Relevance"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:131
+#: lib/dpul_collections/solr.ex:3
+#: lib/dpul_collections_web/live/search_live.ex:25
+#: lib/dpul_collections_web/live/search_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Year (newest first)"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:132
+#: lib/dpul_collections/solr.ex:3
+#: lib/dpul_collections_web/live/search_live.ex:25
+#: lib/dpul_collections_web/live/search_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Year (oldest first)"
 msgstr ""
 
-#: lib/dpul_collections_web/live/browse_live.ex:66
+#: lib/dpul_collections_web/live/browse_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Browse"
 msgstr ""
 
-#: lib/dpul_collections_web/components/header_component.ex:18
+#: lib/dpul_collections_web/components/header_component.ex:26
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Digital Collections"
 msgstr ""
 
-#: lib/dpul_collections_web/live/browse_live.ex:71
+#: lib/dpul_collections_web/live/browse_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Randomize"
 msgstr ""
@@ -163,22 +170,29 @@ msgstr ""
 msgid "The Trustees of Princeton University"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:30
+#: lib/dpul_collections_web/components/search_bar_component.ex:39
 #, elixir-autogen, elixir-format
 msgid "Browse all items"
 msgstr ""
 
-#: lib/dpul_collections_web/live/browse_live.ex:59
+#: lib/dpul_collections_web/live/browse_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:26
-#, elixir-autogen, elixir-format
-msgid "Recent Items"
-msgstr ""
-
-#: lib/dpul_collections_web/live/search_live.ex:91
+#: lib/dpul_collections_web/live/search_live.ex:99
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Search Results for"
+msgstr ""
+
+#: lib/dpul_collections/solr.ex:3
+#: lib/dpul_collections_web/live/search_live.ex:25
+#: lib/dpul_collections_web/live/search_live.ex:29
+#, elixir-autogen, elixir-format
+msgid "Recently Added"
+msgstr ""
+
+#: lib/dpul_collections_web/live/home_live.ex:175
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Recently Added Items"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -21,8 +21,9 @@ msgstr "¡Error!"
 msgid "Hang in there while we get back on track"
 msgstr "Aguanta mientras volvemos al buen camino"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:14
-#: lib/dpul_collections_web/components/search_bar_component.ex:20
+#: lib/dpul_collections_web/components/search_bar_component.ex:16
+#: lib/dpul_collections_web/components/search_bar_component.ex:22
+#: lib/dpul_collections_web/components/search_bar_component.ex:29
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Buscar"
@@ -47,48 +48,48 @@ msgstr "cerrar"
 msgid "Download"
 msgstr "Descargar"
 
-#: lib/dpul_collections_web/live/search_live.ex:120
+#: lib/dpul_collections_web/live/search_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Apply"
 msgstr "Aplicar"
 
-#: lib/dpul_collections_web/components/header_component.ex:30
+#: lib/dpul_collections_web/components/header_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr "Idioma"
 
-#: lib/dpul_collections_web/live/search_live.ex:249
+#: lib/dpul_collections_web/live/search_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Proxima"
 
 #: lib/dpul_collections_web/live/item_live.ex:60
-#: lib/dpul_collections_web/live/search_live.ex:171
+#: lib/dpul_collections_web/live/search_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Pages"
 msgstr "Páginas"
 
-#: lib/dpul_collections_web/live/search_live.ex:206
+#: lib/dpul_collections_web/live/search_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Anterior"
 
-#: lib/dpul_collections_web/live/search_live.ex:101
+#: lib/dpul_collections_web/live/search_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "filter by date"
 msgstr "filtrar por fecha"
 
-#: lib/dpul_collections_web/live/search_live.ex:125
+#: lib/dpul_collections_web/live/search_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "sort by"
 msgstr "Ordenar por"
 
-#: lib/dpul_collections_web/live/search_live.ex:106
+#: lib/dpul_collections_web/live/search_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr "De"
 
-#: lib/dpul_collections_web/live/search_live.ex:114
+#: lib/dpul_collections_web/live/search_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr "A"
@@ -118,42 +119,48 @@ msgstr "Descargar PDF"
 msgid "Page not found"
 msgstr "Página no encontrada"
 
-#: lib/dpul_collections_web/live/search_live.ex:71
+#: lib/dpul_collections_web/live/search_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "No items found"
 msgstr "No artículos encontrada"
 
-#: lib/dpul_collections_web/live/search_live.ex:83
+#: lib/dpul_collections_web/live/search_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "of"
 msgstr "de"
 
-#: lib/dpul_collections_web/live/search_live.ex:130
+#: lib/dpul_collections/solr.ex:3
+#: lib/dpul_collections_web/live/search_live.ex:25
+#: lib/dpul_collections_web/live/search_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Relevance"
 msgstr "Relevancia"
 
-#: lib/dpul_collections_web/live/search_live.ex:131
+#: lib/dpul_collections/solr.ex:3
+#: lib/dpul_collections_web/live/search_live.ex:25
+#: lib/dpul_collections_web/live/search_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Year (newest first)"
 msgstr "Año (más reciente primero)"
 
-#: lib/dpul_collections_web/live/search_live.ex:132
+#: lib/dpul_collections/solr.ex:3
+#: lib/dpul_collections_web/live/search_live.ex:25
+#: lib/dpul_collections_web/live/search_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Year (oldest first)"
 msgstr "Año (más antigua primero)"
 
-#: lib/dpul_collections_web/live/browse_live.ex:66
+#: lib/dpul_collections_web/live/browse_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Browse"
 msgstr "navegar"
 
-#: lib/dpul_collections_web/components/header_component.ex:18
+#: lib/dpul_collections_web/components/header_component.ex:26
 #, elixir-autogen, elixir-format
 msgid "Digital Collections"
 msgstr "Colecciones Digitales"
 
-#: lib/dpul_collections_web/live/browse_live.ex:71
+#: lib/dpul_collections_web/live/browse_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Randomize"
 msgstr "Aleatorizar"
@@ -163,22 +170,29 @@ msgstr "Aleatorizar"
 msgid "The Trustees of Princeton University"
 msgstr "Los fideicomisarios de la Universidad de Princeton"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:30
+#: lib/dpul_collections_web/components/search_bar_component.ex:39
 #, elixir-autogen, elixir-format
 msgid "Browse all items"
 msgstr "Explorar todos los materiales"
 
-#: lib/dpul_collections_web/live/browse_live.ex:59
+#: lib/dpul_collections_web/live/browse_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr "Fijado"
 
-#: lib/dpul_collections_web/live/home_live.ex:26
-#, elixir-autogen, elixir-format
-msgid "Recent Items"
-msgstr "Materiales Recientes"
-
-#: lib/dpul_collections_web/live/search_live.ex:91
+#: lib/dpul_collections_web/live/search_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Search Results for"
 msgstr "Resultados de la búsqueda por"
+
+#: lib/dpul_collections/solr.ex:3
+#: lib/dpul_collections_web/live/search_live.ex:25
+#: lib/dpul_collections_web/live/search_live.ex:29
+#, elixir-autogen, elixir-format
+msgid "Recently Added"
+msgstr "Añadido recientemente"
+
+#: lib/dpul_collections_web/live/home_live.ex:175
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Recently Added Items"
+msgstr "Materiales Recientes"

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -137,6 +137,23 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
            |> Enum.empty?()
   end
 
+  test "items can be sorted by recently added", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/search")
+
+    {:ok, document} =
+      view
+      |> render_click("sort", %{"sort-by" => "recently_added"})
+      |> Floki.parse_document()
+
+    assert document
+           |> Floki.find(~s{a[href="/i/document1/item/1"]})
+           |> Enum.empty?()
+
+    assert document
+           |> Floki.find(~s{a[href="/i/document100/item/100"]})
+           |> Enum.any?()
+  end
+
   test "changing query parameter resets sort_by to default", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/search")
 

--- a/test/support/solr_test_support.ex
+++ b/test/support/solr_test_support.ex
@@ -30,7 +30,7 @@ defmodule SolrTestSupport do
           "https://example.com/iiif/2/image7"
         ],
         primary_thumbnail_service_url_s: thumbnail_url,
-        digitized_at_dt: DateTime.utc_now() |> DateTime.to_iso8601()
+        digitized_at_dt: DateTime.utc_now() |> DateTime.add(-100+1*n, :day) |> DateTime.to_iso8601()
       }
     end
   end

--- a/test/support/solr_test_support.ex
+++ b/test/support/solr_test_support.ex
@@ -30,7 +30,8 @@ defmodule SolrTestSupport do
           "https://example.com/iiif/2/image7"
         ],
         primary_thumbnail_service_url_s: thumbnail_url,
-        digitized_at_dt: DateTime.utc_now() |> DateTime.add(-100+1*n, :day) |> DateTime.to_iso8601()
+        digitized_at_dt:
+          DateTime.utc_now() |> DateTime.add(-100 + 1 * n, :day) |> DateTime.to_iso8601()
       }
     end
   end


### PR DESCRIPTION
This also does some refactoring of sort_by, so to add new things we just update `Solr.Constants`. `https://hexdocs.pm/elixir/module-attributes.html#as-compile-time-constants` said that's pretty common. Maybe it should be elsewhere though? I dunno.

The macro business is a little complicated - basically we have to have module attributes to use them in function guards, but you can't call attributes from another module, so we have to compile-time define them in places we want to use those constants. To do that we can do `use` and `using`, effectively working as a module include from Ruby (hmmm, maybe that's bad..), to make it available to the compiler.

We also have to call Gettext's macro directly, because if I `use Gettext` in that `__using__` then it complains for modules that already `use Gettext`. If we instead call `gettext` with dynamic values, then GetText is unable to recognize those strings for the mix tasks, and I like that workflow.

Work supporting #437
