### PR TITLE
Decrease font sizes and y-padding in key areas

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -183,6 +183,14 @@
   @apply px-4 sm:px-8 lg:px-10;
 }
 
+@utility header-y-padding {
+  @apply py-4;
+}
+
+@utility heading-y-padding {
+  @apply py-3;
+}
+
 @utility header-s-padding {
   @apply ps-6 sm:ps-8 lg:ps-10;
 }
@@ -232,11 +240,11 @@
   }
 
   h1 {
-    @apply heading text-3xl;
+    @apply heading text-2xl;
   }
 
   h2 {
-    @apply text-2xl font-bold;
+    @apply text-xl font-bold;
   }
 
   p {

--- a/lib/dpul_collections_web/components/header_component.ex
+++ b/lib/dpul_collections_web/components/header_component.ex
@@ -6,7 +6,7 @@ defmodule DpulCollectionsWeb.HeaderComponent do
 
   def header(assigns) do
     ~H"""
-    <header class="flex flex-row gap-10 items-center bg-brand py-6 header-x-padding">
+    <header class="flex flex-row gap-10 items-center bg-brand header-y-padding header-x-padding">
       
     <!-- logo -->
       <.link href="https://library.princeton.edu">
@@ -19,10 +19,10 @@ defmodule DpulCollectionsWeb.HeaderComponent do
       </.link>
       
     <!-- title -->
-      <div class="app_name flex-1 w-auto text-center">
+      <div class="app_name flex-1 w-auto text-center px-2">
         <.link
           navigate={~p"/"}
-          class="text-lg sm:text-3xl md:text-4xl sm:inline-block uppercase tracking-widest font-extrabold text-center"
+          class="text-lg sm:text-xl md:text-2xl lg:text-3xl sm:inline-block uppercase tracking-widest font-bold text-center"
         >
           {gettext("Digital Collections")}
         </.link>

--- a/lib/dpul_collections_web/live/browse_live.ex
+++ b/lib/dpul_collections_web/live/browse_live.ex
@@ -73,8 +73,8 @@ defmodule DpulCollectionsWeb.BrowseLive do
     <Layouts.app flash={@flash}>
       <div id="browse" class="content-area">
         <h1 id="browse-header" class="mb-2">{gettext("Browse")}</h1>
-        <div class="mb-5 text-2xl w-full items-center">
-          <div :if={!@focused_item} class="text-2xl mb-5">
+        <div class="mb-5 text-lg w-full items-center">
+          <div :if={!@focused_item} class="mb-5">
             {gettext("Exploring a random set of items from our collections.")}
           </div>
           <h3 :if={@focused_item}>

--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -53,7 +53,7 @@ defmodule DpulCollectionsWeb.HomeLive do
                 )
                 |> Phoenix.HTML.raw()}
               </div>
-              <div class="content-area bg-primary text-light-text p-x-4 text-2xl">
+              <div class="content-area bg-primary text-light-text p-x-4 text-xl">
                 <.primary_button href={~p"/browse"}>
                   {gettext("Explore")}
                 </.primary_button>

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -237,7 +237,7 @@ defmodule DpulCollectionsWeb.ItemLive do
       phx-key="escape"
       phx-hook="ScrollTop"
     >
-      <div class="header-x-padding page-y-padding bg-accent flex flex-row">
+      <div class="header-x-padding heading-y-padding bg-accent flex flex-row">
         <h1 class="uppercase text-light-text flex-auto">{gettext("Metadata")}</h1>
         <.link
           aria-label={gettext("close")}
@@ -307,7 +307,7 @@ defmodule DpulCollectionsWeb.ItemLive do
       phx-key="escape"
       phx-hook="ScrollTop"
     >
-      <div id="viewer-header" class="header-x-padding page-y-padding bg-accent flex flex-row">
+      <div id="viewer-header" class="header-x-padding heading-y-padding bg-accent flex flex-row">
         <div class="flex-auto flex flex-row">
           <h1 class="uppercase text-light-text flex-none">{gettext("Viewer")}</h1>
           <.action_icon


### PR DESCRIPTION
navigating the site with a smaller laptop screen, the things that really felt
too big were headers and headings, paragraph text, and browse and search titles

The facets were also very big, but they're about to get redone

design elements are still on the large side after these changes, but we wanted to make images quite central, and this should make a meaningful difference.

refs #487 