### PR TITLE
Mosaic images should not be tabbable and marked as for presentation.

### DIFF
--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -194,7 +194,7 @@ defmodule DpulCollectionsWeb.HomeLive do
             <div class="h-[200px] flex items-start overflow-hidden">
               <%= for {id, image_url} <- chunk do %>
                 <div class="h-[200px] w-auto min-w-px flex-shrink-0">
-                  <.link navigate={~p"/item/#{id}"} aria-label="Link to item">
+                  <.link tabindex="-1" navigate={~p"/item/#{id}"} aria-label="Link to item">
                     <img
                       class="h-full w-auto opacity-40 select-none hover:opacity-100 cursor-pointer"
                       draggable="false"

--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -199,7 +199,7 @@ defmodule DpulCollectionsWeb.HomeLive do
                       class="h-full w-auto opacity-40 select-none hover:opacity-100 cursor-pointer"
                       draggable="false"
                       src={image_url}
-                      aria-label="Item image"
+                      role="presentation"
                     />
                   </.link>
                 </div>


### PR DESCRIPTION
- **Prevent mosaic images from being tabbable.**
- **Set image as presentation.**

I'm not 100% sure about the accessibility of this, but it's what the automated tests let through...

Closes #605 