### PR TITLE
Add intro context in front of the mosaic

### DIFF
--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -151,7 +151,7 @@ defmodule DpulCollectionsWeb.HomeLive do
                 class="text-rust"
                 href="#"
               >Posters</a>, <a class="text-rust" href="#">Books</a>, and
-              <a class="text-rust" href="#">more</a>
+              <.link navigate={~p"/browse"} class="text-rust">more</.link>
               to inspire and support your research.
             </div>
             <div class="content-area bg-dark-blue text-taupe p-4 text-2xl">

--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -143,7 +143,7 @@ defmodule DpulCollectionsWeb.HomeLive do
     ~H"""
     <div class="grid grid-flow-row auto-rows-max">
       <div class="explore-header grid-row bg-taupe relative">
-        <div class="backdrop-blur-xs shadow-lg bg-taupe/70 absolute max-h-[600px] min-w-[400px] w-full lg:max-w-1/2 xl:max-w-1/3 top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 p-8">
+        <div class="shadow-lg bg-taupe absolute max-h-[600px] sm:min-w-[350px] w-full lg:max-w-1/2 2xl:max-w-1/3 top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 p-8">
           <div class="content-area text-center h-full w-full flex flex-col justify-evenly">
             <h1 class="normal-case">Explore Our Collections</h1>
             <div class="content-area page-y-padding text-xl flex-grow">

--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -142,15 +142,20 @@ defmodule DpulCollectionsWeb.HomeLive do
   def render(assigns) do
     ~H"""
     <div class="grid grid-flow-row auto-rows-max">
-      <div class="explore-header grid-row bg-taupe">
-        <div class="content-area">
-          <div class="page-y-padding">
-            <h1 class="text-2xl sm:text-3xl md:text-4xl uppercase tracking-widest font-extrabold text-center">
-              {gettext("Explore Ephemera at Princeton")}
-            </h1>
+      <div class="explore-header grid-row bg-taupe relative">
+        <div class="bg-taupe/80 absolute h-[350px] min-w-1/3 top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 p-4">
+          <div class="content-area page-y-padding text-center border-1 border-rust/80 h-full">
+            <h1>Explore Princeton Material</h1>
+            <div class="content-area page-y-padding text-2xl">
+              Princeton collects and makes available a wide variety of material including <a class="text-rust" href="#">Photographs</a>, <a class="text-rust" href="#">Posters</a>, <a class="text-rust" href="#">Books</a>, and <a class="text-rust" href="#">more</a> to inspire and support your research.
+            </div>
+            <div class="content-area page-y-padding">
+              <.link navigate={~p"/browse"} class="bg-dark-blue text-taupe p-4 text-2xl uppercase">
+                {gettext("Browse all items")}
+              </.link>
+            </div>
           </div>
         </div>
-        <hr class="h-1 border-0 bg-rust" />
         <div class="h-[600px] overflow-hidden">
           <%= for chunk <- @hero_images do %>
             <div class="h-[200px] flex items-start overflow-hidden">

--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -147,7 +147,7 @@ defmodule DpulCollectionsWeb.HomeLive do
           <div class="content-area text-center h-full w-full flex flex-col justify-evenly">
             <h1 class="normal-case">Explore Our Collections</h1>
             <div class="content-area page-y-padding text-xl flex-grow">
-              We have a wide variety of material including <a class="text-rust" href="#">Photographs</a>, <a
+              Here you'll find a wide variety of material including <a class="text-rust" href="#">Photographs</a>, <a
                 class="text-rust"
                 href="#"
               >Posters</a>, <a class="text-rust" href="#">Books</a>, and

--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -143,14 +143,14 @@ defmodule DpulCollectionsWeb.HomeLive do
     ~H"""
     <div class="grid grid-flow-row auto-rows-max">
       <div class="explore-header grid-row bg-taupe relative">
-        <div class="bg-taupe/80 absolute h-[350px] min-w-1/3 top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 p-4">
-          <div class="content-area page-y-padding text-center border-1 border-rust/80 h-full">
-            <h1>Explore Princeton Material</h1>
-            <div class="content-area page-y-padding text-2xl">
-              Princeton collects and makes available a wide variety of material including <a class="text-rust" href="#">Photographs</a>, <a class="text-rust" href="#">Posters</a>, <a class="text-rust" href="#">Books</a>, and <a class="text-rust" href="#">more</a> to inspire and support your research.
+        <div class="backdrop-blur-xs shadow-lg bg-taupe/70 absolute max-h-[600px] min-w-[400px] w-full lg:max-w-1/2 xl:max-w-1/3 top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 p-8">
+          <div class="content-area text-center h-full w-full flex flex-col justify-evenly">
+            <h1 class="normal-case">Explore Our Collections</h1>
+            <div class="content-area page-y-padding text-xl flex-grow">
+              We have a wide variety of material including <a class="text-rust" href="#">Photographs</a>, <a class="text-rust" href="#">Posters</a>, <a class="text-rust" href="#">Books</a>, and <a class="text-rust" href="#">more</a> to inspire and support your research.
             </div>
-            <div class="content-area page-y-padding">
-              <.link navigate={~p"/browse"} class="bg-dark-blue text-taupe p-4 text-2xl uppercase">
+            <div class="content-area bg-dark-blue text-taupe p-4 text-2xl">
+              <.link navigate={~p"/browse"} class="">
                 {gettext("Browse all items")}
               </.link>
             </div>

--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -147,7 +147,12 @@ defmodule DpulCollectionsWeb.HomeLive do
           <div class="content-area text-center h-full w-full flex flex-col justify-evenly">
             <h1 class="normal-case">Explore Our Collections</h1>
             <div class="content-area page-y-padding text-xl flex-grow">
-              We have a wide variety of material including <a class="text-rust" href="#">Photographs</a>, <a class="text-rust" href="#">Posters</a>, <a class="text-rust" href="#">Books</a>, and <a class="text-rust" href="#">more</a> to inspire and support your research.
+              We have a wide variety of material including <a class="text-rust" href="#">Photographs</a>, <a
+                class="text-rust"
+                href="#"
+              >Posters</a>, <a class="text-rust" href="#">Books</a>, and
+              <a class="text-rust" href="#">more</a>
+              to inspire and support your research.
             </div>
             <div class="content-area bg-dark-blue text-taupe p-4 text-2xl">
               <.link navigate={~p"/browse"} class="">


### PR DESCRIPTION
I wanted to see what it would look like if we had an intro box over our mosaic like https://pdimagearchive.org/.

I'd have to do a lot to get this to display right in Mobile, so before I do that I wanted some feedback on if this was interesting to us at all.

![Screen Shot 2025-04-23 at 9 56 41 AM](https://github.com/user-attachments/assets/1d470c15-8b04-4ca9-9851-81d41249e378)


The text is flexible, obviously.