### PR TITLE
Display PDF Button

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -129,7 +129,7 @@
 }
 
 @utility btn-primary {
-  @apply flex items-center justify-center cursor-pointer font-bold *:font-bold uppercase bg-primary h-14;
+  @apply flex items-center justify-center cursor-pointer font-bold *:font-bold uppercase bg-primary text-dark-text h-14 disabled:cursor-not-allowed;
 }
 
 @utility btn-secondary {

--- a/lib/dpul_collections/item.ex
+++ b/lib/dpul_collections/item.ex
@@ -37,7 +37,8 @@ defmodule DpulCollections.Item do
     :subject,
     :transliterated_title,
     :url,
-    :width
+    :width,
+    :pdf_url
   ]
 
   def metadata_display_fields do
@@ -93,7 +94,8 @@ defmodule DpulCollections.Item do
       subject: doc["subject_txtm"] || [],
       transliterated_title: doc["transliterated_title_txtm"] || [],
       url: generate_url(id, slug),
-      width: doc["width_txtm"] || []
+      width: doc["width_txtm"] || [],
+      pdf_url: doc["pdf_url_s"]
     }
   end
 

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -198,7 +198,7 @@ defmodule DpulCollectionsWeb.ItemLive do
   def download_button(assigns) do
     ~H"""
     <.primary_button disabled>
-      No PDF Available
+          {gettext("No PDF Available")}
     </.primary_button>
     """
   end

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -178,17 +178,28 @@ defmodule DpulCollectionsWeb.ItemLive do
         height="800"
       />
 
-      <.primary_button class="left-arrow-box" href="#" target="_blank">
+      <.primary_button class="left-arrow-box">
         <.icon name="hero-eye" /> {gettext("View")}
       </.primary_button>
 
-      <.primary_button
-        href={"#{Application.fetch_env!(:dpul_collections, :web_connections)[:figgy_url]}/catalog/#{@item.id}/pdf"}
-        target="_blank"
-      >
-        <.icon name="hero-arrow-down-on-square" class="h-5" /><span>{gettext("Download")}</span>
-      </.primary_button>
+      <.download_button item={@item} />
     </div>
+    """
+  end
+
+  def download_button(assigns = %{item: %{pdf_url: pdf_url}}) when is_binary(pdf_url) do
+    ~H"""
+    <.primary_button href={@item.pdf_url} target="_blank">
+      <.icon name="hero-arrow-down-on-square" class="h-5" /><span>{gettext("Download")}</span>
+    </.primary_button>
+    """
+  end
+
+  def download_button(assigns) do
+    ~H"""
+    <.primary_button disabled>
+      No PDF Available
+    </.primary_button>
     """
   end
 
@@ -237,15 +248,24 @@ defmodule DpulCollectionsWeb.ItemLive do
 
   slot :inner_block
   attr :class, :string, default: nil
-  attr :href, :string, default: nil
+  attr :href, :string, default: nil, doc: "link - if set it makes an anchor tag"
+  attr :disabled, :boolean, default: false
   attr :rest, :global, doc: "the arbitrary HTML attributes to add link"
+
+  def primary_button(assigns = %{href: href}) when href != nil do
+    ~H"""
+    <a href={@href} class={["btn-primary", "flex gap-2", @class]} {@rest}>
+      <div>
+        {render_slot(@inner_block)}
+      </div>
+    </a>
+    """
+  end
 
   def primary_button(assigns) do
     ~H"""
-    <button class={["btn-primary", @class]}>
-      <a href={@href} class="flex gap-2" {@rest}>
-        {render_slot(@inner_block)}
-      </a>
+    <button class={["btn-primary flex gap-2", @class]} disabled={@disabled}>
+      {render_slot(@inner_block)}
     </button>
     """
   end
@@ -261,7 +281,7 @@ defmodule DpulCollectionsWeb.ItemLive do
         />
       </dl>
     </div>
-    <.primary_button class="right-arrow-box" href="#" target="_blank">
+    <.primary_button class="right-arrow-box">
       <.icon name="hero-table-cells" /> {gettext("View all metadata for this item")}
     </.primary_button>
     """

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -198,7 +198,7 @@ defmodule DpulCollectionsWeb.ItemLive do
   def download_button(assigns) do
     ~H"""
     <.primary_button disabled>
-          {gettext("No PDF Available")}
+      {gettext("No PDF Available")}
     </.primary_button>
     """
   end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -43,7 +43,7 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:188
+#: lib/dpul_collections_web/live/item_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
@@ -53,7 +53,7 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:48
+#: lib/dpul_collections/item.ex:49
 #: lib/dpul_collections_web/components/header_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "Language"
@@ -162,7 +162,7 @@ msgid "The Trustees of Princeton University"
 msgstr ""
 
 #: lib/dpul_collections_web/components/search_bar_component.ex:39
-#: lib/dpul_collections_web/live/home_live.ex:157
+#: lib/dpul_collections_web/live/home_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Browse all items"
 msgstr ""
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Recently Added"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:185
+#: lib/dpul_collections_web/live/home_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Recently Added Items"
 msgstr ""
@@ -195,7 +195,7 @@ msgstr ""
 msgid "Added"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:187
+#: lib/dpul_collections_web/live/home_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "Our collections are constantly growing. Discover something new!"
 msgstr ""
@@ -205,7 +205,7 @@ msgstr ""
 msgid "%{file_min} of %{file_max} pages"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:181
+#: lib/dpul_collections_web/live/item_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -250,47 +250,52 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:46
+#: lib/dpul_collections/item.ex:47
 #, elixir-autogen, elixir-format
 msgid "Creator of work"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:49
+#: lib/dpul_collections/item.ex:50
 #, elixir-autogen, elixir-format
 msgid "Geographic Origin"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:47
+#: lib/dpul_collections/item.ex:48
 #, elixir-autogen, elixir-format
 msgid "Publisher"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:50
+#: lib/dpul_collections/item.ex:51
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:221
+#: lib/dpul_collections_web/live/item_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "View all metadata for this item"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:148
+#: lib/dpul_collections_web/live/home_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Discover %{photographs}, %{posters}, %{books}, and more to inspire your research"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:152
+#: lib/dpul_collections_web/live/home_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "books"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:150
+#: lib/dpul_collections_web/live/home_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "photographs"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:151
+#: lib/dpul_collections_web/live/home_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "posters"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:201
+#, elixir-autogen, elixir-format
+msgid "No PDF Available"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:188
+#: lib/dpul_collections_web/live/item_live.ex:193
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Download"
 msgstr ""
@@ -53,7 +53,7 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:48
+#: lib/dpul_collections/item.ex:49
 #: lib/dpul_collections_web/components/header_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "Language"
@@ -162,7 +162,7 @@ msgid "The Trustees of Princeton University"
 msgstr ""
 
 #: lib/dpul_collections_web/components/search_bar_component.ex:39
-#: lib/dpul_collections_web/live/home_live.ex:157
+#: lib/dpul_collections_web/live/home_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Browse all items"
 msgstr ""
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Recently Added"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:185
+#: lib/dpul_collections_web/live/home_live.ex:201
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Recently Added Items"
 msgstr ""
@@ -195,7 +195,7 @@ msgstr ""
 msgid "Added"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:187
+#: lib/dpul_collections_web/live/home_live.ex:203
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our collections are constantly growing. Discover something new!"
 msgstr ""
@@ -205,7 +205,7 @@ msgstr ""
 msgid "%{file_min} of %{file_max} pages"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:181
+#: lib/dpul_collections_web/live/item_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -250,47 +250,52 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:46
+#: lib/dpul_collections/item.ex:47
 #, elixir-autogen, elixir-format
 msgid "Creator of work"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:49
+#: lib/dpul_collections/item.ex:50
 #, elixir-autogen, elixir-format
 msgid "Geographic Origin"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:47
+#: lib/dpul_collections/item.ex:48
 #, elixir-autogen, elixir-format
 msgid "Publisher"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:50
+#: lib/dpul_collections/item.ex:51
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:221
+#: lib/dpul_collections_web/live/item_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "View all metadata for this item"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:148
+#: lib/dpul_collections_web/live/home_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Discover %{photographs}, %{posters}, %{books}, and more to inspire your research"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:152
+#: lib/dpul_collections_web/live/home_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "books"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:150
+#: lib/dpul_collections_web/live/home_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "photographs"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:151
+#: lib/dpul_collections_web/live/home_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "posters"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:201
+#, elixir-autogen, elixir-format
+msgid "No PDF Available"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -43,7 +43,7 @@ msgstr "¡Éxito!"
 msgid "close"
 msgstr "cerrar"
 
-#: lib/dpul_collections_web/live/item_live.ex:188
+#: lib/dpul_collections_web/live/item_live.ex:193
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Download"
 msgstr "Descargar"
@@ -53,7 +53,7 @@ msgstr "Descargar"
 msgid "Apply"
 msgstr "Aplicar"
 
-#: lib/dpul_collections/item.ex:48
+#: lib/dpul_collections/item.ex:49
 #: lib/dpul_collections_web/components/header_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "Language"
@@ -162,7 +162,7 @@ msgid "The Trustees of Princeton University"
 msgstr "Los fideicomisarios de la Universidad de Princeton"
 
 #: lib/dpul_collections_web/components/search_bar_component.ex:39
-#: lib/dpul_collections_web/live/home_live.ex:157
+#: lib/dpul_collections_web/live/home_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Browse all items"
 msgstr "Explorar todos los materiales"
@@ -184,7 +184,7 @@ msgstr "Resultados de la búsqueda por"
 msgid "Recently Added"
 msgstr "Añadido recientemente"
 
-#: lib/dpul_collections_web/live/home_live.ex:185
+#: lib/dpul_collections_web/live/home_live.ex:201
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Recently Added Items"
 msgstr "Materiales Recientes"
@@ -195,7 +195,7 @@ msgstr "Materiales Recientes"
 msgid "Added"
 msgstr "Añadido"
 
-#: lib/dpul_collections_web/live/home_live.ex:187
+#: lib/dpul_collections_web/live/home_live.ex:203
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our collections are constantly growing. Discover something new!"
 msgstr "Nuestras colecciones están en constante crecimiento. ¡Descubre algo nuevo!"
@@ -205,7 +205,7 @@ msgstr "Nuestras colecciones están en constante crecimiento. ¡Descubre algo nu
 msgid "%{file_min} of %{file_max} pages"
 msgstr "%{file_min} de %{file_max} páginas"
 
-#: lib/dpul_collections_web/live/item_live.ex:181
+#: lib/dpul_collections_web/live/item_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Abrir"
@@ -250,47 +250,52 @@ msgstr "filtrar por fecha"
 msgid "to"
 msgstr "hasta"
 
-#: lib/dpul_collections/item.ex:46
+#: lib/dpul_collections/item.ex:47
 #, elixir-autogen, elixir-format
 msgid "Creator of work"
 msgstr "Creador de la obra"
 
-#: lib/dpul_collections/item.ex:49
+#: lib/dpul_collections/item.ex:50
 #, elixir-autogen, elixir-format
 msgid "Geographic Origin"
 msgstr "Origen geográfico"
 
-#: lib/dpul_collections/item.ex:47
+#: lib/dpul_collections/item.ex:48
 #, elixir-autogen, elixir-format
 msgid "Publisher"
 msgstr "Editor"
 
-#: lib/dpul_collections/item.ex:50
+#: lib/dpul_collections/item.ex:51
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr "Tema"
 
-#: lib/dpul_collections_web/live/item_live.ex:221
+#: lib/dpul_collections_web/live/item_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "View all metadata for this item"
 msgstr "Ver todos los metadatos de este ítem"
 
-#: lib/dpul_collections_web/live/home_live.ex:148
+#: lib/dpul_collections_web/live/home_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Discover %{photographs}, %{posters}, %{books}, and more to inspire your research"
 msgstr "Descubre %{photographs}, %{posters}, %{books} y más para inspirar tu investigación."
 
-#: lib/dpul_collections_web/live/home_live.ex:152
+#: lib/dpul_collections_web/live/home_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "books"
 msgstr "libros"
 
-#: lib/dpul_collections_web/live/home_live.ex:150
+#: lib/dpul_collections_web/live/home_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "photographs"
 msgstr "fotografías"
 
-#: lib/dpul_collections_web/live/home_live.ex:151
+#: lib/dpul_collections_web/live/home_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "posters"
 msgstr "pósteres"
+
+#: lib/dpul_collections_web/live/item_live.ex:201
+#, elixir-autogen, elixir-format
+msgid "No PDF Available"
+msgstr "PDF no disponible"

--- a/test/dpul_collections_web/live/item_live_test.exs
+++ b/test/dpul_collections_web/live/item_live_test.exs
@@ -47,7 +47,9 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
           subject_txtm: ["subject"],
           transliterated_title_txtm: ["transliterated title"],
           width_txtm: ["200"],
-          ephemera_project_title_s: "Test Project"
+          ephemera_project_title_s: "Test Project",
+          pdf_url_s:
+            "https://figgy.example.com/concern/ephemera_folders/3da68e1c-06af-4d17-8603-fc73152e1ef7/pdf"
         },
         %{
           id: 2,
@@ -130,40 +132,50 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
     assert conn.status == 200
   end
 
-  test "GET /i/{:slug}/item/{:id} response", %{conn: conn} do
-    {:ok, view, _html} = live(conn, "/i/învăţămîntul-trebuie-urmărească-dez/item/1")
-    response = render(view)
-    assert response =~ "Învăţămîntul trebuie să urmărească dezvoltarea deplină a personalităţii"
-    assert response =~ "2022"
-    assert response =~ "17"
-    assert response =~ "This is a test description"
-    # Thumbnails render.
-    assert view
-           |> has_element?(
-             "img[src='https://example.com/iiif/2/image1/full/350,465/0/default.jpg']"
-           )
+  describe "GET /i/{:slug}/item/{:id}" do
+    test "response", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/i/învăţămîntul-trebuie-urmărească-dez/item/1")
+      response = render(view)
+      assert response =~ "Învăţămîntul trebuie să urmărească dezvoltarea deplină a personalităţii"
+      assert response =~ "2022"
+      assert response =~ "17"
+      assert response =~ "This is a test description"
+      # Thumbnails render.
+      assert view
+             |> has_element?(
+               "img[src='https://example.com/iiif/2/image1/full/350,465/0/default.jpg']"
+             )
 
-    assert view
-           |> has_element?(
-             "img[src='https://example.com/iiif/2/image2/full/350,465/0/default.jpg']"
-           )
+      assert view
+             |> has_element?(
+               "img[src='https://example.com/iiif/2/image2/full/350,465/0/default.jpg']"
+             )
 
-    # Large thumbnail renders using thumbnail service url
-    assert view
-           |> has_element?(
-             ".primary-thumbnail img[src='https://example.com/iiif/2/image2/full/525,800/0/default.jpg']"
-           )
+      # Large thumbnail renders using thumbnail service url
+      assert view
+             |> has_element?(
+               ".primary-thumbnail img[src='https://example.com/iiif/2/image2/full/525,800/0/default.jpg']"
+             )
 
-    assert view
-           |> has_element?(
-             ".primary-thumbnail a[href='https://figgy.example.com/catalog/1/pdf']",
-             "Download"
-           )
+      assert view
+             |> has_element?(
+               ".primary-thumbnail a[href='https://figgy.example.com/concern/ephemera_folders/3da68e1c-06af-4d17-8603-fc73152e1ef7/pdf']",
+               "Download"
+             )
 
-    # Renders when there's no description
-    {:ok, view, _html} = live(conn, "/i/زلزلہ/item/2")
-    response = render(view)
-    assert response =~ "زلزلہ"
+      # Renders when there's no description
+      {:ok, view, _html} = live(conn, "/i/زلزلہ/item/2")
+      response = render(view)
+      assert response =~ "زلزلہ"
+    end
+
+    test "doesn't display a pdf for resources with no pdf permission", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/i/زلزلہ/item/2")
+      response = render(view)
+
+      assert response =~ "زلزلہ"
+      assert response =~ "No PDF Available"
+    end
   end
 
   test "/i/{:slug}/item/{:id} 404s with a bad id", %{conn: conn} do


### PR DESCRIPTION
Closes #287

This also fixes the semantics for links/buttons in the Item page by
creating links when there's an `href`, and buttons otherwise.

![Screen Shot 2025-05-29 at 10 51 18 AM](https://github.com/user-attachments/assets/bf7dd216-821f-4255-aa6d-3c74d198d716)
