### PR TITLE
Pass content state URL to clover

### DIFF
--- a/assets/js/dpulc_viewer.jsx
+++ b/assets/js/dpulc_viewer.jsx
@@ -26,7 +26,8 @@ export default function DpulcViewer(props) {
             informationPanel: {
               open: false,
                 renderAbout: false,
-                renderToggle: false
+                renderToggle: false,
+                renderAnnotation: false
             }
         }
       }

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -15,7 +15,7 @@ defmodule DpulCollectionsWeb.ItemLive do
     path = URI.parse(uri).path |> URI.decode()
     # Initialize current_canvas_idx to be 0 if it's not set. 0 is a filler value
     # for "no canvas selected"
-    current_canvas_idx = (params["current_canvas_idx"]  || "0") |> String.to_integer()
+    current_canvas_idx = (params["current_canvas_idx"] || "0") |> String.to_integer()
     current_content_state_url = content_state_url(uri, item, current_canvas_idx)
 
     socket =
@@ -155,6 +155,7 @@ defmodule DpulCollectionsWeb.ItemLive do
                 :if={@item.file_count}
                 thumb={thumb}
                 thumb_num={thumb_num}
+                viewer_url={@item.viewer_url}
               />
             </div>
           </section>
@@ -611,13 +612,15 @@ defmodule DpulCollectionsWeb.ItemLive do
   def thumbs(assigns) do
     ~H"""
     <div class="pr-2 pb-2">
-      <img
-        class="h-full w-full object-cover"
-        src={"#{@thumb}/full/350,465/0/default.jpg"}
-        alt={"image #{@thumb_num}"}
-        style="
-          background-color: lightgray;"
-      />
+      <a href={"#{@viewer_url}/#{@thumb_num + 1}"}>
+        <img
+          class="h-full w-full object-cover"
+          src={"#{@thumb}/full/350,465/0/default.jpg"}
+          alt={"image #{@thumb_num}"}
+          style="
+            background-color: lightgray;"
+        />
+      </a>
     </div>
     """
   end

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -303,6 +303,9 @@ defmodule DpulCollectionsWeb.ItemLive do
     """
   end
 
+  defp content_state_url(_, nil, _), do: nil
+  defp content_state_url(_, _, 0), do: nil
+
   defp content_state_url(uri, item, current_canvas_idx) do
     %URI{scheme: scheme, authority: authority} = URI.parse(uri)
     base = "#{scheme}://#{authority}"
@@ -612,7 +615,7 @@ defmodule DpulCollectionsWeb.ItemLive do
   def thumbs(assigns) do
     ~H"""
     <div class="pr-2 pb-2">
-      <a href={"#{@viewer_url}/#{@thumb_num + 1}"}>
+      <a href={"#{@viewer_url}/#{@thumb_num + 1}"} }>
         <img
           class="h-full w-full object-cover"
           src={"#{@thumb}/full/350,465/0/default.jpg"}

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -15,7 +15,15 @@ defmodule DpulCollectionsWeb.ItemLive do
     path = URI.parse(uri).path |> URI.decode()
     # Initialize current_canvas_idx to be 0 if it's not set. 0 is a filler value
     # for "no canvas selected"
-    socket = socket |> assign(:current_canvas_idx, params["current_canvas_idx"] || "0")
+    current_canvas_idx = (params["current_canvas_idx"]  || "0") |> String.to_integer()
+    current_content_state_url = content_state_url(uri, item, current_canvas_idx)
+
+    socket =
+      assign(socket,
+        current_canvas_idx: current_canvas_idx,
+        current_content_state_url: current_content_state_url
+      )
+
     {:noreply, build_socket(socket, item, path)}
   end
 
@@ -88,7 +96,11 @@ defmodule DpulCollectionsWeb.ItemLive do
       />
     </div>
     <.metadata_pane :if={@live_action == :metadata} item={@item} />
-    <.viewer_pane :if={@live_action == :viewer} item={@item} />
+    <.viewer_pane
+      :if={@live_action == :viewer}
+      item={@item}
+      current_content_state_url={@current_content_state_url}
+    />
     """
   end
 
@@ -281,13 +293,19 @@ defmodule DpulCollectionsWeb.ItemLive do
         {live_react_component(
           "Components.DpulcViewer",
           [
-            iiifContent: @item.iiif_manifest_url
+            iiifContent: @current_content_state_url
           ],
           id: "viewer-component"
         )}
       </div>
     </div>
     """
+  end
+
+  defp content_state_url(uri, item, current_canvas_idx) do
+    %URI{scheme: scheme, authority: authority} = URI.parse(uri)
+    base = "#{scheme}://#{authority}"
+    "#{base}/iiif/#{item.id}/content_state/#{current_canvas_idx - 1}"
   end
 
   attr :rest, :global
@@ -368,7 +386,7 @@ defmodule DpulCollectionsWeb.ItemLive do
       when not is_nil(current_canvas_idx) do
     idx = Enum.find_index(canvas_ids, fn x -> x == canvas_id end) || 0
 
-    case idx + 1 == String.to_integer(current_canvas_idx) do
+    case idx + 1 == current_canvas_idx do
       # We're already on the correct page, don't do anything.
       true ->
         {:noreply, socket}

--- a/test/dpul_collections_web/live/item_live_test.exs
+++ b/test/dpul_collections_web/live/item_live_test.exs
@@ -159,16 +159,22 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
       assert response =~ "2022"
       assert response =~ "17"
       assert response =~ "This is a test description"
-      # Thumbnails render.
+      # Thumbnails render with link to viewer
       assert view
              |> has_element?(
                "img[src='https://example.com/iiif/2/image1/full/350,465/0/default.jpg']"
              )
 
       assert view
+             |> has_element?("a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/1']")
+
+      assert view
              |> has_element?(
                "img[src='https://example.com/iiif/2/image2/full/350,465/0/default.jpg']"
              )
+
+      assert view
+             |> has_element?("a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/2']")
 
       # Large thumbnail renders using thumbnail service url
       assert view


### PR DESCRIPTION
Closes #342 

- **Pass content state URL to clover**
- **adds href with viewer_url to the thumbnails so they open on the right canvas in Clover**
- **Add tests**
