### PR TITLE
Align icon and text in right-arrow metadata button

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -90,21 +90,19 @@
 }
 
 .left-arrow-box {
-  clip-path: polygon(100% 0%, 100% 100%, 15% 100%, 0% 50%, 15% 0%);
-  /* Add a 7.5% padding so items are centered in the square bit of the box */
-  @apply *:pl-[7.5%]
+  clip-path: polygon(100% 0%, 100% 100%, 40px 100%, 0% 50%, 40px 0%);
+  @apply pl-[20px];
 }
 
 .right-arrow-box {
   clip-path: polygon(
     0% 0%,
     0% 100%,
-    calc(100% - 50px) 100%,
+    calc(100% - 40px) 100%,
     100% 50%,
-    calc(100% - 50px) 0%
+    calc(100% - 40px) 0%
   );
-  @apply *:pl-[10px];
-  @apply *:pr-[60px];
+  @apply pr-[20px];
 }
 
 #search-form:focus-within #search-button {

--- a/lib/dpul_collections_web/components/core_components.ex
+++ b/lib/dpul_collections_web/components/core_components.ex
@@ -174,7 +174,7 @@ defmodule DpulCollectionsWeb.CoreComponents do
 
   def primary_button(assigns = %{href: href, patch: patch}) when href != nil or patch != nil do
     ~H"""
-    <.link href={@href} patch={@patch} class={["btn-primary", "flex gap-2 p-x-2", @class]} {@rest}>
+    <.link href={@href} patch={@patch} class={["btn-primary", "flex gap-2 px-2", @class]} {@rest}>
       {render_slot(@inner_block)}
     </.link>
     """
@@ -182,7 +182,7 @@ defmodule DpulCollectionsWeb.CoreComponents do
 
   def primary_button(assigns) do
     ~H"""
-    <button class={["btn-primary flex gap-2 p-x-2", @class]} disabled={@disabled} {@rest}>
+    <button class={["btn-primary flex gap-2 px-2", @class]} disabled={@disabled} {@rest}>
       {render_slot(@inner_block)}
     </button>
     """

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -634,7 +634,11 @@ defmodule DpulCollectionsWeb.ItemLive do
       </dl>
     </div>
     <.primary_button id="metadata-link" class="right-arrow-box" patch={@item.metadata_url} replace>
-      <span class="w-max flex gap-2"><.icon name="hero-table-cells" /> {gettext("View all metadata for this item")}</span>
+      <span class="w-max flex gap-2 text-sm sm:text-base">
+        <.icon name="hero-table-cells h-5 w-5 sm:h-6 sm:w-6" /> {gettext(
+          "View all metadata for this item"
+        )}
+      </span>
     </.primary_button>
     """
   end

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -634,7 +634,7 @@ defmodule DpulCollectionsWeb.ItemLive do
       </dl>
     </div>
     <.primary_button id="metadata-link" class="right-arrow-box" patch={@item.metadata_url} replace>
-      <.icon name="hero-table-cells" />{gettext("View all metadata for this item")}
+      <span class="w-max flex gap-2"><.icon name="hero-table-cells" /> {gettext("View all metadata for this item")}</span>
     </.primary_button>
     """
   end


### PR DESCRIPTION
- adjust left-arrow-box and right-arrow-box for consistent arrow size
  and styling
- fix erroneous tailwind padding syntax on primary button
- ensure metadata button text and icon stay together, while allowing for
  wrapping when necessary (actually because of making it smaller on smallest screens it doesn't really wrap anymore)
- make the font and icon size smaller for the smallest screen sizes

closes #643 

screenshot, average case:
<img width="839" height="439" alt="Screenshot 2025-07-28 at 4 57 24 PM" src="https://github.com/user-attachments/assets/0ee4e8f9-815d-4af1-b6cf-64dd25c4d7ed" />

screenshot, smallest width case: 
<img width="351" height="219" alt="Screenshot 2025-07-28 at 5 18 51 PM" src="https://github.com/user-attachments/assets/3959b7b8-240f-4921-9398-ad516ab02189" />


