### PR TITLE
Add an empty checklist item in acceptance criteria

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -14,10 +14,11 @@ assignees: ''
 ### Acceptance Criteria
 
 This section can be completed by the DLS team. Some requirements to consider
-including:
+include:
 
 - [ ] The UI implemented for this issue meets accessibility requirements
 - [ ] New functionality is documented
+- [ ]
 
 
 ### First step


### PR DESCRIPTION
We often delete the suggested defaults, and it's awkward to delete those
but keep a check box. Adding a new empty check box should make that
simpler for a thing we do almost daily
