### PR TITLE
Fixes misplaced image count on browse item

### DIFF
--- a/lib/dpul_collections_web/components/browse_item.ex
+++ b/lib/dpul_collections_web/components/browse_item.ex
@@ -98,7 +98,7 @@ defmodule DpulCollectionsWeb.BrowseItem do
         </div>
         
     <!-- card text area -->
-        <div class="px-6 py-5 bg-white flex flex-col flex-grow">
+        <div class="relative px-6 py-5 bg-white flex flex-col flex-grow">
           <div
             :if={@item.file_count > 4}
             class="absolute bg-background right-2 top-0 z-10 pr-2 pb-1 diagonal-drop"


### PR DESCRIPTION
### Screenshot
<img width="351" height="531" alt="Screenshot 2025-07-24 at 3 51 35 PM" src="https://github.com/user-attachments/assets/b5c043c9-423a-4af9-9a10-8513d986b727" />

Fixes #632 