### PR TITLE
Adjust mobile header styles

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -176,7 +176,7 @@
 }
 
 @utility home-content-area {
-  @apply content-area max-w-[80%];
+  @apply content-area max-w-screen sm:max-w-[80%];
 }
 
 @utility header-x-padding {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -180,7 +180,7 @@
 }
 
 @utility header-x-padding {
-  @apply px-6 sm:px-8 lg:px-10;
+  @apply px-4 sm:px-8 lg:px-10;
 }
 
 @utility header-s-padding {

--- a/lib/dpul_collections_web/components/header_component.ex
+++ b/lib/dpul_collections_web/components/header_component.ex
@@ -22,7 +22,7 @@ defmodule DpulCollectionsWeb.HeaderComponent do
       <div class="app_name flex-1 w-auto text-center">
         <.link
           navigate={~p"/"}
-          class="text-xl sm:text-3xl md:text-4xl sm:inline-block uppercase tracking-widest font-extrabold text-center"
+          class="text-lg sm:text-3xl md:text-4xl sm:inline-block uppercase tracking-widest font-extrabold text-center"
         >
           {gettext("Digital Collections")}
         </.link>
@@ -39,12 +39,9 @@ defmodule DpulCollectionsWeb.HeaderComponent do
             aria-expanded="false"
             phx-click={JS.toggle(to: "#dropdownMenu")}
           >
-            <span class="hidden sm:flex hover:link-hover font-medium text-md cursor-pointer">
+            <span class="hover:link-hover font-normal sm:font-medium text-sm sm:text-md cursor-pointer">
               {gettext("Language")}&nbsp;<span class="font-normal">&gt;</span>
             </span>
-            <div class="sm:hidden text-sm cursor-pointer">
-              {gettext("Language")}&nbsp;<span class="font-normal">&gt;</span>
-            </div>
           </button>
           <ul
             id="dropdownMenu"

--- a/lib/dpul_collections_web/components/header_component.ex
+++ b/lib/dpul_collections_web/components/header_component.ex
@@ -10,14 +10,13 @@ defmodule DpulCollectionsWeb.HeaderComponent do
       
     <!-- logo -->
       <.link href="https://library.princeton.edu">
+        <div class="logo flex-none w-9 sm:hidden">
+          <img src={~p"/images/local-svgs.svg"} alt="Princeton University Library Logo" />
+        </div>
         <div class="logo flex-none sm:w-32 md:w-40 hidden sm:flex">
           <img src={~p"/images/pul-logo.svg"} alt="Princeton University Library Logo" />
         </div>
       </.link>
-
-      <div class="logo flex-none w-9 sm:hidden">
-        <img src={~p"/images/local-svgs.svg"} alt="Princeton University Library Logo" />
-      </div>
       
     <!-- title -->
       <div class="app_name flex-1 w-auto text-center">

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -34,7 +34,7 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
         </div>
 
         <div
-          class="browse-link flex flex-none justify-end items-center header-e-padding bg-primary ml-auto"
+          class="browse-link min-h-10 flex flex-none justify-end items-center header-e-padding bg-primary ml-auto"
           role="navigation"
         >
           <div class="w-full text-right heading text-xl font-bold">


### PR DESCRIPTION
closes #645

- Move little pul logo into link, giving correct alignment
- Add min height to search bar browse link
- Increase spacing between site title and language dropdown on mobile
- Fix browse item row width on smallest mobile


smallest size, before: 
<img width="376" height="232" alt="Screenshot 2025-07-29 at 12 11 18 PM" src="https://github.com/user-attachments/assets/83ca7659-b43e-4337-b04c-d0f885bd49cd" />

smallest size, after:
<img width="373" height="234" alt="Screenshot 2025-07-29 at 12 13 28 PM" src="https://github.com/user-attachments/assets/85310db1-e545-4611-80e0-65dc9d526177" />

second-smallest size, before:
<img width="422" height="241" alt="Image" src="https://github.com/user-attachments/assets/4a5a6939-2691-4b1a-b581-204f0bd1dde0" />

second-smallest size, after:
<img width="432" height="273" alt="Screenshot 2025-07-29 at 12 13 39 PM" src="https://github.com/user-attachments/assets/72deb106-6c30-4e3f-95d2-c134e21a8ca8" />
