### PR TITLE
Create a Modal CoreComponent

### DIFF
--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -29,6 +29,9 @@ Hooks.Dialog = {
     this.el.addEventListener('dpulc:showDialog', (e) =>  {
       this.el.showModal()
     })
+    this.el.addEventListener('close', (e) => {
+      this.js().exec(this.el.getAttribute('phx-close'))
+    })
   }
 }
 

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -30,6 +30,8 @@ Hooks.Dialog = {
       this.el.showModal()
     })
     this.el.addEventListener('close', (e) => {
+      // If the user hits "escape" then JS closes the modal, we still want
+      // after-close to render.
       this.js().exec(this.el.getAttribute('phx-after-close'))
     })
   }

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -30,7 +30,7 @@ Hooks.Dialog = {
       this.el.showModal()
     })
     this.el.addEventListener('close', (e) => {
-      this.js().exec(this.el.getAttribute('phx-close'))
+      this.js().exec(this.el.getAttribute('phx-after-close'))
     })
   }
 }

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -32,7 +32,7 @@ Hooks.Dialog = {
     this.el.addEventListener('close', (e) => {
       // If the user hits "escape" then JS closes the modal, we still want
       // after-close to render.
-      this.js().exec(this.el.getAttribute('phx-after-close'))
+      this.js().exec(this.el.getAttribute('dcjs-after-close'))
     })
   }
 }

--- a/lib/dpul_collections_web/components/core_components.ex
+++ b/lib/dpul_collections_web/components/core_components.ex
@@ -199,4 +199,28 @@ defmodule DpulCollectionsWeb.CoreComponents do
     />
     """
   end
+
+  attr :id, :string, required: true
+  attr :afterClose, :any, required: false, default: %JS{}
+
+  slot :inner_block, doc: "the modal content"
+
+  def modal(assigns) do
+    ~H"""
+    <dialog
+      id={@id}
+      phx-hook="Dialog"
+      phx-open={JS.dispatch("dpulc:showDialog")}
+      phx-close={JS.dispatch("dpulc:closeDialog") |> JS.exec("phx-after-close")}
+      phx-after-close={@afterClose}
+      phx-remove={JS.exec("phx-close")}
+      closedBy="any"
+      class="modal max-w-2xl backdrop:bg-black/50 open:fixed open:top-[50%] open:left-[50%] open:-translate-x-[50%] open:-translate-y-[50%] fixed bg-white rounded-lg shadow-sm text-dark-text"
+    >
+      <div class="w-full max-w-2xl bg-white shadow-lg rounded-lg p-8 relative">
+        {render_slot(@inner_block)}
+      </div>
+    </dialog>
+    """
+  end
 end

--- a/lib/dpul_collections_web/components/core_components.ex
+++ b/lib/dpul_collections_web/components/core_components.ex
@@ -211,10 +211,10 @@ defmodule DpulCollectionsWeb.CoreComponents do
     <dialog
       id={@id}
       phx-hook="Dialog"
-      phx-open={JS.dispatch("dpulc:showDialog")}
-      phx-close={JS.dispatch("dpulc:closeDialog") |> JS.exec("phx-after-close")}
-      phx-after-close={@afterClose}
-      phx-remove={JS.exec("phx-close")}
+      dcjs-open={JS.dispatch("dpulc:showDialog")}
+      dcjs-close={JS.dispatch("dpulc:closeDialog") |> JS.exec("phx-after-close")}
+      dcjs-after-close={@afterClose}
+      phx-remove={JS.exec("dcjs-close")}
       aria-labelledby={"#{@id}-label"}
       closedBy="any"
       class="modal max-w-2xl backdrop:bg-black/50 open:fixed open:top-[50%] open:left-[50%] open:-translate-x-[50%] open:-translate-y-[50%] fixed bg-white rounded-lg shadow-sm text-dark-text"
@@ -228,7 +228,7 @@ defmodule DpulCollectionsWeb.CoreComponents do
           <button
             type="button"
             class="cursor-pointer"
-            phx-click={JS.exec("phx-close", to: {:closest, "dialog"})}
+            phx-click={JS.exec("dcjs-close", to: {:closest, "dialog"})}
           >
             <.icon name="hero-x-mark" />
             <span class="sr-only">{gettext("Close modal")}</span>

--- a/lib/dpul_collections_web/components/core_components.ex
+++ b/lib/dpul_collections_web/components/core_components.ex
@@ -202,6 +202,7 @@ defmodule DpulCollectionsWeb.CoreComponents do
 
   attr :id, :string, required: true
   attr :afterClose, :any, required: false, default: %JS{}
+  attr :label, :string, required: true
 
   slot :inner_block, doc: "the modal content"
 
@@ -214,10 +215,25 @@ defmodule DpulCollectionsWeb.CoreComponents do
       phx-close={JS.dispatch("dpulc:closeDialog") |> JS.exec("phx-after-close")}
       phx-after-close={@afterClose}
       phx-remove={JS.exec("phx-close")}
+      aria-labelledby={"#{@id}-label"}
       closedBy="any"
       class="modal max-w-2xl backdrop:bg-black/50 open:fixed open:top-[50%] open:left-[50%] open:-translate-x-[50%] open:-translate-y-[50%] fixed bg-white rounded-lg shadow-sm text-dark-text"
     >
       <div class="w-full max-w-2xl bg-white shadow-lg rounded-lg p-8 relative">
+        <!-- Modal header -->
+        <div class="flex items-center justify-between border-b border-gray-300 pb-3">
+          <h2 id={"#{@id}-label"} class="text-xl font-semibold">
+            {@label}
+          </h2>
+          <button
+            type="button"
+            class="cursor-pointer"
+            phx-click={JS.exec("phx-close", to: {:closest, "dialog"})}
+          >
+            <.icon name="hero-x-mark" />
+            <span class="sr-only">{gettext("Close modal")}</span>
+          </button>
+        </div>
         {render_slot(@inner_block)}
       </div>
     </dialog>

--- a/lib/dpul_collections_web/content_warnings.ex
+++ b/lib/dpul_collections_web/content_warnings.ex
@@ -61,38 +61,8 @@ defmodule DpulCollectionsWeb.ContentWarnings do
   end
 
   def content_modal(assigns) do
-    # aria-labelledby={"show-image-modal-#{@item_id}-title"}
     ~H"""
-    <.modal id={"show-image-banner-#{@item_id}-dialog"}>
-      <!-- Modal header -->
-      <div class="flex items-center justify-between p-6 pb-0 rounded-t">
-        <h2 id={"show-image-modal-#{@item_id}-title"} class="text-3xl font-semibold">
-          Content Warning
-        </h2>
-        <button
-          id={"show-image-banner-close-button-#{@item_id}"}
-          type="button"
-          class="bg-transparent hover:bg-gray-200 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white"
-          phx-click={JS.exec("phx-close", to: {:closest, "dialog"})}
-        >
-          <svg
-            class="w-3 h-3"
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 14 14"
-          >
-            <path
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"
-            />
-          </svg>
-          <span class="sr-only">{gettext("Close modal")}</span>
-        </button>
-      </div>
+    <.modal id={"show-image-banner-#{@item_id}-dialog"} label="Content Warning">
       <.content_warning_body {assigns} />
     </.modal>
     """

--- a/lib/dpul_collections_web/content_warnings.ex
+++ b/lib/dpul_collections_web/content_warnings.ex
@@ -56,23 +56,14 @@ defmodule DpulCollectionsWeb.ContentWarnings do
         </span>
       </.link>
     </div>
-    <.modal {assigns} />
+    <.content_modal {assigns} />
     """
   end
 
-  def modal(assigns) do
+  def content_modal(assigns) do
+    # aria-labelledby={"show-image-modal-#{@item_id}-title"}
     ~H"""
-    <!-- Modal content -->
-    <dialog
-      id={"show-image-banner-#{@item_id}-dialog"}
-      class="modal max-w-2xl backdrop:bg-black/50 open:top-[50%] open:left-[50%] open:-translate-x-50 open:-translate-y-50 fixed bg-white rounded-lg shadow-sm text-dark-text"
-      aria-labelledby={"show-image-modal-#{@item_id}-title"}
-      closedBy="any"
-      phx-open={JS.dispatch("dpulc:showDialog")}
-      phx-close={JS.dispatch("dpulc:closeDialog")}
-      phx-remove={JS.exec("phx-close")}
-      phx-hook="Dialog"
-    >
+    <.modal id={"show-image-banner-#{@item_id}-dialog"}>
       <!-- Modal header -->
       <div class="flex items-center justify-between p-6 pb-0 rounded-t">
         <h2 id={"show-image-modal-#{@item_id}-title"} class="text-3xl font-semibold">
@@ -103,7 +94,7 @@ defmodule DpulCollectionsWeb.ContentWarnings do
         </button>
       </div>
       <.content_warning_body {assigns} />
-    </dialog>
+    </.modal>
     """
   end
 

--- a/lib/dpul_collections_web/content_warnings.ex
+++ b/lib/dpul_collections_web/content_warnings.ex
@@ -46,7 +46,7 @@ defmodule DpulCollectionsWeb.ContentWarnings do
       <.link
         id={"open-show-image-banner-#{@item_id}"}
         class="flex gap-2 align-center text-rust"
-        phx-click={JS.exec("phx-open", to: "#show-image-banner-#{@item_id}-dialog")}
+        phx-click={JS.exec("dcjs-open", to: "#show-image-banner-#{@item_id}-dialog")}
       >
         <span class="flex-none">
           <.icon name="hero-eye-slash" class="h-5 w-5 icon mb-[2px]" />

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -630,13 +630,7 @@ defmodule DpulCollectionsWeb.ItemLive do
 
   def share_modal(assigns) do
     ~H"""
-    <.modal id={@id} afterClose={JS.add_class("dismissable", to: "#viewer-pane")}>
-      <div class="flex items-center pb-3 border-b border-gray-300">
-        <h3 class="text-xl font-semibold flex-1 text-slate-900">{@heading}</h3>
-        <button aria-label="close" phx-click={hide_modal(@id)} class="cursor-pointer">
-          <.icon name="hero-x-mark" />
-        </button>
-      </div>
+    <.modal id={@id} label={@heading} afterClose={JS.add_class("dismissable", to: "#viewer-pane")}>
       <div class="mt-4">
         <.copy_element value={"#{DpulCollectionsWeb.Endpoint.url()}#{@path}"} id={"#{@id}-value"} />
       </div>

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -630,27 +630,17 @@ defmodule DpulCollectionsWeb.ItemLive do
 
   def share_modal(assigns) do
     ~H"""
-    <dialog
-      id={@id}
-      phx-hook="Dialog"
-      phx-open={JS.dispatch("dpulc:showDialog")}
-      phx-close={JS.dispatch("dpulc:closeDialog") |> JS.add_class("dismissable", to: "#viewer-pane")}
-      phx-remove={JS.exec("phx-close")}
-      closedBy="any"
-      class="modal max-w-2xl backdrop:bg-black/50 open:fixed open:top-[50%] open:left-[50%] open:-translate-x-[50%] open:-translate-y-[50%] fixed bg-white rounded-lg shadow-sm text-dark-text"
-    >
-      <div class="w-full max-w-2xl bg-white shadow-lg rounded-lg p-8 relative">
-        <div class="flex items-center pb-3 border-b border-gray-300">
-          <h3 class="text-xl font-semibold flex-1 text-slate-900">{@heading}</h3>
-          <button aria-label="close" phx-click={hide_modal(@id)} class="cursor-pointer">
-            <.icon name="hero-x-mark" />
-          </button>
-        </div>
-        <div class="mt-4">
-          <.copy_element value={"#{DpulCollectionsWeb.Endpoint.url()}#{@path}"} id={"#{@id}-value"} />
-        </div>
+    <.modal id={@id} afterClose={JS.add_class("dismissable", to: "#viewer-pane")}>
+      <div class="flex items-center pb-3 border-b border-gray-300">
+        <h3 class="text-xl font-semibold flex-1 text-slate-900">{@heading}</h3>
+        <button aria-label="close" phx-click={hide_modal(@id)} class="cursor-pointer">
+          <.icon name="hero-x-mark" />
+        </button>
       </div>
-    </dialog>
+      <div class="mt-4">
+        <.copy_element value={"#{DpulCollectionsWeb.Endpoint.url()}#{@path}"} id={"#{@id}-value"} />
+      </div>
+    </.modal>
     """
   end
 

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -393,7 +393,7 @@ defmodule DpulCollectionsWeb.ItemLive do
         <.action_icon
           icon="hero-share"
           variant="item-action-icon"
-          phx-click={JS.show(to: "#share-modal")}
+          phx-click={JS.exec("phx-open", to: "#share-modal")}
         >
           {gettext("Share")}
         </.action_icon>
@@ -613,16 +613,15 @@ defmodule DpulCollectionsWeb.ItemLive do
   def show_viewer_share_modal(js \\ %JS{}) do
     js
     |> JS.remove_class("dismissable", to: "#viewer-pane")
-    |> JS.show(to: "#viewer-share-modal")
+    |> JS.exec("phx-open", to: "#viewer-share-modal")
   end
 
   # When we hide the modal we have to re-set the copy button and make "Escape"
   # work again for dismissing the viewer pane.
   def hide_modal(id, js \\ %JS{}) do
     js
-    |> JS.hide(to: "##{id}")
+    |> JS.exec("phx-close", to: "##{id}")
     |> JS.remove_class("bg-accent", to: "##{id}-value-copy")
-    |> JS.add_class("dismissable", to: "#viewer-pane")
   end
 
   attr :id, :string, required: true
@@ -631,24 +630,27 @@ defmodule DpulCollectionsWeb.ItemLive do
 
   def share_modal(assigns) do
     ~H"""
-    <div id={@id} class="hidden" phx-window-keydown={hide_modal(@id)} phx-key="escape">
-      <div class="fixed inset-0 p-4 flex flex-wrap justify-center items-center w-full h-full z-[1000] before:fixed before:inset-0 before:w-full before:h-full before:bg-[rgba(0,0,0,0.5)] overflow-auto">
-        <div
-          class="w-full max-w-2xl bg-white shadow-lg rounded-lg p-8 relative"
-          phx-click-away={hide_modal(@id)}
-        >
-          <div class="flex items-center pb-3 border-b border-gray-300">
-            <h3 class="text-xl font-semibold flex-1 text-slate-900">{@heading}</h3>
-            <button aria-label="close" phx-click={hide_modal(@id)} class="cursor-pointer">
-              <.icon name="hero-x-mark" />
-            </button>
-          </div>
-          <div class="mt-4">
-            <.copy_element value={"#{DpulCollectionsWeb.Endpoint.url()}#{@path}"} id={"#{@id}-value"} />
-          </div>
+    <dialog
+      id={@id}
+      phx-hook="Dialog"
+      phx-open={JS.dispatch("dpulc:showDialog")}
+      phx-close={JS.dispatch("dpulc:closeDialog") |> JS.add_class("dismissable", to: "#viewer-pane")}
+      phx-remove={JS.exec("phx-close")}
+      closedBy="any"
+      class="modal max-w-2xl backdrop:bg-black/50 open:fixed open:top-[50%] open:left-[50%] open:-translate-x-[50%] open:-translate-y-[50%] fixed bg-white rounded-lg shadow-sm text-dark-text"
+    >
+      <div class="w-full max-w-2xl bg-white shadow-lg rounded-lg p-8 relative">
+        <div class="flex items-center pb-3 border-b border-gray-300">
+          <h3 class="text-xl font-semibold flex-1 text-slate-900">{@heading}</h3>
+          <button aria-label="close" phx-click={hide_modal(@id)} class="cursor-pointer">
+            <.icon name="hero-x-mark" />
+          </button>
+        </div>
+        <div class="mt-4">
+          <.copy_element value={"#{DpulCollectionsWeb.Endpoint.url()}#{@path}"} id={"#{@id}-value"} />
         </div>
       </div>
-    </div>
+    </dialog>
     """
   end
 

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -616,21 +616,22 @@ defmodule DpulCollectionsWeb.ItemLive do
     |> JS.exec("phx-open", to: "#viewer-share-modal")
   end
 
-  # When we hide the modal we have to re-set the copy button and make "Escape"
-  # work again for dismissing the viewer pane.
-  def hide_modal(id, js \\ %JS{}) do
-    js
-    |> JS.exec("phx-close", to: "##{id}")
-    |> JS.remove_class("bg-accent", to: "##{id}-value-copy")
-  end
-
   attr :id, :string, required: true
   attr :heading, :string, required: true
   attr :path, :string, required: true
 
   def share_modal(assigns) do
     ~H"""
-    <.modal id={@id} label={@heading} afterClose={JS.add_class("dismissable", to: "#viewer-pane")}>
+    <.modal
+      id={@id}
+      label={@heading}
+      afterClose={
+        # When we hide the modal we have to re-set the copy button and make "Escape"
+        # work again for dismissing the viewer pane.
+        JS.add_class("dismissable", to: "#viewer-pane")
+        |> JS.remove_class("bg-accent", to: "##{@id}-value-copy")
+      }
+    >
       <div class="mt-4">
         <.copy_element value={"#{DpulCollectionsWeb.Endpoint.url()}#{@path}"} id={"#{@id}-value"} />
       </div>

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -393,7 +393,7 @@ defmodule DpulCollectionsWeb.ItemLive do
         <.action_icon
           icon="hero-share"
           variant="item-action-icon"
-          phx-click={JS.exec("phx-open", to: "#share-modal")}
+          phx-click={JS.exec("dcjs-open", to: "#share-modal")}
         >
           {gettext("Share")}
         </.action_icon>
@@ -613,7 +613,7 @@ defmodule DpulCollectionsWeb.ItemLive do
   def show_viewer_share_modal(js \\ %JS{}) do
     js
     |> JS.remove_class("dismissable", to: "#viewer-pane")
-    |> JS.exec("phx-open", to: "#viewer-share-modal")
+    |> JS.exec("dcjs-open", to: "#viewer-share-modal")
   end
 
   attr :id, :string, required: true

--- a/test/dpul_collections_web/features/item_test.exs
+++ b/test/dpul_collections_web/features/item_test.exs
@@ -79,9 +79,10 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
         |> click_button("Share")
       end)
       |> assert_has("#viewer-share-modal h2", text: "Share this image")
+      |> refute_has("#viewer-pane.dismissable")
       |> Playwright.press("#viewer-share-modal", "Escape")
       |> refute_has("#viewer-share-modal h2")
-      |> assert_has("#viewer-pane")
+      |> assert_has("#viewer-pane.dismissable")
       |> assert_path("/i/document1/item/1/viewer/1")
       # can still also close the viewer pane
       |> Playwright.press("#viewer-pane", "Escape")

--- a/test/dpul_collections_web/features/item_test.exs
+++ b/test/dpul_collections_web/features/item_test.exs
@@ -31,7 +31,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
       |> refute_has("#share-modal")
       # opens the modal
       |> click_button("Share")
-      |> assert_has("#share-modal h3", text: "Share this item")
+      |> assert_has("#share-modal h2", text: "Share this item")
       |> click_button("Copy")
       # changes the button text
       |> assert_has("#share-modal button", text: "Copied")
@@ -65,7 +65,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
         |> click_button("Share")
       end)
       # opens the modal
-      |> assert_has("#viewer-share-modal h3", text: "Share this image")
+      |> assert_has("#viewer-share-modal h2", text: "Share this image")
       |> assert_has("#viewer-share-modal-value",
         text: "http://localhost:4002/i/document1/item/1/viewer/1"
       )
@@ -78,9 +78,9 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
         session
         |> click_button("Share")
       end)
-      |> assert_has("#viewer-share-modal h3", text: "Share this image")
+      |> assert_has("#viewer-share-modal h2", text: "Share this image")
       |> Playwright.press("#viewer-share-modal", "Escape")
-      |> refute_has("#viewer-share-modal h3")
+      |> refute_has("#viewer-share-modal h2")
       |> assert_has("#viewer-pane")
       |> assert_path("/i/document1/item/1/viewer/1")
       # can still also close the viewer pane

--- a/test/dpul_collections_web/features/item_test.exs
+++ b/test/dpul_collections_web/features/item_test.exs
@@ -73,6 +73,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
       |> assert_has("button#viewer-share-modal-value-copy", text: "Copied")
       |> click_button("close")
       |> refute_has("#viewer-share-modal")
+      |> refute_has("#viewer-modal.dismissable")
       # Escape closes the modal
       |> within("#viewer-header", fn session ->
         session


### PR DESCRIPTION
This makes the Share and Content Warning modals use the same code and hooks, which improves the accessibility of the Share modal by making background content inert.

Work towards #490 