### PR TITLE
Try item page thumbnails that maintain aspect ratio.

### DIFF
--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -347,7 +347,7 @@ defmodule DpulCollectionsWeb.ItemLive do
     <div class="primary-thumbnail grid grid-cols-2 gap-2 content-start">
       <img
         class="col-span-2 w-full"
-        src={"#{@item.primary_thumbnail_service_url}/full/525,800/0/default.jpg"}
+        src={"#{@item.primary_thumbnail_service_url}/full/!525,800/0/default.jpg"}
         alt="main image display"
         style="
           background-color: lightgray;"

--- a/test/dpul_collections_web/live/item_live_test.exs
+++ b/test/dpul_collections_web/live/item_live_test.exs
@@ -168,7 +168,7 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
       # Large thumbnail renders using thumbnail service url
       assert view
              |> has_element?(
-               ".primary-thumbnail img[src='https://example.com/iiif/2/image2/full/525,800/0/default.jpg']"
+               ".primary-thumbnail img[src='https://example.com/iiif/2/image2/full/!525,800/0/default.jpg']"
              )
 
       assert view


### PR DESCRIPTION
Closes #545 

The only downside to these are that the window jumps around - we should find a way to get the height/width of these ahead of time so we can render the correct sized box.

![Screen Shot 2025-06-16 at 1 45 22 PM](https://github.com/user-attachments/assets/aa9bd723-4c2d-4b67-b1e3-54221c85164f)
![Screen Shot 2025-06-16 at 1 45 41 PM](https://github.com/user-attachments/assets/0487c7e8-e6aa-448d-a5fb-5a1844ae1e74)
![Screen Shot 2025-06-16 at 1 45 53 PM](https://github.com/user-attachments/assets/6ddccfcd-b0df-4858-a3ee-224cefe77edd)
![Screen Shot 2025-06-16 at 1 46 13 PM](https://github.com/user-attachments/assets/938b3505-35b7-45f5-8ec4-84598e0e53ae)
