### PR TITLE
Stop telemetry message crashing.

### DIFF
--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -34,7 +34,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
         module: {options[:producer_module], options[:producer_options]}
       ],
       processors: [
-        default: []
+        default: [concurrency: System.schedulers_online() * 2]
       ],
       batchers: [
         default: [batch_size: options[:batch_size]],

--- a/lib/dpul_collections/indexing_pipeline/figgy/indexing_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/indexing_consumer.ex
@@ -39,7 +39,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.IndexingConsumer do
         module: {options[:producer_module], options[:producer_options]}
       ],
       processors: [
-        default: []
+        default: [concurrency: System.schedulers_online() * 2]
       ],
       batchers: [
         default: [batch_size: options[:batch_size]],

--- a/lib/dpul_collections/indexing_pipeline/figgy/transformation_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/transformation_consumer.ex
@@ -36,7 +36,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationConsumer do
         module: {options[:producer_module], options[:producer_options]}
       ],
       processors: [
-        default: []
+        default: [concurrency: System.schedulers_online() * 2]
       ],
       batchers: [
         default: [batch_size: options[:batch_size]],


### PR DESCRIPTION
These were happening because this line: https://github.com/akoutmos/prom_ex/blob/master/lib/prom_ex/plugins/broadway.ex#L146 is expecting that processor concurrency is set. We were just accepting the default. This explicitly puts in the default, which is System.schedulers_online()*2, according to https://hexdocs.pm/broadway/Broadway.html#start_link/2-processors-options

Closes #447
