### PR TITLE
Try a header more consistent with our other applications.

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -26,6 +26,7 @@
   --color-light-green: #ECF2CB;
 
   --color-princeton-black: #121212;
+  --color-princeton-orange-on-black: rgb(245, 128, 37);
 
   /* sage mono colors from canva: https://www.canva.com/colors/color-meanings/sage-green/ */
 

--- a/lib/dpul_collections_web/components/header_component.ex
+++ b/lib/dpul_collections_web/components/header_component.ex
@@ -6,70 +6,75 @@ defmodule DpulCollectionsWeb.HeaderComponent do
 
   def header(assigns) do
     ~H"""
-    <header class="flex flex-row gap-10 items-center bg-brand py-6 header-x-padding">
-      
-    <!-- logo -->
-      <.link href="https://library.princeton.edu">
-        <div class="logo flex-none w-9 sm:hidden">
-          <img src={~p"/images/local-svgs.svg"} alt={gettext("Princeton University Library Logo")} />
+    <header class="flex bg-brand items-center justify-center border-b-1 border-princeton-orange-on-black">
+      <div class="max-w-[1440px] w-full h-full flex flex-row gap-10 items-center bg-brand py-4 header-x-padding">
+        <!-- logo -->
+        <div class="grid auto-cols-max grid-flow-col flex-grow gap-4 items-center">
+          <.link href="https://library.princeton.edu">
+            <div class="logo w-9 sm:hidden">
+              <img
+                src={~p"/images/local-svgs.svg"}
+                alt={gettext("Princeton University Library Logo")}
+              />
+            </div>
+            <div class="logo sm:w-32 md:w-40 hidden sm:flex">
+              <img src={~p"/images/pul-logo.svg"} alt={gettext("Princeton University Library Logo")} />
+            </div>
+          </.link>
+          <!-- title -->
+          <div class="h-full pl-4 border-white border-l-[1px] justify-self-start app_name">
+            <.link
+              navigate={~p"/"}
+              class="text-[24px] sm:inline-block tracking-widest font-semibold text-center"
+            >
+              {gettext("Digital Collections")}
+            </.link>
+          </div>
         </div>
-        <div class="logo flex-none sm:w-32 md:w-40 hidden sm:flex">
-          <img src={~p"/images/pul-logo.svg"} alt={gettext("Princeton University Library Logo")} />
-        </div>
-      </.link>
-      
-    <!-- title -->
-      <div class="app_name flex-1 w-auto text-center">
-        <.link
-          navigate={~p"/"}
-          class="text-lg sm:text-3xl md:text-4xl sm:inline-block uppercase tracking-widest font-extrabold text-center"
-        >
-          {gettext("Digital Collections")}
-        </.link>
-      </div>
-      
+        
     <!-- language -->
-      <nav
-        class="menu flex flex-none justify-end w-10 sm:w-32 md:w-40"
-        aria-label={gettext("Language menu")}
-      >
-        <div class="dropdown relative inline-block">
-          <button
-            id="dropdownButton"
-            name={gettext("Language")}
-            class="text-white hover:link-hover font-medium"
-            aria-haspopup="true"
-            aria-expanded="false"
-            phx-click={JS.toggle(to: "#dropdownMenu")}
-          >
-            <span class="hover:link-hover font-normal sm:font-medium text-sm sm:text-md cursor-pointer">
-              {gettext("Language")}&nbsp;<span class="font-normal">&gt;</span>
-            </span>
-          </button>
-          <ul
-            id="dropdownMenu"
-            phx-click-away={JS.hide(to: "#dropdownMenu")}
-            class="dropdown-menu aria-hidden hidden absolute left-auto right-0 list-none bg-white min-w-3xs py-2 px-0 mt-2 shadow-md rounded-md z-100"
-            role="menu"
-            aria-hidden="true"
-          >
-            <li
-              role="menuitem"
-              tabindex="-1"
-              class="p-2 hover:bg-stone-200 focus:bg-stone-200 cursor-pointer"
+        <nav
+          class="menu flex flex-grow justify-end w-10 sm:w-32 md:w-40"
+          aria-label={gettext("Language menu")}
+        >
+          <div class="dropdown relative inline-block">
+            <button
+              id="dropdownButton"
+              name={gettext("Language")}
+              class="text-white hover:link-hover font-medium"
+              aria-haspopup="true"
+              aria-expanded="false"
+              phx-click={JS.toggle(to: "#dropdownMenu")}
             >
-              <div phx-click={JS.dispatch("setLocale", detail: %{locale: "en"})}>English</div>
-            </li>
-            <li
-              role="menuitem"
-              tabindex="-1"
-              class="p-2 hover:bg-stone-200 focus:bg-stone-200 cursor-pointer"
+              <span class="hover:link-hover font-normal sm:font-medium text-sm sm:text-md cursor-pointer">
+                {gettext("Language")}&nbsp;<span class="font-normal">&gt;</span>
+              </span>
+            </button>
+            <ul
+              id="dropdownMenu"
+              phx-click-away={JS.hide(to: "#dropdownMenu")}
+              class="dropdown-menu aria-hidden hidden absolute left-auto right-0 list-none bg-white min-w-3xs py-2 px-0 mt-2 shadow-md rounded-md z-100"
+              role="menu"
+              aria-hidden="true"
             >
-              <div phx-click={JS.dispatch("setLocale", detail: %{locale: "es"})}>Español</div>
-            </li>
-          </ul>
-        </div>
-      </nav>
+              <li
+                role="menuitem"
+                tabindex="-1"
+                class="p-2 hover:bg-stone-200 focus:bg-stone-200 cursor-pointer"
+              >
+                <div phx-click={JS.dispatch("setLocale", detail: %{locale: "en"})}>English</div>
+              </li>
+              <li
+                role="menuitem"
+                tabindex="-1"
+                class="p-2 hover:bg-stone-200 focus:bg-stone-200 cursor-pointer"
+              >
+                <div phx-click={JS.dispatch("setLocale", detail: %{locale: "es"})}>Español</div>
+              </li>
+            </ul>
+          </div>
+        </nav>
+      </div>
     </header>
     """
   end


### PR DESCRIPTION
I thought since we've got this black header, we may as well see what it
looks like when it's closer to our other experiences.


<img width="485" height="904" alt="Screen Shot 2025-08-29 at 3 55 22 PM" src="https://github.com/user-attachments/assets/ce8c0250-8376-49e7-a87c-28b4ba62e199" />

<img width="1897" height="803" alt="Screen Shot 2025-08-29 at 3 55 15 PM" src="https://github.com/user-attachments/assets/63b8c3a3-cbe2-42f6-a020-8ba5c4b379b3" />

**Current Experience**
<img width="1647" height="748" alt="Screen Shot 2025-08-29 at 3 56 15 PM" src="https://github.com/user-attachments/assets/d18b4d2f-350a-41ac-9380-f381233fb9e7" />

