### PR TITLE
Don't run locale test asynchronously.

### DIFF
--- a/test/dpul_collections_web/features/locale_test.exs
+++ b/test/dpul_collections_web/features/locale_test.exs
@@ -1,6 +1,6 @@
 defmodule DpulCollectionsWeb.Features.LocaleTest do
-  use ExUnit.Case, async: true
-  use PhoenixTest.Playwright.Case, async: true
+  use ExUnit.Case
+  use PhoenixTest.Playwright.Case
   alias PhoenixTest.Playwright
   import SolrTestSupport
   alias DpulCollections.Solr


### PR DESCRIPTION
We don't have tests set up to handle async solr access. This is what was
causing `mix test` failures locally.

Closes #467
