### PR TITLE
Try a green secondary shade -- required bumping primary a bit darker

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -37,6 +37,7 @@
   --color-sage-900: #6B6645;
 
   /* hsl(65, 15%, 70%) */
+  --color-dpulc-primary: hsl(65, 15%, 65%);
 
   /* Some semantic colors */
   --color-background: var(--color-taupe);
@@ -45,9 +46,10 @@
   /* brand is the color that's the site's brand - header/footer */
   --color-brand: var(--color-princeton-black);
   /* Primary is calls to action - buttons */
-  --color-primary: hsl(65, 15%, 70%);
+  --color-primary: var(--color-dpulc-primary);
   /* Secondary is for gentler highlights */
-  --color-secondary: var(--color-wafer-pink);
+  --color-secondary: var(--color-sage-200);
+  --color-light-secondary: var(--color-sage-100);
   /* Accents are an additional color.
    * Images/highlights/hyperlinks/boxes/cards/etc.
    */

--- a/lib/dpul_collections_web/components/browse_item.ex
+++ b/lib/dpul_collections_web/components/browse_item.ex
@@ -70,7 +70,7 @@ defmodule DpulCollectionsWeb.BrowseItem do
       </div>
       
     <!-- "added on" note -->
-      <div :if={@added?} class="digitized_at self-end w-full bg-secondary h-10 p-2 text-right">
+      <div :if={@added?} class="digitized_at self-end w-full bg-light-secondary h-10 p-2 text-right">
         {"#{gettext("Added")} #{time_ago(@item.digitized_at)}"}
       </div>
     </div>


### PR DESCRIPTION
I thought a green secondary might tie the color scheme together more, and it turned out the color used on the search bar was the right contrast against the taupe. But on the item page it was hard to distinguish it from the primary color so I bumped that a bit darker.

## before
![Screenshot 2025-05-30 at 09-56-23 Digital Collections · Phoenix Framework](https://github.com/user-attachments/assets/b623c066-4161-4f91-971c-e33526259196)

![Screenshot 2025-05-30 at 09-57-37 Digital Collections · Phoenix Framework](https://github.com/user-attachments/assets/914d72d0-1d94-4d02-ae0b-34c9c0deabd9)

## after
![Screenshot 2025-05-30 at 09-50-33 Digital Collections · Phoenix Framework](https://github.com/user-attachments/assets/f90744f1-5675-4f2e-8769-572f55f838f6)


![Screenshot 2025-05-30 at 09-50-42 Digital Collections · Phoenix Framework](https://github.com/user-attachments/assets/84c59b54-156d-43e3-ac95-944091799459)

