### PR TITLE
Fix css comment

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -151,13 +151,13 @@
   @apply bg-primary cursor-pointer;
 }
 
-// action_icon utilities
+/* action_icon utilities */
 @utility item-action-icon {
-  @apply hover:text-white hover:bg-accent cursor-pointer w-10 h-10 p-2 bg-secondary rounded-full flex justify-center items-center;
+  @apply hover:text-white hover:bg-accent w-10 h-10 p-2 bg-secondary;
 }
 
 @utility pane-action-icon {
-  @apply text-accent hover:bg-secondary cursor-pointer w-6 h-6 p-1 bg-background rounded-full flex justify-center items-center;
+  @apply text-accent hover:bg-secondary w-6 h-6 p-1 bg-background;
 }
 
 @utility skip-to-content {

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -299,7 +299,7 @@ defmodule DpulCollectionsWeb.ItemLive do
           <.action_icon
             icon="hero-share"
             phx-click={show_viewer_share_modal()}
-            utility="pane-action-icon"
+            variant="pane-action-icon"
             aria-label={gettext("Share")}
           >
           </.action_icon>
@@ -354,14 +354,14 @@ defmodule DpulCollectionsWeb.ItemLive do
         <.action_icon
           :if={has_dimensions(@item)}
           icon="pepicons-pencil:ruler"
-          utility="item-action-icon"
+          variant="item-action-icon"
           phx-click="toggle_size"
         >
           {gettext("Size")}
         </.action_icon>
         <.action_icon
           icon="hero-share"
-          utility="item-action-icon"
+          variant="item-action-icon"
           phx-click={JS.show(to: "#share-modal")}
         >
           {gettext("Share")}
@@ -403,10 +403,10 @@ defmodule DpulCollectionsWeb.ItemLive do
   attr :rest, :global
   attr :icon, :string, required: true
 
-  attr :utility, :string,
+  attr :variant, :string,
     required: true,
     doc:
-      "utilities group classes, are defined in app.css, and allow rendering the icon in different sizes and with different color combinations, for example."
+      "A variant should be defined in app.css as a tailwind utility. Variants allow rendering the icon in different sizes and with different color combinations."
 
   slot :inner_block, doc: "the optional inner block that renders the icon label"
 
@@ -414,7 +414,7 @@ defmodule DpulCollectionsWeb.ItemLive do
     ~H"""
     <div class="flex flex-col justify-center text-center text-sm mr-2 min-w-15 items-center">
       <button {@rest}>
-        <div class={@utility}>
+        <div class={@variant <> " cursor-pointer rounded-full flex justify-center items-center"}>
           <.icon class="w-full h-full" name={@icon} />
         </div>
         {render_slot(@inner_block)}


### PR DESCRIPTION
It was breaking the style.

Also refactors the action_icon to use "variant" instead of "utility" as an attribute name, and pushes the
common classes into the function component out of the tailwind utility

closes #597 

<img width="836" height="464" alt="Screenshot 2025-07-16 at 9 48 06 AM" src="https://github.com/user-attachments/assets/a5bb373f-fcce-450a-94cd-e5a2dc7699e2" />
