### PR TITLE
Lighten the colors on the home page in particular, use sage as primary

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -24,17 +24,20 @@
   /* Button Text on Dark Blue */
   --color-light-green: #ECF2CB;
 
+  --color-princeton-black: #121212;
+
+  /* hsl(65, 15%, 70%) */
 
   /* Some semantic colors */
   --color-background: var(--color-taupe);
   --color-light-text: var(--color-taupe);
-  --color-dark-text: var(--color-dark-blue);
+  --color-dark-text: var(--color-princeton-black);
   /* brand is the color that's the site's brand - header/footer */
-  --color-brand: var(--color-dark-blue);
+  --color-brand: var(--color-princeton-black);
   /* Primary is calls to action - buttons */
-  --color-primary: var(--color-dark-blue);
-  /* Secondary is for alternate lower-priority sections */
-  --color-secondary: hsl(65, 15%, 70%);
+  --color-primary: hsl(65, 15%, 70%);
+  /* Secondary is for gentler highlights */
+  --color-secondary: var(--color-wafer-pink);
   /* Accents are an additional color.
    * Images/highlights/hyperlinks/boxes/cards/etc.
    */
@@ -52,7 +55,7 @@
 }
 
 .bg-primary {
-  @apply text-light-text;
+  @apply text-dark-text;
 }
 
 .browse-link {
@@ -121,7 +124,7 @@
 
 .btn-arrow {
   clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
-  @apply bg-primary cursor-pointer border;
+  @apply bg-primary cursor-pointer;
 }
 
 @utility active {
@@ -193,7 +196,7 @@
   }
 
   .item-page button a {
-    @apply text-light-green hover:no-underline;
+    @apply text-dark-text hover:no-underline;
   }
 
   h1 {

--- a/lib/dpul_collections_web/components/browse_item.ex
+++ b/lib/dpul_collections_web/components/browse_item.ex
@@ -70,7 +70,7 @@ defmodule DpulCollectionsWeb.BrowseItem do
       </div>
       
     <!-- "added on" note -->
-      <div :if={@added?} class="digitized_at self-end w-full bg-background h-10 p-2 text-right">
+      <div :if={@added?} class="digitized_at self-end w-full bg-secondary h-10 p-2 text-right">
         {"#{gettext("Added")} #{time_ago(@item.digitized_at)}"}
       </div>
     </div>

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -32,7 +32,7 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
           </form>
         </div>
 
-        <div class="browse-link flex flex-none justify-end items-center header-e-padding bg-secondary ml-auto">
+        <div class="browse-link flex flex-none justify-end items-center header-e-padding bg-primary ml-auto">
           <div class="w-full text-right heading text-xl font-bold">
             <span><.icon name="hero-square-3-stack-3d" class="p-1 h-10 w-10 icon" /></span>
             <.link navigate={~p"/browse"} class="pl-2">

--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -180,7 +180,7 @@ defmodule DpulCollectionsWeb.HomeLive do
       </div>
       <.content_separator />
 
-      <div class="recent-items grid-row bg-secondary">
+      <div class="recent-items grid-row bg-background">
         <div class="content-area">
           <div class="page-t-padding" />
           <h1>{gettext("Recently Added Items")}</h1>

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -94,7 +94,7 @@ defmodule DpulCollectionsWeb.ItemLive do
       </div>
 
       <div class="">
-        <div class="bg-cloud">RELATED ITEMS</div>
+        <div class="bg-secondary">RELATED ITEMS</div>
       </div>
       <.share_modal item={@item} />
     </div>
@@ -156,7 +156,7 @@ defmodule DpulCollectionsWeb.ItemLive do
     ~H"""
     <div class="flex flex-col justify-center text-center text-sm mr-2 min-w-15 items-center">
       <button {@rest}>
-        <div class="hover:text-white hover:bg-accent cursor-pointer w-10 h-10 p-2 bg-wafer-pink rounded-full flex justify-center items-center">
+        <div class="hover:text-white hover:bg-accent cursor-pointer w-10 h-10 p-2 bg-secondary rounded-full flex justify-center items-center">
           <.icon class="w-full h-full" name={@icon} />
         </div>
         {render_slot(@inner_block)}


### PR DESCRIPTION
Oh, this also uses the princeton black as the brand color, and integrates that color into the site via the text color.

refs #488

After
![Screenshot 2025-05-29 at 10-56-49 Digital Collections · Phoenix Framework](https://github.com/user-attachments/assets/f525db9a-af0d-4cd6-9204-b2eec2c126a0)

![Screenshot 2025-05-29 at 10-47-09 Digital Collections · Phoenix Framework](https://github.com/user-attachments/assets/da02d123-aba9-4892-91d1-5acf7d84de2f)
