### PR TITLE
Add viewer links on item page

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,11 @@ Steps to rebuild figgy fixtures locally:
 ```
 cd figgy-fixture-container && ./create-fixture-exports.sh
 cd ..
-mix fixtures.setup
+lando destroy -y && lando start && mix setup
 ```
+
+Then when you run the server, do a `DpulCollections.Solr.commit()`
+
 
 ### Figgy Fixtures: Creating Synthetic Fixtures
 

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -144,19 +144,26 @@ defmodule DpulCollectionsWeb.ItemLive do
             <div class="grid grid-cols-2 py-1 pr-2">
               <div class="text-left text-l text-gray-600 font-semibold">
                 {gettext("%{file_min} of %{file_max} images",
-                  file_min: min(@item.file_count, 12),
+                  file_min: min(@item.file_count, image_thumb_grid_count()),
                   file_max: @item.file_count
                 )}
               </div>
               <div class="text-right text-accent uppercase">
-                <a href="#" target="_blank">
+                <.link
+                  :if={@item.file_count > image_thumb_grid_count()}
+                  patch={"#{@item.viewer_url}/1"}
+                  replace
+                >
                   {gettext("View all images")}
-                </a>
+                </.link>
               </div>
             </div>
             <div class="py-1 grid grid-cols-4">
               <.thumbs
-                :for={{thumb, thumb_num} <- Enum.with_index(Enum.take(@item.image_service_urls, 12))}
+                :for={
+                  {thumb, thumb_num} <-
+                    Enum.with_index(Enum.take(@item.image_service_urls, image_thumb_grid_count()))
+                }
                 :if={@item.file_count}
                 thumb={thumb}
                 thumb_num={thumb_num}
@@ -492,6 +499,10 @@ defmodule DpulCollectionsWeb.ItemLive do
   defp primary_thumbnail_idx(item) do
     (Enum.find_index(item.image_service_urls, fn x -> x == item.primary_thumbnail_service_url end) ||
        0) + 1
+  end
+
+  defp image_thumb_grid_count() do
+    12
   end
 
   @letter_dimensions %{width: 21.59, height: 27.94}

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -447,14 +447,16 @@ defmodule DpulCollectionsWeb.ItemLive do
           <span class="w-[11px] h-[1px] bg-accent"></span>
         </div>
         <div class="col-start-2 relative">
-          <img
-            src={"#{@item.primary_thumbnail_service_url}/full/!#{@item.primary_thumbnail_width},#{@item.primary_thumbnail_height}/0/default.jpg"}
-            alt="main image display"
-            style="
-            background-color: lightgray;"
-            width={@item.primary_thumbnail_width}
-            height={@item.primary_thumbnail_height}
-          />
+          <.link patch={"#{@item.viewer_url}/#{primary_thumbnail_idx(@item)}"} replace>
+            <img
+              src={"#{@item.primary_thumbnail_service_url}/full/!#{@item.primary_thumbnail_width},#{@item.primary_thumbnail_height}/0/default.jpg"}
+              alt="main image display"
+              style="
+              background-color: lightgray;"
+              width={@item.primary_thumbnail_width}
+              height={@item.primary_thumbnail_height}
+            />
+          </.link>
           <div
             :if={@display_size && relative_paper_dimension_style(@item)}
             id="letter-preview"
@@ -485,6 +487,11 @@ defmodule DpulCollectionsWeb.ItemLive do
       </div>
     </div>
     """
+  end
+
+  defp primary_thumbnail_idx(item) do
+    (Enum.find_index(item.image_service_urls, fn x -> x == item.primary_thumbnail_service_url end) ||
+       0) + 1
   end
 
   @letter_dimensions %{width: 21.59, height: 27.94}

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -428,8 +428,8 @@ defmodule DpulCollectionsWeb.ItemLive do
 
   def primary_thumbnail(assigns) do
     ~H"""
-    <div class="primary-thumbnail grid grid-cols-[auto_minmax(0,1fr)] gap-y-2 content-start mb-2">
-      <div class="col-span-2 grid grid-cols-subgrid relative">
+    <div class="grid grid-cols-[auto_minmax(0,1fr)] gap-y-2 content-start mb-2">
+      <div class="primary-thumbnail col-span-2 grid grid-cols-subgrid relative">
         <div :if={@display_size} class="col-start-2 flex justify-center items-center">
           <span class="h-[11px] w-[1px] bg-accent"></span>
           <span class="h-[1px] mr-[5px] flex-grow bg-accent"></span>
@@ -470,7 +470,7 @@ defmodule DpulCollectionsWeb.ItemLive do
         </div>
       </div>
       <div class="w-full col-span-2 gap-2">
-        <div class="grid grid-cols-2 gap-2">
+        <div class="thumbnail-buttons grid grid-cols-2 gap-2">
           <.primary_button
             id="viewer-link"
             class="left-arrow-box"

--- a/test/dpul_collections_web/live/item_live_test.exs
+++ b/test/dpul_collections_web/live/item_live_test.exs
@@ -228,6 +228,25 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
     end
   end
 
+  describe "view all images link" do
+    test "doesn't display if there are 12 or fewer images", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/i/اب-كوئى-جنگ-نه-هوگى/item/3")
+
+      response = render(view)
+      refute response =~ "View all images"
+    end
+
+    test "links to viewer if there are more than 12 images", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/i/învăţămîntul-trebuie-urmărească-dez/item/1")
+
+      assert view
+             |> has_element?(
+               "a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/1']",
+               "View all images"
+             )
+    end
+  end
+
   describe "size toggle" do
     test "displays size when using the button", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/i/învăţămîntul-trebuie-urmărească-dez/item/1")

--- a/test/dpul_collections_web/live/item_live_test.exs
+++ b/test/dpul_collections_web/live/item_live_test.exs
@@ -174,29 +174,24 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
       assert document |> Floki.find(~s{dt:fl-contains("Sort title")}) |> Enum.any?() == false
     end
 
-    test "renders values and thumbnails", %{conn: conn} do
+    test "renders values, thumbnails, and links", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/i/învăţămîntul-trebuie-urmărească-dez/item/1")
       response = render(view)
       assert response =~ "Învăţămîntul trebuie să urmărească dezvoltarea deplină a personalităţii"
       assert response =~ "2022"
       assert response =~ "17"
       assert response =~ "This is a test description"
-      # Thumbnails render with link to viewer
+
+      # Small thumbnails render with links to viewer
       assert view
              |> has_element?(
-               "img[src='https://example.com/iiif/2/image1/full/350,465/0/default.jpg']"
+               "a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/1'] > img[src='https://example.com/iiif/2/image1/full/350,465/0/default.jpg']"
              )
 
       assert view
-             |> has_element?("a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/1']")
-
-      assert view
              |> has_element?(
-               "img[src='https://example.com/iiif/2/image2/full/350,465/0/default.jpg']"
+               "a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/2'] > img[src='https://example.com/iiif/2/image2/full/350,465/0/default.jpg']"
              )
-
-      assert view
-             |> has_element?("a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/2']")
 
       # Large thumbnail renders using thumbnail service url
       assert view
@@ -214,11 +209,11 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
 
       assert view
              |> has_element?(
-               ".primary-thumbnail a[href='https://figgy.example.com/concern/ephemera_folders/3da68e1c-06af-4d17-8603-fc73152e1ef7/pdf']",
+               ".thumbnail-buttons a[href='https://figgy.example.com/concern/ephemera_folders/3da68e1c-06af-4d17-8603-fc73152e1ef7/pdf']",
                "Download"
              )
 
-      # Renders when there's no description
+      # Page renders when there's no description
       {:ok, view, _html} = live(conn, "/i/زلزلہ/item/2")
       response = render(view)
       assert response =~ "زلزلہ"

--- a/test/dpul_collections_web/live/item_live_test.exs
+++ b/test/dpul_collections_web/live/item_live_test.exs
@@ -185,18 +185,18 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
       # Small thumbnails render with links to viewer
       assert view
              |> has_element?(
-               "a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/1'] > img[src='https://example.com/iiif/2/image1/full/350,465/0/default.jpg']"
+               "a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/1'] img[src='https://example.com/iiif/2/image1/full/350,465/0/default.jpg']"
              )
 
       assert view
              |> has_element?(
-               "a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/2'] > img[src='https://example.com/iiif/2/image2/full/350,465/0/default.jpg']"
+               "a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/2'] img[src='https://example.com/iiif/2/image2/full/350,465/0/default.jpg']"
              )
 
-      # Large thumbnail renders using thumbnail service url
+      # Large thumbnail links to the correct image when it's not the first image
       assert view
              |> has_element?(
-               ".primary-thumbnail img[src='https://example.com/iiif/2/image2/full/!453,600/0/default.jpg']"
+               ".primary-thumbnail a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/2'] img[src='https://example.com/iiif/2/image2/full/!453,600/0/default.jpg']"
              )
 
       # Large thumbnail has default width


### PR DESCRIPTION
- Reorganize item_live_test
- Move ids and classes to more localized places
- Wrap primary thumbnail in link, ensure it opens to the thumbnail
- Add link to view all images, only show it if there are > 12

closes #575

Note to reviewer: You may want to review commits 1 at a time, the first 2 are refactors and the second 2 implement the ticket requirements.
