### PR TITLE
Thumbnail on left

### DIFF
--- a/assets/js/dpulc_viewer.jsx
+++ b/assets/js/dpulc_viewer.jsx
@@ -23,6 +23,7 @@ const handleCanvasIdCallback = (activeCanvasId, loadedCanvasIdx, pushEvent) => {
   }
 };
 
+// Clover scrolls the thumbnail bar horizontally already in https://github.com/samvera-labs/clover-iiif/blob/03d6a9292a4d60ff2b6524a5579af34ad30dc3b2/src/components/Viewer/Media/Media.tsx#L76-L81, but we need to handle vertical scroll.
 const scrollThumbnail = (activeCanvasId, loadedCanvasIdx) => {
   const canvasThumbnail = document.querySelector(`button[value='${activeCanvasId}']`)
   if(canvasThumbnail) {

--- a/assets/js/dpulc_viewer.jsx
+++ b/assets/js/dpulc_viewer.jsx
@@ -15,10 +15,28 @@ const handleCanvasIdCallback = (activeCanvasId, pushEvent) => {
 const StyledViewer = styled("section", {
   ".clover-viewer-content > div": {
     "display": "grid",
-    "grid-template-columns": "1fr min-content"
+    "grid-template-columns": "min-content 1fr",
+    "gap": "1rem"
   },
   ".clover-viewer-media-wrapper > div[role='radiogroup']": {
-    "flex-direction": "column"
+    "flex-direction": "column",
+    "height": 0,
+    "overflow-x": "hidden",
+    "overflow-y": "scroll"
+  },
+  ".clover-viewer-painting": {
+    "grid-column-start": 2,
+    "grid-row-start": 1,
+  },
+  ".clover-viewer-media-wrapper": {
+    "grid-column-start": 1,
+    "grid-row-start": 1,
+    "display": "flex",
+    "flex-direction": "column",
+    "gap": "1rem"
+  },
+  ".clover-viewer-media-wrapper > div:first-child > div": {
+    "position": "unset",
   }
 })
 export default function DpulcViewer(props) {

--- a/assets/js/dpulc_viewer.jsx
+++ b/assets/js/dpulc_viewer.jsx
@@ -1,6 +1,7 @@
 import Viewer from "@samvera/clover-iiif/viewer";
 import React from 'react';
 import Loader from './loader';
+import { styled } from '@stitches/react';
 // DpulcViewer is a react component which acts as a wrapper for Clover with
 // all of our default settings and functionality.
 const handleCanvasIdCallback = (activeCanvasId, pushEvent) => {
@@ -10,9 +11,20 @@ const handleCanvasIdCallback = (activeCanvasId, pushEvent) => {
     pushEvent("changedCanvas", { "canvas_id": activeCanvasId })
   }
 };
+
+const StyledViewer = styled("section", {
+  ".clover-viewer-content > div": {
+    "display": "grid",
+    "grid-template-columns": "1fr min-content"
+  },
+  ".clover-viewer-media-wrapper > div[role='radiogroup']": {
+    "flex-direction": "column"
+  }
+})
 export default function DpulcViewer(props) {
   return (
     <>
+    <StyledViewer>
     <Viewer
     canvasIdCallback={(activeCanvasId) => { handleCanvasIdCallback(activeCanvasId, props.pushEvent) }}
       options={
@@ -36,6 +48,7 @@ export default function DpulcViewer(props) {
       }
       {...props}
     />
+    </StyledViewer>
     </>
   );
 }

--- a/assets/js/dpulc_viewer.jsx
+++ b/assets/js/dpulc_viewer.jsx
@@ -1,10 +1,21 @@
 import Viewer from "@samvera/clover-iiif/viewer";
 import React from 'react';
 import Loader from './loader';
-import { styled } from '@stitches/react';
+import { createStitches } from '@stitches/react';
+const { styled } = createStitches({
+  media: {
+    sm: '(min-width: 640px)',
+    md: '(min-width: 768px)',
+    lg: '(min-width: 1024px)',
+    xl: '(min-width: 1280px)'
+  },
+});
 // DpulcViewer is a react component which acts as a wrapper for Clover with
 // all of our default settings and functionality.
-const handleCanvasIdCallback = (activeCanvasId, pushEvent) => {
+let currentCanvas = null
+const handleCanvasIdCallback = (activeCanvasId, loadedCanvasIdx, pushEvent) => {
+  // In vertical thumbnails, scroll to view.
+  scrollThumbnail(activeCanvasId, loadedCanvasIdx - 1)
   // Tell LiveView that we've changed the canvas so we can change the URL or
   // anything else, if necessary.
   if(typeof pushEvent === 'function') {
@@ -12,31 +23,63 @@ const handleCanvasIdCallback = (activeCanvasId, pushEvent) => {
   }
 };
 
+const scrollThumbnail = (activeCanvasId, loadedCanvasIdx) => {
+  const canvasThumbnail = document.querySelector(`button[value='${activeCanvasId}']`)
+  if(canvasThumbnail) {
+    const allThumbnails = document.querySelectorAll(`div[role='radiogroup'] button`)
+    const canvasContainer = canvasThumbnail.closest("div[role='radiogroup']")
+    const thumbnailRect = canvasThumbnail.getBoundingClientRect()
+    const containerRect = canvasContainer.getBoundingClientRect()
+
+    const isOutsideVertically = thumbnailRect.top < containerRect.top || thumbnailRect.bottom > containerRect.bottom;
+    if (currentCanvas != canvasThumbnail && isOutsideVertically) {
+      // If we're loading the first canvas we were asked to load, then scroll
+      // the bar so it's at the top.
+      const isStartup = Array.prototype.indexOf.call(allThumbnails, canvasThumbnail) == loadedCanvasIdx
+      if(isStartup) {
+        canvasThumbnail.scrollIntoView();
+      // Otherwise scroll it as close as we can - used for the left/right
+      // buttons.
+      } else {
+        canvasThumbnail.scrollIntoView({ block: 'nearest' });
+      }
+      currentCanvas = activeCanvasId
+    }
+  }
+}
+
 const StyledViewer = styled("section", {
-  ".clover-viewer-content > div": {
-    "display": "grid",
-    "grid-template-columns": "min-content 1fr",
-    "gap": "1rem"
-  },
-  ".clover-viewer-media-wrapper > div[role='radiogroup']": {
-    "flex-direction": "column",
-    "height": 0,
-    "overflow-x": "hidden",
-    "overflow-y": "scroll"
-  },
-  ".clover-viewer-painting": {
-    "grid-column-start": 2,
-    "grid-row-start": 1,
-  },
-  ".clover-viewer-media-wrapper": {
-    "grid-column-start": 1,
-    "grid-row-start": 1,
-    "display": "flex",
-    "flex-direction": "column",
-    "gap": "1rem"
-  },
-  ".clover-viewer-media-wrapper > div:first-child > div": {
-    "position": "unset",
+  "@sm": {
+    ".clover-viewer-content > div": {
+      "display": "grid",
+      "grid-template-columns": "min-content 1fr",
+      "gap": "1rem"
+    },
+    ".clover-viewer-media-wrapper > div[role='radiogroup']": {
+      "flex-direction": "column",
+      "height": 0,
+      "overflow-x": "hidden",
+      "overflow-y": "scroll"
+    },
+    ".clover-viewer-painting": {
+      "grid-column-start": 2,
+      "grid-row-start": 1,
+    },
+    ".clover-viewer-media-wrapper": {
+      "grid-column-start": 1,
+      "grid-row-start": 1,
+      "display": "flex",
+      "flex-direction": "column",
+      "gap": "1rem",
+      "align-items": "center"
+    },
+    ".clover-viewer-media-wrapper > div:first-child > div": {
+      "position": "unset"
+    },
+    ".clover-viewer-media-wrapper > div:first-child": {
+      "width": "unset",
+      "position": "unset"
+    }
   }
 })
 export default function DpulcViewer(props) {
@@ -44,7 +87,7 @@ export default function DpulcViewer(props) {
     <>
     <StyledViewer>
     <Viewer
-    canvasIdCallback={(activeCanvasId) => { handleCanvasIdCallback(activeCanvasId, props.pushEvent) }}
+    canvasIdCallback={(activeCanvasId) => { handleCanvasIdCallback(activeCanvasId, props.contentCanvasIndex, props.pushEvent) }}
       options={
         {
           canvasHeight: "auto",

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -332,7 +332,8 @@ defmodule DpulCollectionsWeb.ItemLive do
           {live_react_component(
             "Components.DpulcViewer",
             [
-              iiifContent: unverified_url(DpulCollectionsWeb.Endpoint, @current_content_state_url)
+              iiifContent: unverified_url(DpulCollectionsWeb.Endpoint, @current_content_state_url),
+              contentCanvasIndex: @current_canvas_idx
             ],
             id: "viewer-component"
           )}


### PR DESCRIPTION
Some iteration on #689 
<img width="1901" height="919" alt="Screen Shot 2025-08-21 at 2 37 18 PM" src="https://github.com/user-attachments/assets/d2c3fe3e-313f-4d17-8f7b-88b468448175" />

This puts thumbnails on the left side of the screen as long as you're above Tailwind's sm breakpoint.
