### PR TITLE
Add geographic subject to brief metadata area on item page

### DIFF
--- a/lib/dpul_collections/item.ex
+++ b/lib/dpul_collections/item.ex
@@ -55,6 +55,7 @@ defmodule DpulCollections.Item do
       {:publisher, gettext("Publisher")},
       {:language, gettext("Language")},
       {:geographic_origin, gettext("Geographic Origin")},
+      {:geo_subject, gettext("Geographic Subject")},
       {:subject, gettext("Subject")}
     ]
   end

--- a/test/dpul_collections_web/live/item_live_test.exs
+++ b/test/dpul_collections_web/live/item_live_test.exs
@@ -226,6 +226,12 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
              |> Floki.find(~s{.metadata *:fl-contains("geographic origin")})
              |> Enum.any?()
 
+      assert document |> Floki.find(~s{dt:fl-contains("Geographic Subject")}) |> Enum.any?()
+
+      assert document
+             |> Floki.find(~s{.metadata *:fl-contains("geo subject")})
+             |> Enum.any?()
+
       assert document |> Floki.find(~s{dt:fl-contains("Language")}) |> Enum.any?()
       assert document |> Floki.find(~s{.metadata *:fl-contains("language")}) |> Enum.any?()
       assert document |> Floki.find(~s{dt:fl-contains("Publisher")}) |> Enum.any?()


### PR DESCRIPTION
closes #728

<img width="835" height="516" alt="Screenshot 2025-09-04 at 4 13 47 PM" src="https://github.com/user-attachments/assets/4c08ddaa-b6ee-4486-9e53-9e011b217ef0" />
