### PR TITLE
Patch, but scroll to top for metadata.

### DIFF
--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -2,7 +2,6 @@ let Hooks = {};
 
 Hooks.ToolbarHook = {
   mounted() {
-
     this.observer = new IntersectionObserver(entries => {
       entries.forEach(entry => {
         if (!entry.isIntersecting) {
@@ -19,5 +18,13 @@ Hooks.ToolbarHook = {
     this.observer.observe(this.el);
   }
 };
+
+// Scrolls to the top of the page when an element is mounted. Usually
+// used for slide ins updated via patch.
+Hooks.ScrollTop = {
+  mounted() {
+    window.scrollTo(0,0)
+  }
+}
 
 export default Hooks;

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -153,6 +153,7 @@ defmodule DpulCollectionsWeb.ItemLive do
       data-cancel={JS.exec("phx-remove")}
       phx-window-keydown={JS.exec("data-cancel", to: "#metadata-pane")}
       phx-key="escape"
+      phx-hook="ScrollTop"
     >
       <div class="header-x-padding page-y-padding bg-accent flex flex-row">
         <h1 class="uppercase text-light-text flex-auto">{gettext("Metadata")}</h1>
@@ -375,7 +376,7 @@ defmodule DpulCollectionsWeb.ItemLive do
         />
       </dl>
     </div>
-    <.primary_button id="metadata-link" class="right-arrow-box" href={@item.metadata_url}>
+    <.primary_button id="metadata-link" class="right-arrow-box" patch={@item.metadata_url}>
       <.icon name="hero-table-cells" />{gettext("View all metadata for this item")}
     </.primary_button>
     """


### PR DESCRIPTION
This should get rid of the strange "blip" when the page reloads and the
metadata pane slides in.
