### PR TITLE
Don't show more related item rows

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -114,8 +114,8 @@
 .recent-container {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  grid-template-rows: 1fr 0px 0px;
-  @apply gap-x-6;
+  grid-template-rows: 1fr repeat(4, 0px);
+  @apply gap-6;
 }
 
 /*


### PR DESCRIPTION
originally the item row only had 3 items, so it was styled to hide only
2. now it might have up to 5 items, this adjusts styling to hide up to 4.

closes #644
