### PR TITLE
Genre Facet

### DIFF
--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -32,7 +32,8 @@ defmodule DpulCollections.Solr do
 
     solr_params = [
       q: query_param(search_state),
-      "q.op": "AND",
+      mm: "6<90%",
+      fq: facet_param(search_state),
       fl: fl,
       sort: sort_param(search_state),
       rows: search_state[:per_page],
@@ -86,7 +87,11 @@ defmodule DpulCollections.Solr do
   end
 
   defp query_param(search_state) do
-    Enum.reject([search_state[:q], date_query(search_state)], &is_nil(&1))
+    search_state[:q]
+  end
+
+  def facet_param(search_state) do
+    Enum.reject([date_query(search_state)], &is_nil(&1))
     |> Enum.join(" ")
   end
 

--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -103,7 +103,7 @@ defmodule DpulCollections.Solr do
   def generate_filter_query({facet_key, facet_value})
       when is_binary(facet_value) and facet_key in @facet_keys do
     solr_field = @facets[facet_key].solr_field
-    "+filter(#{solr_field}:#{facet_value})"
+    "+filter(#{solr_field}:\"#{facet_value}\")"
   end
 
   # Range facet.

--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -97,19 +97,25 @@ defmodule DpulCollections.Solr do
     |> Enum.join(" ")
   end
 
-  def genre_facet(%{genre: genre}) when is_binary(genre) do
-    "genre_txtm:#{genre}"
+  def genre_facet(%{facet: %{"genre" => genre}}) when is_binary(genre) and genre != "" do
+    "+filter(genre_txtm:#{genre})"
   end
 
   def genre_facet(_), do: nil
 
-  defp date_query(%{date_from: nil, date_to: nil}), do: nil
+  defp date_query(%{facet: %{"year" => %{"date_from" => nil, "date_to" => nil}}}), do: nil
 
-  defp date_query(%{date_from: date_from, date_to: date_to}) do
-    from = date_from || "*"
-    to = date_to || "*"
-    "years_is:[#{from} TO #{to}]"
+  defp date_query(%{facet: %{"year" => %{"date_from" => date_from, "date_to" => date_to}}}) do
+    from = to_date_query_param(date_from)
+    to = to_date_query_param(date_to)
+    "+filter(years_is:[#{from} TO #{to}])"
   end
+
+  defp date_query(_), do: nil
+
+  defp to_date_query_param(""), do: "*"
+  defp to_date_query_param(nil), do: "*"
+  defp to_date_query_param(param), do: param
 
   defp sort_param(%{sort_by: sort_by}) do
     @valid_sort_by[sort_by][:solr_param]

--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -32,6 +32,8 @@ defmodule DpulCollections.Solr do
 
     solr_params = [
       q: query_param(search_state),
+      # https://solr.apache.org/docs/9_4_0/core/org/apache/solr/util/doc-files/min-should-match.html
+      # If more than 6 clauses, only require 90%. Pulled from our catalog.
       mm: "6<90%",
       fq: facet_param(search_state),
       fl: fl,
@@ -91,9 +93,15 @@ defmodule DpulCollections.Solr do
   end
 
   def facet_param(search_state) do
-    Enum.reject([date_query(search_state)], &is_nil(&1))
+    Enum.reject([date_query(search_state), genre_facet(search_state)], &is_nil(&1))
     |> Enum.join(" ")
   end
+
+  def genre_facet(%{genre: genre}) when is_binary(genre) do
+    "genre_txtm:#{genre}"
+  end
+
+  def genre_facet(_), do: nil
 
   defp date_query(%{date_from: nil, date_to: nil}), do: nil
 

--- a/lib/dpul_collections/solr/constants.ex
+++ b/lib/dpul_collections/solr/constants.ex
@@ -1,4 +1,6 @@
 defmodule DpulCollections.Solr.Constants do
+  use Gettext, backend: DpulCollectionsWeb.Gettext
+
   defmacro __using__(_) do
     quote do
       # List of valid sort_by, keys are URL params in DPUL-C, values are solr params.
@@ -25,6 +27,31 @@ defmodule DpulCollections.Solr.Constants do
         }
       }
       @sort_by_keys Enum.map(Map.keys(@valid_sort_by), &to_string/1)
+
+      @facets %{
+        "year" => %{
+          solr_field: "years_is",
+          label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Year"),
+          value_function: &DpulCollections.Solr.Constants.date_value/1
+        },
+        "genre" => %{
+          solr_field: "genre_txtm",
+          label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Genre"),
+          # Identity just returns whatever you gave it.
+          value_function: &Function.identity/1
+        }
+      }
+
+      @facet_keys Map.keys(@facets)
     end
   end
+
+  # Returns a string version of a date facet.
+  def date_value(year_params = %{}) do
+    from = year_params["from"] || gettext("Up")
+    to = year_params["to"] || gettext("Now")
+    "#{from} #{gettext("to")} #{to}"
+  end
+
+  def date_value(_), do: nil
 end

--- a/lib/dpul_collections_web/live/browse_live.ex
+++ b/lib/dpul_collections_web/live/browse_live.ex
@@ -67,7 +67,11 @@ defmodule DpulCollectionsWeb.BrowseLive do
       <h1 class="col-span-3">{gettext("Pinned")}</h1>
       <div id="pinned-items" class="my-5 grid grid-flow-row auto-rows-max gap-10 grid-cols-1">
         <div class="grid grid-flow-row auto-rows-max gap-8">
-          <DpulCollectionsWeb.SearchLive.search_item :for={item <- @pinned_items} item={item} />
+          <DpulCollectionsWeb.SearchLive.search_item
+            :for={item <- @pinned_items}
+            search_state={%{}}
+            item={item}
+          />
         </div>
       </div>
       <div

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -30,7 +30,12 @@ defmodule DpulCollectionsWeb.ItemLive do
     <div class="content-area item-page">
       <div class="column-layout my-5 flex flex-col sm:grid sm:grid-flow-row sm:auto-rows-0 sm:grid-cols-5 sm:grid-rows-[auto_1fr] sm:content-start gap-x-14 gap-y-4">
         <div class="item-title sm:row-start-1 sm:col-start-3 sm:col-span-3 h-min flex flex-col gap-4">
-          <a class="text-xl uppercase tracking-wide">{@item.genre}</a>
+          <.link
+            class="text-xl uppercase tracking-wide"
+            href={~p"/search?facet[genre]=#{@item.genre |> List.first()}"}
+          >
+            {@item.genre}
+          </.link>
           <h1 class="text-4xl font-bold normal-case">{@item.title}</h1>
           <div
             :if={!Enum.empty?(@item.transliterated_title) || !Enum.empty?(@item.alternative_title)}

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -28,12 +28,13 @@ defmodule DpulCollectionsWeb.ItemLive do
 
   attr :facet_name, :string, required: true
   attr :facet_value, :string, required: true
+  attr :rest, :global, doc: "the arbitrary HTML attributes to add to the link"
 
   def facet_link(assigns) do
     ~H"""
     <.link
-      class="text-xl uppercase tracking-wide"
       href={~p"/search?#{%{facet: %{@facet_name => @facet_value}} |> Helpers.clean_params()}"}
+      {@rest}
     >
       {@facet_value}
     </.link>
@@ -45,7 +46,7 @@ defmodule DpulCollectionsWeb.ItemLive do
     <div class="content-area item-page">
       <div class="column-layout my-5 flex flex-col sm:grid sm:grid-flow-row sm:auto-rows-0 sm:grid-cols-5 sm:grid-rows-[auto_1fr] sm:content-start gap-x-14 gap-y-4">
         <div class="item-title sm:row-start-1 sm:col-start-3 sm:col-span-3 h-min flex flex-col gap-4">
-          <.facet_link facet_value={@item.genre |> List.first()} facet_name="genre" />
+          <.facet_link class="text-xl uppercase tracking-wide" facet_value={@item.genre |> List.first()} facet_name="genre" />
           <h1 class="text-4xl font-bold normal-case">{@item.title}</h1>
           <div
             :if={!Enum.empty?(@item.transliterated_title) || !Enum.empty?(@item.alternative_title)}

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -1,4 +1,5 @@
 defmodule DpulCollectionsWeb.ItemLive do
+  alias DpulCollectionsWeb.Live.Helpers
   use DpulCollectionsWeb, :live_view
   use Gettext, backend: DpulCollectionsWeb.Gettext
   alias DpulCollections.{Item, Solr}
@@ -25,17 +26,26 @@ defmodule DpulCollectionsWeb.ItemLive do
     assign(socket, item: item)
   end
 
+  attr :facet_name, :string, required: true
+  attr :facet_value, :string, required: true
+
+  def facet_link(assigns) do
+    ~H"""
+    <.link
+      class="text-xl uppercase tracking-wide"
+      href={~p"/search?#{%{facet: %{@facet_name => @facet_value}} |> Helpers.clean_params()}"}
+    >
+      {@facet_value}
+    </.link>
+    """
+  end
+
   def render(assigns) do
     ~H"""
     <div class="content-area item-page">
       <div class="column-layout my-5 flex flex-col sm:grid sm:grid-flow-row sm:auto-rows-0 sm:grid-cols-5 sm:grid-rows-[auto_1fr] sm:content-start gap-x-14 gap-y-4">
         <div class="item-title sm:row-start-1 sm:col-start-3 sm:col-span-3 h-min flex flex-col gap-4">
-          <.link
-            class="text-xl uppercase tracking-wide"
-            href={~p"/search?facet[genre]=#{@item.genre |> List.first()}"}
-          >
-            {@item.genre}
-          </.link>
+          <.facet_link facet_value={@item.genre |> List.first()} facet_name="genre" />
           <h1 class="text-4xl font-bold normal-case">{@item.title}</h1>
           <div
             :if={!Enum.empty?(@item.transliterated_title) || !Enum.empty?(@item.alternative_title)}

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -46,7 +46,11 @@ defmodule DpulCollectionsWeb.ItemLive do
     <div class="content-area item-page">
       <div class="column-layout my-5 flex flex-col sm:grid sm:grid-flow-row sm:auto-rows-0 sm:grid-cols-5 sm:grid-rows-[auto_1fr] sm:content-start gap-x-14 gap-y-4">
         <div class="item-title sm:row-start-1 sm:col-start-3 sm:col-span-3 h-min flex flex-col gap-4">
-          <.facet_link class="text-xl uppercase tracking-wide" facet_value={@item.genre |> List.first()} facet_name="genre" />
+          <.facet_link
+            class="text-xl uppercase tracking-wide"
+            facet_value={@item.genre |> List.first()}
+            facet_name="genre"
+          />
           <h1 class="text-4xl font-bold normal-case">{@item.title}</h1>
           <div
             :if={!Enum.empty?(@item.transliterated_title) || !Enum.empty?(@item.alternative_title)}

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -184,7 +184,12 @@ defmodule DpulCollectionsWeb.SearchLive do
         </div>
       </div>
       <div class="grid grid-flow-row auto-rows-max gap-8">
-        <.search_item :for={item <- @items} item={item} sort_by={@search_state.sort_by} />
+        <.search_item
+          :for={item <- @items}
+          search_state={@search_state}
+          item={item}
+          sort_by={@search_state.sort_by}
+        />
       </div>
       <div class="text-center max-w-5xl mx-auto text-lg py-8">
         <.paginator
@@ -215,8 +220,10 @@ defmodule DpulCollectionsWeb.SearchLive do
           {@item.file_count} {gettext("Pages")}
         </div>
       </div>
-      <div class="pt-4 text-gray-500 font-bold text-sm uppercase">
-        <a href="">{@item.genre}</a>
+      <div data-field="genre" class="pt-4 text-gray-500 font-bold text-sm uppercase">
+        <.link navigate={self_route(@search_state, %{genre: first_value(@item.genre)})}>
+          {@item.genre}
+        </.link>
       </div>
       <h2>
         <.link navigate={@item.url}>{@item.title}</.link>
@@ -362,6 +369,16 @@ defmodule DpulCollectionsWeb.SearchLive do
     params = %{socket.assigns.search_state | page: page} |> Helpers.clean_params()
     socket = push_navigate(socket, to: ~p"/search?#{params}")
     {:noreply, socket}
+  end
+
+  def first_value([item | _]), do: item
+  def first_value([]), do: nil
+  def first_value(nil), do: nil
+  def first_value(item), do: item
+
+  def self_route(search_state, extra \\ %{}) do
+    params = Map.merge(search_state, extra) |> Helpers.clean_params()
+    ~p"/search?#{params}"
   end
 
   defp more_pages?(page, per_page, total_items) do

--- a/lib/dpul_collections_web/live/search_live/search_state.ex
+++ b/lib/dpul_collections_web/live/search_live/search_state.ex
@@ -8,26 +8,37 @@ defmodule DpulCollectionsWeb.SearchLive.SearchState do
       sort_by: valid_sort_by(params),
       page: (params["page"] || "1") |> String.to_integer(),
       per_page: (params["per_page"] || "10") |> String.to_integer(),
-      date_from: params["date_from"] || nil,
-      date_to: params["date_to"] || nil,
-      genre: params["genre"] || nil
+      facet: params["facet"] || %{}
     }
   end
 
-  def date_value(%{date_from: date_from, date_to: date_to})
-      when is_binary(date_to) and is_binary(date_from) do
+  def date_from(%{facet: %{"year" => %{"date_from" => date_from}}}), do: date_from
+  def date_from(_), do: nil
+
+  def date_to(%{facet: %{"year" => %{"date_to" => date_to}}}), do: date_to
+  def date_to(_), do: nil
+
+  def facet_value(%{facet: %{"year" => date_facets = %{}}}, "year"), do: date_value(date_facets)
+
+  def facet_value(%{facet: facets = %{}}, facet_key) do
+    case f = Map.get(facets, facet_key) do
+      "" -> nil
+      _ -> f
+    end
+  end
+
+  def date_value(%{"date_from" => date_from, "date_to" => date_to})
+      when is_binary(date_to) and is_binary(date_from) and date_from != "" and date_to != "" do
     "#{date_from} #{gettext("to")} #{date_to}"
   end
 
-  def date_value(%{date_from: date_from}) when is_binary(date_from) do
+  def date_value(%{"date_from" => date_from}) when is_binary(date_from) and date_from != "" do
     "#{date_from} #{gettext("to")} #{gettext("Now")}"
   end
 
-  def date_value(%{date_to: date_to}) when is_binary(date_to) do
+  def date_value(%{"date_to" => date_to}) when is_binary(date_to) and date_to != "" do
     "#{gettext("Up")} #{gettext("to")} #{date_to}"
   end
-
-  def date_value(%{}), do: nil
 
   defp valid_sort_by(%{"sort_by" => sort_by})
        when sort_by in @sort_by_keys do

--- a/lib/dpul_collections_web/live/search_live/search_state.ex
+++ b/lib/dpul_collections_web/live/search_live/search_state.ex
@@ -1,0 +1,38 @@
+defmodule DpulCollectionsWeb.SearchLive.SearchState do
+  use DpulCollections.Solr.Constants
+  use Gettext, backend: DpulCollectionsWeb.Gettext
+
+  def from_params(params) do
+    %{
+      q: params["q"],
+      sort_by: valid_sort_by(params),
+      page: (params["page"] || "1") |> String.to_integer(),
+      per_page: (params["per_page"] || "10") |> String.to_integer(),
+      date_from: params["date_from"] || nil,
+      date_to: params["date_to"] || nil,
+      genre: params["genre"] || nil
+    }
+  end
+
+  def date_value(%{date_from: date_from, date_to: date_to})
+      when is_binary(date_to) and is_binary(date_from) do
+    "#{date_from} #{gettext("to")} #{date_to}"
+  end
+
+  def date_value(%{date_from: date_from}) when is_binary(date_from) do
+    "#{date_from} #{gettext("to")} #{gettext("Now")}"
+  end
+
+  def date_value(%{date_to: date_to}) when is_binary(date_to) do
+    "#{gettext("Up")} #{gettext("to")} #{date_to}"
+  end
+
+  def date_value(%{}), do: nil
+
+  defp valid_sort_by(%{"sort_by" => sort_by})
+       when sort_by in @sort_by_keys do
+    String.to_existing_atom(sort_by)
+  end
+
+  defp valid_sort_by(_), do: :relevance
+end

--- a/lib/dpul_collections_web/live/search_live/search_state.ex
+++ b/lib/dpul_collections_web/live/search_live/search_state.ex
@@ -12,34 +12,6 @@ defmodule DpulCollectionsWeb.SearchLive.SearchState do
     }
   end
 
-  def date_from(%{facet: %{"year" => %{"date_from" => date_from}}}), do: date_from
-  def date_from(_), do: nil
-
-  def date_to(%{facet: %{"year" => %{"date_to" => date_to}}}), do: date_to
-  def date_to(_), do: nil
-
-  def facet_value(%{facet: %{"year" => date_facets = %{}}}, "year"), do: date_value(date_facets)
-
-  def facet_value(%{facet: facets = %{}}, facet_key) do
-    case f = Map.get(facets, facet_key) do
-      "" -> nil
-      _ -> f
-    end
-  end
-
-  def date_value(%{"date_from" => date_from, "date_to" => date_to})
-      when is_binary(date_to) and is_binary(date_from) and date_from != "" and date_to != "" do
-    "#{date_from} #{gettext("to")} #{date_to}"
-  end
-
-  def date_value(%{"date_from" => date_from}) when is_binary(date_from) and date_from != "" do
-    "#{date_from} #{gettext("to")} #{gettext("Now")}"
-  end
-
-  def date_value(%{"date_to" => date_to}) when is_binary(date_to) and date_to != "" do
-    "#{gettext("Up")} #{gettext("to")} #{date_to}"
-  end
-
   defp valid_sort_by(%{"sort_by" => sort_by})
        when sort_by in @sort_by_keys do
     String.to_existing_atom(sort_by)

--- a/test/dpul_collections_web/live/helpers_test.exs
+++ b/test/dpul_collections_web/live/helpers_test.exs
@@ -1,0 +1,37 @@
+defmodule DpulCollectionsWeb.HelpersTest do
+  use DpulCollectionsWeb.ConnCase
+  alias DpulCollectionsWeb.Live.Helpers
+
+  describe "clean_params/2" do
+    test "removes keys with empty values, nil values, or keys to be stripped" do
+      test_map = %{
+        "stay" => "1",
+        "remove" => "",
+        "remove_2" => nil,
+        "remove_explicit" => "bla"
+      }
+
+      assert Helpers.clean_params(test_map, ["remove_explicit"]) == %{"stay" => "1"}
+    end
+
+    test "removes nested parameters with empty keys" do
+      test_map = %{
+        "stay" => "1",
+        "remove" => "",
+        "remove_2" => nil,
+        "facet" => %{
+          "year" => %{
+            "to" => "",
+            "from" => "1900"
+          },
+          "genre" => ""
+        }
+      }
+
+      assert Helpers.clean_params(test_map) == %{
+               "stay" => "1",
+               "facet" => %{"year" => %{"from" => "1900"}}
+             }
+    end
+  end
+end

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -323,6 +323,32 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
            |> Enum.empty?()
   end
 
+  test "items can be filtered by genre", %{conn: conn} do
+    {:ok, view, html} = live(conn, "/search")
+
+    {:ok, document} =
+      view
+      |> element("#item-2 a", "Folders")
+      |> render_click()
+      |> follow_redirect(conn)
+      |> elem(2)
+      |> Floki.parse_document()
+
+    # Only folders
+    assert document
+           |> Floki.find(~s{a[href="/i/document2/item/2"]})
+           |> Enum.any?()
+
+    assert document
+           |> Floki.find(~s{a[href="/i/document4/item/4"]})
+           |> Enum.any?()
+
+    # Odd numbered ones are pamphlets.
+    assert document
+           |> Floki.find(~s{a[href="/i/document1/item/1"]})
+           |> Enum.empty?()
+  end
+
   test "paginator works as expected", %{conn: conn} do
     # Check that the previous link is hidden on the first page
     {:ok, view, _html} = live(conn, ~p"/search?page=1")

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -197,7 +197,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
     assert document |> Floki.find("#year-facet") |> Enum.empty?()
     assert document |> Floki.find("#genre-facet") |> Enum.empty?()
 
-    {:ok, _view, html} = live(conn, "/search?date_to=2025")
+    {:ok, _view, html} = live(conn, "/search?facet[year][date_to]=2025")
 
     {:ok, document} =
       html
@@ -210,7 +210,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
 
     assert document |> Floki.find("#genre-facet") |> Enum.empty?()
 
-    {:ok, _view, html} = live(conn, "/search?date_from=2020")
+    {:ok, _view, html} = live(conn, "/search?facet[year][date_from]=2020")
 
     {:ok, document} =
       html
@@ -223,7 +223,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
 
     assert document |> Floki.find("#genre-facet") |> Enum.empty?()
 
-    {:ok, _view, html} = live(conn, "/search?genre=posters")
+    {:ok, _view, html} = live(conn, "/search?facet[genre]=posters")
 
     {:ok, document} =
       html
@@ -236,7 +236,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
            |> Floki.text()
            |> TestUtils.clean_string() == "Genre posters"
 
-    {:ok, _view, html} = live(conn, "/search?genre=posters&date_to=2025")
+    {:ok, _view, html} = live(conn, "/search?facet[genre]=posters&facet[year][date_to]=2025")
 
     {:ok, document} =
       html
@@ -307,7 +307,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
     {:ok, document} =
       view
       |> element("#date-filter")
-      |> render_submit(%{"date-from" => "1925", "date-to" => "1926"})
+      |> render_submit(%{"facet" => %{"year" => %{"date_from" => "1925", "date_to" => "1926"}}})
       |> Floki.parse_document()
 
     assert document

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -197,7 +197,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
     assert document |> Floki.find("#year-facet") |> Enum.empty?()
     assert document |> Floki.find("#genre-facet") |> Enum.empty?()
 
-    {:ok, _view, html} = live(conn, "/search?facet[year][date_to]=2025")
+    {:ok, _view, html} = live(conn, "/search?facet[year][to]=2025")
 
     {:ok, document} =
       html
@@ -210,7 +210,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
 
     assert document |> Floki.find("#genre-facet") |> Enum.empty?()
 
-    {:ok, _view, html} = live(conn, "/search?facet[year][date_from]=2020")
+    {:ok, _view, html} = live(conn, "/search?facet[year][from]=2020&facet[year][to]=")
 
     {:ok, document} =
       html
@@ -236,7 +236,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
            |> Floki.text()
            |> TestUtils.clean_string() == "Genre posters"
 
-    {:ok, _view, html} = live(conn, "/search?facet[genre]=posters&facet[year][date_to]=2025")
+    {:ok, _view, html} = live(conn, "/search?facet[genre]=posters&facet[year][to]=2025")
 
     {:ok, document} =
       html
@@ -307,7 +307,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
     {:ok, document} =
       view
       |> element("#date-filter")
-      |> render_submit(%{"facet" => %{"year" => %{"date_from" => "1925", "date_to" => "1926"}}})
+      |> render_submit(%{"facet" => %{"year" => %{"from" => "1925", "to" => "1926"}}})
       |> Floki.parse_document()
 
     assert document
@@ -320,6 +320,16 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
 
     assert document
            |> Floki.find(~s{a[href="/i/document98/item/98"]})
+           |> Enum.empty?()
+  end
+
+  test "unknown filters are ignored", %{conn: conn} do
+    {:ok, view, html} = live(conn, "/search?facet[stuff]=1")
+
+    {:ok, document} = Floki.parse_document(html)
+
+    assert document
+           |> Floki.find(~s{.facet})
            |> Enum.empty?()
   end
 

--- a/test/support/solr_test_support.ex
+++ b/test/support/solr_test_support.ex
@@ -14,6 +14,13 @@ defmodule SolrTestSupport do
           true -> nil
         end
 
+      # Even numbered documents are folders.
+      genre =
+        cond do
+          rem(n, 2) == 0 -> ["Folders"]
+          true -> ["Pamphlets"]
+        end
+
       %{
         id: n,
         title_txtm: "Document-#{n}",
@@ -29,6 +36,7 @@ defmodule SolrTestSupport do
           "https://example.com/iiif/2/image6",
           "https://example.com/iiif/2/image7"
         ],
+        genre_txtm: genre,
         primary_thumbnail_service_url_s: thumbnail_url,
         digitized_at_dt:
           DateTime.utc_now() |> DateTime.add(-100 + 1 * n, :day) |> DateTime.to_iso8601()


### PR DESCRIPTION
Closes #485 

This refactors existing facets to be much more configurable (in `Constants.ex`) and makes faceting work in a much more general way, to make it easier to add simple facets later.

It also converts faceting to use the `fq` parameter (which Solr can cache, and which is a little easier to combine separate from the query param)

![Screen Shot 2025-06-02 at 4 05 12 PM](https://github.com/user-attachments/assets/5103b079-5af9-4f9f-b33b-b57f16c21859)
