### PR TITLE
Add primary color background and corner cut decoration to call to action

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -80,8 +80,8 @@
 }
 
 .browse-link {
-  padding-left: 50px;
-  clip-path: polygon(40px 0%, 100% 0%, 100% 100%, 0% 100%);
+  padding-left: 60px;
+  clip-path: polygon(50.72px 0%, 100% 0%, 100% 100%, 0% 100%);
 }
 
 .diagonal-drop {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -256,3 +256,6 @@
   box-shadow: 0 0 10px var(--color-rust), 0 0 5px var(--color-rust);
 }
 
+.corner-cut {
+  clip-path: polygon(0 50.72px,50.72px 0,100% 0,100% 50.72px,100% calc(100% - 50.72px),calc(100% - 50.72px) 100%,0 100%,0 calc(100% - 50.72px));
+}

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -81,7 +81,7 @@
 
 .browse-link {
   padding-left: 60px;
-  clip-path: polygon(50.72px 0%, 100% 0%, 100% 100%, 0% 100%);
+  clip-path: polygon(0 50.72px,50.72px 0%, 100% 0%, 100% 100%, 0% 100%);
 }
 
 .diagonal-drop {

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -6,16 +6,16 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
   def render(assigns) do
     ~H"""
     <div class="search-bar">
-      <div class="search-browse-container min-h-14 flex flex-wrap bg-search">
+      <div class="search-browse-container min-h-10 flex flex-wrap bg-search">
         <div class="search-box header-x-padding grow">
           <form id="search-form" class="w-full h-full" phx-submit="search" phx-target={@myself}>
             <div class="flex items-center w-full h-full" role="search">
               <span class="flex-none">
-                <.icon name="hero-magnifying-glass" class="h-10 w-10 icon" />
+                <.icon name="hero-magnifying-glass" class="h-8 w-8 icon" />
               </span>
               <label for="q" class="sr-only">{gettext("Search")}</label>
               <input
-                class="m-2 p-1 grow h-full placeholder:text-dark-text/40 bg-transparent border-none placeholder:text-2xl text-2xl placeholder:font-bold w-full"
+                class="m-2 px-1 py-0 grow h-full placeholder:text-dark-text/40 bg-transparent border-none placeholder:text-xl text-xl placeholder:font-bold w-full"
                 type="text"
                 id="q"
                 name="q"
@@ -38,7 +38,7 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
           role="navigation"
         >
           <div class="w-full text-right heading text-xl font-bold">
-            <span><.icon name="hero-square-3-stack-3d" class="p-1 h-10 w-10 icon" /></span>
+            <span><.icon name="hero-square-3-stack-3d" class="p-1 h-8 w-8 icon" /></span>
             <.link navigate={~p"/browse"} class="pl-2">
               {gettext("Explore")}
             </.link>

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -40,7 +40,7 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
           <div class="w-full text-right heading text-xl font-bold">
             <span><.icon name="hero-square-3-stack-3d" class="p-1 h-10 w-10 icon" /></span>
             <.link navigate={~p"/browse"} class="pl-2">
-              {gettext("Browse all items")}
+              {gettext("Explore")}
             </.link>
           </div>
         </div>

--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -159,9 +159,9 @@ defmodule DpulCollectionsWeb.HomeLive do
     ~H"""
     <div class="grid grid-flow-row auto-rows-max">
       <div class="explore-header grid-row bg-background relative">
-        <div class="drop-shadow-[1px_1px_3rem_rgba(0,0,0,1)] bg-background absolute max-h-[600px] sm:min-w-[350px] w-full lg:max-w-1/2 2xl:max-w-1/3 top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 p-8">
-          <div class="content-area text-center h-full w-full flex flex-col justify-evenly">
-            <div class="page-y-padding text-xl flex-grow">
+        <div class="drop-shadow-[1px_1px_3rem_rgba(0,0,0,1)] bg-primary absolute max-h-[600px] sm:min-w-[350px] w-full lg:max-w-1/2 2xl:max-w-1/3 top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 p-4">
+          <div class="corner-cut content-area text-center h-full w-full flex flex-col justify-evenly bg-background p-8">
+            <div class="page-y-padding text-2xl flex-grow">
               {gettext(
                 "Discover %{photographs}, %{posters}, %{pamphlets}, and more to inspire your research",
                 photographs:
@@ -182,10 +182,10 @@ defmodule DpulCollectionsWeb.HomeLive do
               )
               |> Phoenix.HTML.raw()}
             </div>
-            <div class="content-area bg-primary text-light-text p-4 text-2xl">
-              <.link navigate={~p"/browse"}>
-                {gettext("Browse all items")}
-              </.link>
+            <div class="content-area bg-primary text-light-text p-x-4 text-2xl">
+              <.primary_button href={~p"/browse"}>
+                {gettext("Explore")}
+              </.primary_button>
             </div>
           </div>
         </div>
@@ -196,7 +196,7 @@ defmodule DpulCollectionsWeb.HomeLive do
                 <div class="h-[200px] w-auto min-w-px flex-shrink-0">
                   <.link navigate={~p"/item/#{id}"} aria-label="Link to item">
                     <img
-                      class="h-full w-auto opacity-60 select-none hover:opacity-100 cursor-pointer"
+                      class="h-full w-auto opacity-40 select-none hover:opacity-100 cursor-pointer"
                       draggable="false"
                       src={image_url}
                       aria-label="Item image"
@@ -228,7 +228,7 @@ defmodule DpulCollectionsWeb.HomeLive do
 
   defp callout_link(assigns) do
     Phoenix.HTML.Safe.to_iodata(~H"""
-    <.link href={@url} class="text-accent" target="_blank">{@label}</.link>
+    <.link href={@url} class="text-accent font-bold" target="_blank">{@label}</.link>
     """)
   end
 end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -158,12 +158,6 @@ msgstr ""
 msgid "The Trustees of Princeton University"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:43
-#: lib/dpul_collections_web/live/home_live.ex:187
-#, elixir-autogen, elixir-format
-msgid "Browse all items"
-msgstr ""
-
 #: lib/dpul_collections_web/live/search_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Search Results for"
@@ -545,4 +539,10 @@ msgstr ""
 #: lib/dpul_collections_web/live/browse_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Exploring items similar to"
+msgstr ""
+
+#: lib/dpul_collections_web/components/search_bar_component.ex:43
+#: lib/dpul_collections_web/live/home_live.ex:187
+#, elixir-autogen, elixir-format
+msgid "Explore"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -158,12 +158,6 @@ msgstr ""
 msgid "The Trustees of Princeton University"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:43
-#: lib/dpul_collections_web/live/home_live.ex:187
-#, elixir-autogen, elixir-format
-msgid "Browse all items"
-msgstr ""
-
 #: lib/dpul_collections_web/live/search_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Search Results for"
@@ -545,4 +539,10 @@ msgstr ""
 #: lib/dpul_collections_web/live/browse_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Exploring items similar to"
+msgstr ""
+
+#: lib/dpul_collections_web/components/search_bar_component.ex:43
+#: lib/dpul_collections_web/live/home_live.ex:187
+#, elixir-autogen, elixir-format
+msgid "Explore"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -158,12 +158,6 @@ msgstr "Colecciones Digitales"
 msgid "The Trustees of Princeton University"
 msgstr "Los fideicomisarios de la Universidad de Princeton"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:43
-#: lib/dpul_collections_web/live/home_live.ex:187
-#, elixir-autogen, elixir-format
-msgid "Browse all items"
-msgstr "Explorar todos los materiales"
-
 #: lib/dpul_collections_web/live/search_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Search Results for"
@@ -546,3 +540,9 @@ msgstr "Aleatorio"
 #, elixir-autogen, elixir-format
 msgid "Exploring items similar to"
 msgstr "Explorando artículos similares a"
+
+#: lib/dpul_collections_web/components/search_bar_component.ex:43
+#: lib/dpul_collections_web/live/home_live.ex:187
+#, elixir-autogen, elixir-format
+msgid "Explore"
+msgstr "Explorar"

--- a/test/dpul_collections_web/features/locale_test.exs
+++ b/test/dpul_collections_web/features/locale_test.exs
@@ -10,10 +10,10 @@ defmodule DpulCollectionsWeb.Features.LocaleTest do
   test "locale persists between pages", %{conn: conn} do
     conn
     |> visit("/")
-    |> assert_has("a", text: "Browse all items")
+    |> assert_has("a", text: "Explore")
     |> click_button("Language")
     |> Playwright.click("//div[text()='Español']")
-    |> assert_has("a", text: "Explorar todos los materiales")
+    |> assert_has("a", text: "Explorar")
     |> Playwright.type("input#q", " ")
     |> click_button("Buscar")
     |> assert_has("label", text: "filtrar por fecha:")

--- a/test/dpul_collections_web/live/home_live_test.exs
+++ b/test/dpul_collections_web/live/home_live_test.exs
@@ -99,9 +99,9 @@ defmodule DpulCollectionsWeb.HomeLiveTest do
     {:ok, view, _} = live(conn, "/")
 
     assert view
-           |> element("#main-content a", "Browse all items")
+           |> element("#main-content a", "Explore")
            |> render_click() ==
-             {:error, {:live_redirect, %{kind: :push, to: "/browse"}}}
+             {:error, {:redirect, %{to: "/browse"}}}
   end
 
   test "page title", %{conn: conn} do


### PR DESCRIPTION
Also desaturates the mosaic images a bit, to forward the call to action
Also changes "browse" language to "explore" and removes "all items"

closes #489

drafted pending translations but posting for consideration

<img width="2223" height="1359" alt="Screenshot 2025-07-18 at 17-09-32 Digital Collections" src="https://github.com/user-attachments/assets/ea5f901a-c630-44ac-a0cf-ef62c070f774" />
