### PR TITLE
Style paginator current page

### DIFF
--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -324,7 +324,7 @@ defmodule DpulCollectionsWeb.SearchLive do
 
   def page_link_or_span(assigns = %{current_page: true}) do
     ~H"""
-    <span class={[@class, "active bg-accent"]}>
+    <span class={[@class, "active bg-accent font-semibold"]}>
       {@text}
     </span>
     """

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -1,25 +1,5 @@
-defmodule DpulCollectionsWeb.SearchComponents do
-  use Phoenix.Component
-  alias DpulCollections.Solr
-
-  attr :text, :string, doc: "the page number, or ellipsis"
-  attr :rest, :global, doc: "the arbitrary HTML attributes to add to the flash container"
-
-  def page_link_or_span(assigns) do
-    ~H"""
-    <a :if={@text != "..."} {@rest} href="#" phx-click="paginate" phx-value-page={@text}>
-      {@text}
-    </a>
-    <span :if={@text == "..."} {@rest}>
-      {@text}
-    </span>
-    """
-  end
-end
-
 defmodule DpulCollectionsWeb.SearchLive do
   use DpulCollectionsWeb, :live_view
-  import DpulCollectionsWeb.SearchComponents
   use Gettext, backend: DpulCollectionsWeb.Gettext
   alias DpulCollections.{Item, Solr}
   use Solr.Constants
@@ -286,22 +266,8 @@ defmodule DpulCollectionsWeb.SearchLive do
       <.page_link_or_span
         :for={{text, current_page?} <- pages(@page, @per_page, @total_items)}
         text={text}
-        class={"
-          flex
-          items-center
-          justify-center
-          px-3
-          h-8
-          leading-tight
-          #{if current_page?, do: "active", else: "
-              border-dark-blue
-              text-dark-text
-              bg-white border
-              hover:bg-gray-100
-              hover:text-gray-700
-              no-underline
-            "}
-        "}
+        current_page={current_page?}
+        class="flex items-center justify-center px-3 h-8 leading-tight border border-dark-blue"
       />
       <.link
         :if={more_pages?(@page, @per_page, @total_items)}
@@ -328,6 +294,39 @@ defmodule DpulCollectionsWeb.SearchLive do
         </svg>
       </.link>
     </nav>
+    """
+  end
+
+  attr :text, :string, doc: "the page number, or ellipsis"
+  attr :current_page, :boolean, default: false, doc: "whether this is the current page"
+  attr :class, :string
+
+  def page_link_or_span(assigns = %{current_page: false, text: "..."}) do
+    ~H"""
+    <span class={[@class, "text-dark-text bg-white"]}>
+      {@text}
+    </span>
+    """
+  end
+
+  def page_link_or_span(assigns = %{current_page: false}) do
+    ~H"""
+    <a
+      class={[@class, "no-underline hover:bg-gray-100 hover:text-gray-700 text-dark-text bg-white"]}
+      href="#"
+      phx-click="paginate"
+      phx-value-page={@text}
+    >
+      {@text}
+    </a>
+    """
+  end
+
+  def page_link_or_span(assigns = %{current_page: true}) do
+    ~H"""
+    <span class={[@class, "active bg-accent"]}>
+      {@text}
+    </span>
     """
   end
 

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -389,7 +389,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
 
     # Check that the previous and next links are displayed and work as expected
     {:ok, view, _html} = live(conn, ~p"/search?page=5")
-    assert(view |> element(".paginator > a.active", ~r(5)) |> has_element?())
+    assert(view |> element(".paginator > span.active", ~r(5)) |> has_element?())
 
     {:ok, document} =
       view


### PR DESCRIPTION
refactor page_link_or_span out of its own module, close to its caller

closes #642

screenshot:
<img width="1092" height="97" alt="Screenshot 2025-07-29 at 10 48 47 AM" src="https://github.com/user-attachments/assets/c3fd136f-51db-4260-8275-50cbe8b40795" />

