### PR TITLE
Set width/height on image to prevent pushing down item page.

### DIFF
--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -742,6 +742,8 @@ defmodule DpulCollectionsWeb.ItemLive do
           alt={"image #{@thumb_num}"}
           style="
             background-color: lightgray;"
+          width="350"
+          height="465"
         />
       </.link>
     </div>


### PR DESCRIPTION
Closes #657
