### PR TITLE
Make viewer take full space, don't capture mouse events

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -63,11 +63,11 @@ window.addEventListener("dpulc:clipcopy", (event) => {
 });
 
 document.addEventListener("DOMContentLoaded", e => {
-  initLiveReact()
+  window.output = initLiveReact()
 })
 
-import Viewer from "@samvera/clover-iiif/viewer";
+import DpulcViewer from "./dpulc_viewer";
 
 window.Components = {
-  Viewer
+  DpulcViewer
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -62,8 +62,9 @@ window.addEventListener("dpulc:clipcopy", (event) => {
   }
 });
 
+// Initialize react components.
 document.addEventListener("DOMContentLoaded", e => {
-  window.output = initLiveReact()
+  initLiveReact()
 })
 
 import DpulcViewer from "./dpulc_viewer";

--- a/assets/js/dpulc_viewer.jsx
+++ b/assets/js/dpulc_viewer.jsx
@@ -1,11 +1,28 @@
 import Viewer from "@samvera/clover-iiif/viewer";
 import React from 'react';
+// DpulcViewer is a react component which acts as a wrapper for Clover with
+// all of our default settings and functionality.
 export default function DpulcViewer(props) {
-  const output =  (
+  return (
     <>
-    < Viewer {...props} />
+    <Viewer
+      options={
+        {
+          openSeadragon: {
+            mouseNavEnabled: false,
+              gestureSettings: {
+                scrollToZoom: false
+              }
+          },
+            informationPanel: {
+              open: false,
+                renderAbout: false,
+                renderToggle: false
+            }
+        }
+      }
+      {...props}
+    />
     </>
   );
-  window.output = output;
-  return output;
 }

--- a/assets/js/dpulc_viewer.jsx
+++ b/assets/js/dpulc_viewer.jsx
@@ -1,0 +1,11 @@
+import Viewer from "@samvera/clover-iiif/viewer";
+import React from 'react';
+export default function DpulcViewer(props) {
+  const output =  (
+    <>
+    < Viewer {...props} />
+    </>
+  );
+  window.output = output;
+  return output;
+}

--- a/assets/js/dpulc_viewer.jsx
+++ b/assets/js/dpulc_viewer.jsx
@@ -8,6 +8,7 @@ export default function DpulcViewer(props) {
     <Viewer
       options={
         {
+          canvasHeight: "auto",
           openSeadragon: {
             mouseNavEnabled: false,
               gestureSettings: {

--- a/lib/dpul_collections_web/components/layouts/root.html.heex
+++ b/lib/dpul_collections_web/components/layouts/root.html.heex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="[scrollbar-gutter:stable] font-sans">
+<html lang="en" class="font-sans">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -20,10 +20,12 @@
     </a>
     <div class="flex flex-col min-h-screen" id="app">
       {DpulCollectionsWeb.HeaderComponent.header(assigns)}
-      <div class="flex-1 bg-background">
-        {@inner_content}
+      <div class="relative flex-1 flex flex-col">
+        <div class="flex-1 bg-background">
+          {@inner_content}
+        </div>
+        {DpulCollectionsWeb.FooterComponent.footer(assigns)}
       </div>
-      {DpulCollectionsWeb.FooterComponent.footer(assigns)}
     </div>
   </body>
 </html>

--- a/lib/dpul_collections_web/components/layouts/root.html.heex
+++ b/lib/dpul_collections_web/components/layouts/root.html.heex
@@ -20,6 +20,7 @@
     </a>
     <div class="flex flex-col min-h-screen" id="app">
       {DpulCollectionsWeb.HeaderComponent.header(assigns)}
+      <!-- "relative" here lets us have absolute layout elements that cover all parts of the page except the header. -->
       <div class="relative flex-1 flex flex-col">
         <div class="flex-1 bg-background">
           {@inner_content}

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -225,6 +225,20 @@ defmodule DpulCollectionsWeb.ItemLive do
     """
   end
 
+  # Hide elements that get covered by the viewer modal so they're not tab
+  # targetable.
+  def hide_covered_elements(js \\ %JS{}) do
+    [".item-page", ".search-bar", "footer"]
+    |> Enum.reduce(js, fn class, acc_js ->
+      JS.hide(acc_js, to: class, transition: "fade-out-scale", time: 250)
+    end)
+  end
+
+  def show_covered_elements(js \\ %JS{}) do
+    [".item-page", ".search-bar", "footer"]
+    |> Enum.reduce(js, fn class, acc_js -> JS.show(acc_js, to: class) end)
+  end
+
   def viewer_pane(assigns) do
     ~H"""
     <div
@@ -232,12 +246,13 @@ defmodule DpulCollectionsWeb.ItemLive do
       class="bg-background flex flex-col min-h-full min-w-full -translate-x-full col-start-1 row-start-1 absolute top-0"
       phx-mounted={
         JS.transition({"ease-out duration-250", "-translate-x-full", "translate-x-0"})
-        |> JS.hide(to: ".item-page", transition: "fade-out-scale", time: 250)
+        |> hide_covered_elements()
       }
-      phx-remove={JS.show(to: ".item-page")}
+      phx-remove={show_covered_elements()}
       data-cancel={JS.patch(@item.url)}
       phx-window-keydown={JS.exec("data-cancel", to: "#viewer-pane")}
       phx-key="escape"
+      phx-hook="ScrollTop"
     >
       <div class="header-x-padding page-y-padding bg-accent flex flex-row">
         <h1 class="uppercase text-light-text flex-auto">{gettext("Viewer")}</h1>

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -88,7 +88,7 @@ defmodule DpulCollectionsWeb.ItemLive do
 
   def item_page(assigns) do
     ~H"""
-    <div class="bg-background page-y-padding content-area item-page col-start-1 row-start-1">
+    <div class={"bg-background page-y-padding content-area item-page col-start-1 row-start-1"}>
       <div class="column-layout my-5 flex flex-col sm:grid sm:grid-flow-row sm:auto-rows-0 sm:grid-cols-5 sm:grid-rows-[auto_1fr] sm:content-start gap-x-14 gap-y-4">
         <div class="item-title sm:row-start-1 sm:col-start-3 sm:col-span-3 h-min flex flex-col gap-4">
           <.facet_link
@@ -230,8 +230,8 @@ defmodule DpulCollectionsWeb.ItemLive do
     <div
       id="viewer-pane"
       class="bg-background w-full h-full -translate-x-full col-start-1 row-start-1"
-                    phx-mounted={JS.transition({"ease-out duration-250", "-translate-x-full", "translate-x-0"})}
-                    data-cancel={JS.patch(@item.url) |> JS.remove_class("hidden", to: ".item-page")}
+                    phx-mounted={JS.transition({"ease-out duration-250", "-translate-x-full", "translate-x-0"}) |> JS.hide(to: ".item-page", transition: "fade-out-scale", time: 250)}
+                    data-cancel={JS.show(to: ".item-page") |> JS.patch(@item.url)}
       phx-window-keydown={JS.exec("data-cancel", to: "#viewer-pane")}
       phx-key="escape"
     >
@@ -247,7 +247,7 @@ defmodule DpulCollectionsWeb.ItemLive do
       </div>
       <div class="main-content">
         <div class="w-full h-full col-start-1 row-start-1">
-          {live_react_component("Components.Viewer", [iiifContent: @item.iiif_manifest_url, options: %{informationPanel: %{open: false, renderAbout: false, renderToggle: false}}],
+          {live_react_component("Components.DpulcViewer", [iiifContent: @item.iiif_manifest_url, options: %{openSeadragon: %{mouseNavEnabled: false, gestureSettings: %{scrollToZoom: false}},informationPanel: %{open: false, renderAbout: false, renderToggle: false}}],
             id: "viewer-component"
           )}
         </div>

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -88,7 +88,7 @@ defmodule DpulCollectionsWeb.ItemLive do
 
   def item_page(assigns) do
     ~H"""
-    <div class={"bg-background page-y-padding content-area item-page col-start-1 row-start-1"}>
+    <div class="bg-background page-y-padding content-area item-page col-start-1 row-start-1">
       <div class="column-layout my-5 flex flex-col sm:grid sm:grid-flow-row sm:auto-rows-0 sm:grid-cols-5 sm:grid-rows-[auto_1fr] sm:content-start gap-x-14 gap-y-4">
         <div class="item-title sm:row-start-1 sm:col-start-3 sm:col-span-3 h-min flex flex-col gap-4">
           <.facet_link
@@ -230,8 +230,11 @@ defmodule DpulCollectionsWeb.ItemLive do
     <div
       id="viewer-pane"
       class="bg-background w-full h-full -translate-x-full col-start-1 row-start-1"
-                    phx-mounted={JS.transition({"ease-out duration-250", "-translate-x-full", "translate-x-0"}) |> JS.hide(to: ".item-page", transition: "fade-out-scale", time: 250)}
-                    data-cancel={JS.show(to: ".item-page") |> JS.patch(@item.url)}
+      phx-mounted={
+        JS.transition({"ease-out duration-250", "-translate-x-full", "translate-x-0"})
+        |> JS.hide(to: ".item-page", transition: "fade-out-scale", time: 250)
+      }
+      data-cancel={JS.show(to: ".item-page") |> JS.patch(@item.url)}
       phx-window-keydown={JS.exec("data-cancel", to: "#viewer-pane")}
       phx-key="escape"
     >
@@ -247,7 +250,15 @@ defmodule DpulCollectionsWeb.ItemLive do
       </div>
       <div class="main-content">
         <div class="w-full h-full col-start-1 row-start-1">
-          {live_react_component("Components.DpulcViewer", [iiifContent: @item.iiif_manifest_url, options: %{openSeadragon: %{mouseNavEnabled: false, gestureSettings: %{scrollToZoom: false}},informationPanel: %{open: false, renderAbout: false, renderToggle: false}}],
+          {live_react_component(
+            "Components.DpulcViewer",
+            [
+              iiifContent: @item.iiif_manifest_url,
+              options: %{
+                openSeadragon: %{mouseNavEnabled: false, gestureSettings: %{scrollToZoom: false}},
+                informationPanel: %{open: false, renderAbout: false, renderToggle: false}
+              }
+            ],
             id: "viewer-component"
           )}
         </div>

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -230,8 +230,8 @@ defmodule DpulCollectionsWeb.ItemLive do
     <div
       id="viewer-pane"
       class="bg-background w-full h-full -translate-x-full col-start-1 row-start-1"
-      phx-mounted={JS.transition({"ease-out duration-250", "-translate-x-full", "translate-x-0"})}
-      data-cancel={JS.patch(@item.url)}
+                    phx-mounted={JS.transition({"ease-out duration-250", "-translate-x-full", "translate-x-0"})}
+                    data-cancel={JS.patch(@item.url) |> JS.remove_class("hidden", to: ".item-page")}
       phx-window-keydown={JS.exec("data-cancel", to: "#viewer-pane")}
       phx-key="escape"
     >
@@ -245,9 +245,9 @@ defmodule DpulCollectionsWeb.ItemLive do
           <.icon class="w-8 h-8" name="hero-x-mark" />
         </.link>
       </div>
-      <div class="main-content header-x-padding page-y-padding">
-        <div class="bg-cloud w-[92vw] h-[92vh] col-start-1 row-start-1">
-          {live_react_component("Components.Viewer", [iiifContent: @item.iiif_manifest_url],
+      <div class="main-content">
+        <div class="w-full h-full col-start-1 row-start-1">
+          {live_react_component("Components.Viewer", [iiifContent: @item.iiif_manifest_url, options: %{informationPanel: %{open: false, renderAbout: false, renderToggle: false}}],
             id: "viewer-component"
           )}
         </div>

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -264,6 +264,7 @@ defmodule DpulCollectionsWeb.ItemLive do
           <.icon class="w-8 h-8" name="hero-x-mark" />
         </.link>
       </div>
+      <!-- "relative" here lets Clover fill the full size of main-content. -->
       <div class="main-content grow relative">
         {live_react_component(
           "Components.DpulcViewer",

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -253,11 +253,7 @@ defmodule DpulCollectionsWeb.ItemLive do
           {live_react_component(
             "Components.DpulcViewer",
             [
-              iiifContent: @item.iiif_manifest_url,
-              options: %{
-                openSeadragon: %{mouseNavEnabled: false, gestureSettings: %{scrollToZoom: false}},
-                informationPanel: %{open: false, renderAbout: false, renderToggle: false}
-              }
+              iiifContent: @item.iiif_manifest_url
             ],
             id: "viewer-component"
           )}

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -229,14 +229,14 @@ defmodule DpulCollectionsWeb.ItemLive do
   # targetable.
   def hide_covered_elements(js \\ %JS{}) do
     [".item-page", ".search-bar", "footer"]
-    |> Enum.reduce(js, fn class, acc_js ->
-      JS.hide(acc_js, to: class, transition: "fade-out-scale", time: 250)
+    |> Enum.reduce(js, fn selector, acc_js ->
+      JS.hide(acc_js, to: selector, transition: "fade-out-scale", time: 250)
     end)
   end
 
   def show_covered_elements(js \\ %JS{}) do
     [".item-page", ".search-bar", "footer"]
-    |> Enum.reduce(js, fn class, acc_js -> JS.show(acc_js, to: class) end)
+    |> Enum.reduce(js, fn selector, acc_js -> JS.show(acc_js, to: selector) end)
   end
 
   def viewer_pane(assigns) do

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -81,8 +81,8 @@ defmodule DpulCollectionsWeb.ItemLive do
         different_project_related_items={@different_project_related_items}
       />
       <.metadata_pane :if={@live_action == :metadata} item={@item} />
-      <.viewer_pane :if={@live_action == :viewer} item={@item} />
     </div>
+    <.viewer_pane :if={@live_action == :viewer} item={@item} />
     """
   end
 
@@ -228,14 +228,14 @@ defmodule DpulCollectionsWeb.ItemLive do
   # Hide elements that get covered by the viewer modal so they're not tab
   # targetable.
   def hide_covered_elements(js \\ %JS{}) do
-    [".item-page", ".search-bar", "footer"]
+    ["#item-wrap", ".search-bar", "footer"]
     |> Enum.reduce(js, fn selector, acc_js ->
       JS.hide(acc_js, to: selector, transition: "fade-out-scale", time: 250)
     end)
   end
 
   def show_covered_elements(js \\ %JS{}) do
-    [".item-page", ".search-bar", "footer"]
+    ["#item-wrap", ".search-bar", "footer"]
     |> Enum.reduce(js, fn selector, acc_js -> JS.show(acc_js, to: selector) end)
   end
 

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -229,12 +229,13 @@ defmodule DpulCollectionsWeb.ItemLive do
     ~H"""
     <div
       id="viewer-pane"
-      class="bg-background w-full h-full -translate-x-full col-start-1 row-start-1"
+      class="bg-background flex flex-col min-h-full min-w-full -translate-x-full col-start-1 row-start-1 absolute top-0"
       phx-mounted={
         JS.transition({"ease-out duration-250", "-translate-x-full", "translate-x-0"})
         |> JS.hide(to: ".item-page", transition: "fade-out-scale", time: 250)
       }
-      data-cancel={JS.show(to: ".item-page") |> JS.patch(@item.url)}
+      phx-remove={JS.show(to: ".item-page")}
+      data-cancel={JS.patch(@item.url)}
       phx-window-keydown={JS.exec("data-cancel", to: "#viewer-pane")}
       phx-key="escape"
     >
@@ -248,16 +249,14 @@ defmodule DpulCollectionsWeb.ItemLive do
           <.icon class="w-8 h-8" name="hero-x-mark" />
         </.link>
       </div>
-      <div class="main-content">
-        <div class="w-full h-full col-start-1 row-start-1">
-          {live_react_component(
-            "Components.DpulcViewer",
-            [
-              iiifContent: @item.iiif_manifest_url
-            ],
-            id: "viewer-component"
-          )}
-        </div>
+      <div class="main-content grow relative">
+        {live_react_component(
+          "Components.DpulcViewer",
+          [
+            iiifContent: @item.iiif_manifest_url
+          ],
+          id: "viewer-component"
+        )}
       </div>
     </div>
     """
@@ -340,7 +339,7 @@ defmodule DpulCollectionsWeb.ItemLive do
         height="800"
       />
 
-      <.primary_button id="viewer-link" class="left-arrow-box" href={@item.viewer_url}>
+      <.primary_button id="viewer-link" class="left-arrow-box" patch={@item.viewer_url}>
         <.icon name="hero-eye" /> {gettext("View")}
       </.primary_button>
 


### PR DESCRIPTION
I want to do more, like disable mouse scroll but keep pan, but it looks
like to do that we either need 
https://github.com/openseadragon/openseadragon/issues/2151 or add a
placeholder canvas to our manifests which requires IIIF 3 manifests. 

<img width="1718" alt="Screenshot 2025-06-14 at 4 54 32 PM" src="https://github.com/user-attachments/assets/c4042922-76c5-4f86-8480-36750b9549b9" />

Closes #532 
Closes #531 