### PR TITLE
Production DPUL-C is higher priority than other prod apps.

### DIFF
--- a/config/deploy/production.hcl
+++ b/config/deploy/production.hcl
@@ -15,6 +15,7 @@ job "dpulc-production" {
   update {
     auto_revert       = true
   }
+  priority = 55
   group "web" {
     count = 2
     network {


### PR DESCRIPTION
It's having a hard time finding a slot right now because the indexer needs so many cores, and a bunch of stuff is blocking it.