### PR TITLE
Make the language nav accessible.

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -71,7 +71,7 @@
   @apply text-light-text;
 }
 
-.bg-brand #dropdownMenu{
+.bg-brand .dropdown-menu{
   @apply text-dark-text;
 }
 

--- a/lib/dpul_collections_web/components/header_component.ex
+++ b/lib/dpul_collections_web/components/header_component.ex
@@ -30,45 +30,47 @@ defmodule DpulCollectionsWeb.HeaderComponent do
       
     <!-- language -->
       <nav
+        id="language-nav"
         class="menu flex flex-none justify-end w-10 sm:w-32 md:w-40"
-        aria-label={gettext("Language menu")}
+        aria-label={gettext("Main Navigation")}
+        dcjs-toggle-menu={JS.toggle(to: {:inner, "ul[role='menu']"})}
+        dcjs-hide-menu={JS.hide(to: {:inner, "ul[role='menu']"})}
       >
-        <div class="dropdown relative inline-block">
-          <button
-            id="dropdownButton"
-            name={gettext("Language")}
-            class="text-white hover:link-hover font-medium"
-            aria-haspopup="true"
-            aria-expanded="false"
-            phx-click={JS.toggle(to: "#dropdownMenu")}
-          >
-            <span class="hover:link-hover font-normal sm:font-medium text-sm sm:text-md cursor-pointer">
-              {gettext("Language")}&nbsp;<span class="font-normal">&gt;</span>
-            </span>
-          </button>
-          <ul
-            id="dropdownMenu"
-            phx-click-away={JS.hide(to: "#dropdownMenu")}
-            class="dropdown-menu aria-hidden hidden absolute left-auto right-0 list-none bg-white min-w-3xs py-2 px-0 mt-2 shadow-md rounded-md z-100"
-            role="menu"
-            aria-hidden="true"
-          >
-            <li
-              role="menuitem"
-              tabindex="-1"
-              class="p-2 hover:bg-stone-200 focus:bg-stone-200 cursor-pointer"
+        <ul
+          class="dropdown relative inline-block"
+          dcjs-toggle-menu={JS.toggle(to: {:inner, "ul"})}
+          dcjs-hide-menu={JS.hide(to: {:inner, "ul"})}
+        >
+          <li>
+            <button
+              name={gettext("Language")}
+              class="text-white hover:link-hover font-medium"
+              aria-label={gettext("Language")}
+              aria-expanded="false"
+              aria-haspopup="true"
+              phx-click={
+                JS.toggle_attribute({"aria-expanded", "false", "true"})
+                |> JS.exec("dcjs-toggle-menu", to: {:closest, "ul"})
+              }
+              phx-click-away={
+                JS.set_attribute({"aria-expanded", "false"})
+                |> JS.exec("dcjs-hide-menu", to: {:closest, "ul"})
+              }
             >
-              <div phx-click={JS.dispatch("setLocale", detail: %{locale: "en"})}>English</div>
-            </li>
-            <li
-              role="menuitem"
-              tabindex="-1"
-              class="p-2 hover:bg-stone-200 focus:bg-stone-200 cursor-pointer"
-            >
-              <div phx-click={JS.dispatch("setLocale", detail: %{locale: "es"})}>Español</div>
-            </li>
-          </ul>
-        </div>
+              <span class="hover:link-hover font-normal sm:font-medium text-sm sm:text-md cursor-pointer">
+                {gettext("Language")}&nbsp;<span class="font-normal">&gt;</span>
+              </span>
+            </button>
+            <ul class="dropdown-menu hidden absolute left-auto right-0 list-none bg-white min-w-3xs py-2 px-0 mt-2 shadow-md rounded-md z-100">
+              <li class="p-2 hover:bg-stone-200 focus:bg-stone-200 cursor-pointer">
+                <.link phx-click={JS.dispatch("setLocale", detail: %{locale: "en"})}>English</.link>
+              </li>
+              <li class="p-2 hover:bg-stone-200 focus:bg-stone-200 cursor-pointer">
+                <.link phx-click={JS.dispatch("setLocale", detail: %{locale: "es"})}>Español</.link>
+              </li>
+            </ul>
+          </li>
+        </ul>
       </nav>
     </header>
     """

--- a/test/dpul_collections_web/features/locale_test.exs
+++ b/test/dpul_collections_web/features/locale_test.exs
@@ -12,11 +12,30 @@ defmodule DpulCollectionsWeb.Features.LocaleTest do
     |> visit("/")
     |> assert_has("a", text: "Explore")
     |> click_button("Language")
-    |> Playwright.click("//div[text()='Español']")
+    |> click_link("Español")
     |> assert_has("a", text: "Explorar")
     |> Playwright.type("input#q", " ")
     |> click_button("Buscar")
     |> assert_has("label", text: "filtrar por fecha:")
+  end
+
+  test "the language dropdown is accessible", %{conn: conn} do
+    conn
+    |> visit("/")
+    |> assert_has("#language-nav button[aria-expanded='false']")
+    |> refute_has("#language-nav li a")
+    |> click_button("Language")
+    |> assert_has("#language-nav button[aria-expanded='true']")
+    |> assert_has("#language-nav li a")
+    # Click away
+    |> Playwright.click("input")
+    |> refute_has("#language-nav li a")
+    |> assert_has("#language-nav button[aria-expanded='false']")
+    # Click twice
+    |> click_button("Language")
+    |> assert_has("#language-nav button[aria-expanded='true']")
+    |> click_button("Language")
+    |> assert_has("#language-nav button[aria-expanded='false']")
   end
 
   # Testing because these translations happen in a separate library and are not handled by Gettext
@@ -28,7 +47,7 @@ defmodule DpulCollectionsWeb.Features.LocaleTest do
     |> visit("/")
     |> assert_has("#browse-item-9", text: "Updated 3 months ago")
     |> click_button("Language")
-    |> Playwright.click("//div[text()='Español']")
+    |> click_link("Español")
     |> assert_has("#browse-item-9", text: "Actualizado hace 3 meses")
 
     Solr.delete_all(active_collection())


### PR DESCRIPTION
Does a few things:

1. Make the nav items tabbable.
1. Make screen reader read the items better.
1. Handle `aria-expanded`
1. Make the dropdown JS less dependant on IDs, so we can maybe extract a
   component later.

Related to #490