### PR TITLE
Use telemetry to notify stages to poll for changes.

### DIFF
--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -40,7 +40,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
         default: [batch_size: options[:batch_size]],
         noop: [batch_size: options[:batch_size]]
       ],
-      context: %{cache_version: options[:cache_version]}
+      context: %{cache_version: options[:cache_version], type: :figgy_hydrator}
     )
   end
 

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_producer_source.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_producer_source.ex
@@ -8,4 +8,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationProducerSource do
   def get_cache_entries_since!(last_queried_marker, total_demand, _cache_version) do
     IndexingPipeline.get_figgy_resources_since!(last_queried_marker, total_demand)
   end
+
+  def init(_producer_state) do
+  end
 end

--- a/lib/dpul_collections/indexing_pipeline/figgy/indexing_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/indexing_consumer.ex
@@ -47,7 +47,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.IndexingConsumer do
       ],
       context: %{
         cache_version: options[:cache_version],
-        solr_index: options[:solr_index]
+        solr_index: options[:solr_index],
+        type: :figgy_indexer
       }
     )
   end

--- a/lib/dpul_collections/indexing_pipeline/figgy/transformation_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/transformation_consumer.ex
@@ -42,7 +42,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationConsumer do
         default: [batch_size: options[:batch_size]],
         noop: [concurrency: 5, batch_size: options[:batch_size]]
       ],
-      context: %{cache_version: options[:cache_version]}
+      context: %{cache_version: options[:cache_version], type: :figgy_transformer}
     )
   end
 

--- a/lib/dpul_collections/indexing_pipeline/figgy/transformation_producer_source.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/transformation_producer_source.ex
@@ -13,4 +13,29 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationProducerSource do
       cache_version
     )
   end
+
+  def init(%{cache_version: cache_version}) do
+    # Listen for batch_processor stops, so we know when a hydrator we care about
+    # is done.
+    producer_pid = self()
+
+    :telemetry.attach(
+      "hydration-listener-#{producer_pid |> :erlang.pid_to_list()}",
+      [:broadway, :batch_processor, :stop],
+      &handle_batch_closed(&1, &2, &3, &4, cache_version),
+      %{producer_pid: producer_pid}
+    )
+  end
+
+  defp handle_batch_closed(
+         _event,
+         _measurements,
+         %{context: %{type: :figgy_hydrator, cache_version: cache_version}},
+         %{producer_pid: producer_pid},
+         cache_version
+       ) do
+    send(producer_pid, :check_for_updates)
+  end
+
+  defp handle_batch_closed(_event, _measurements, _metadata, _config, _cache_version), do: nil
 end

--- a/test/support/figgy_test_support.ex
+++ b/test/support/figgy_test_support.ex
@@ -111,20 +111,20 @@ defmodule FiggyTestSupport do
     {:ok, indexer} =
       Figgy.IndexingConsumer.start_link(
         cache_version: cache_version,
-        batch_size: 50,
+        batch_size: 1,
         solr_index: SolrTestSupport.active_collection()
       )
 
     {:ok, tracker_pid} = GenServer.start_link(AckTracker, self())
 
     {:ok, transformer} =
-      Figgy.TransformationConsumer.start_link(cache_version: cache_version, batch_size: 50)
+      Figgy.TransformationConsumer.start_link(cache_version: cache_version, batch_size: 1)
 
     # Control hydration indexing.
     {:ok, hydrator} =
       Figgy.HydrationConsumer.start_link(
         cache_version: cache_version,
-        batch_size: 50,
+        batch_size: 1,
         producer_module: MockFiggyHydrationProducer,
         producer_options: {self(), 1}
       )


### PR DESCRIPTION
This should result in a ton less chatter and load against the database - it'll only poll every minute, and most of the time that'll be empty (except for the Hydrator, which polls Figgy.)

Also, this speeds up the tests by so much. I'm not sure why - probably a side effect of the pooled transaction database only allowing one query at a time. It brings the test suite from 118 seconds in https://github.com/pulibrary/dpul-collections/pull/718 to 68 seconds.

Work towards #679 