### PR TITLE
Make file count always cover the bottom right of the last visible thumb

### DIFF
--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -65,6 +65,19 @@ Hooks.ShowPageCount = {
       return true
     }
 
+    function getLastVisibleImg(container) {
+      const allImages = container.querySelectorAll('img')
+      let lastImg = null
+
+      allImages.forEach(el => {
+        if (!isElementHiddenByOverflow(el, container)) {
+          lastImg = el
+        }
+      })
+      console.log(lastImg)
+      return lastImg
+    }
+
     function isElementHiddenByOverflow(element, container) {
       const elementRect = element.getBoundingClientRect()
       const containerRect = container.getBoundingClientRect()
@@ -84,6 +97,9 @@ Hooks.ShowPageCount = {
     // Handle Resize
     this.handleResize = () => {
       if(showPageCount(containerEl, elFilecount) && fileCountLabelEl !== null){
+        let lastImg = getLastVisibleImg(containerEl)
+        console.log(lastImg)
+        lastImg.parentElement.append(fileCountLabelEl)
         fileCountLabelEl.style.display = "block"
       } else {
         fileCountLabelEl.style.display = "none"

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -233,7 +233,7 @@ defmodule DpulCollectionsWeb.SearchLive do
                 <div class="text-base">Origin</div>
               </div>
             </div>
-            <div class="small-thumbnails flex-none hidden sm:flex flex-row flex-wrap gap-5 max-h-[170px] max-w-[740px] justify-start relative overflow-hidden">
+            <div class="small-thumbnails hidden sm:flex flex-row flex-wrap gap-5 max-h-[170px] justify-start overflow-hidden">
               <.thumbs
                 :for={{thumb, thumb_num} <- thumbnail_service_urls(1, 4, @item)}
                 :if={@item.file_count > 1}
@@ -244,7 +244,7 @@ defmodule DpulCollectionsWeb.SearchLive do
               />
               <div
                 id={"filecount-#{@item.id}"}
-                class="hidden absolute diagonal-drop right-0 top-0 bg-background pr-4 py-2"
+                class="hidden absolute diagonal-rise right-0 bottom-0 bg-sage-100 pr-4 py-2"
               >
                 {@item.file_count} {gettext("Images")}
               </div>
@@ -306,18 +306,20 @@ defmodule DpulCollectionsWeb.SearchLive do
 
   def thumbs(assigns) do
     ~H"""
-    <img
-      class={[
-        "h-[170px] w-[170px] md:h-[170px] md:w-[170px] border border-solid border-gray-400",
-        Helpers.obfuscate_item?(assigns) && "obfuscate",
-        "thumbnail-#{@item.id}"
-      ]}
-      src={"#{@thumb}/square/170,170/0/default.jpg"}
-      alt={"image #{@thumb_num}"}
-      style="background-color: lightgray;"
-      width="170"
-      height="170"
-    />
+    <div class="relative">
+      <img
+        class={[
+          "h-[170px] w-[170px] md:h-[170px] md:w-[170px] border border-solid border-gray-400",
+          Helpers.obfuscate_item?(assigns) && "obfuscate",
+          "thumbnail-#{@item.id}"
+        ]}
+        src={"#{@thumb}/square/170,170/0/default.jpg"}
+        alt={"image #{@thumb_num}"}
+        style="background-color: lightgray;"
+        width="170"
+        height="170"
+      />
+    </div>
     """
   end
 

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -477,7 +477,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
              ]
 
       assert document
-             |> Floki.attribute("#item-1 .small-thumbnails > :first-child", "src") == [
+             |> Floki.attribute("#item-1 .small-thumbnails > :first-child > img", "src") == [
                "https://example.com/iiif/2/image2/square/170,170/0/default.jpg"
              ]
 
@@ -489,7 +489,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
              ]
 
       assert document
-             |> Floki.attribute("#item-2 .small-thumbnails > :first-child", "src") == [
+             |> Floki.attribute("#item-2 .small-thumbnails > :first-child > img", "src") == [
                "https://example.com/iiif/2/image1/square/170,170/0/default.jpg"
              ]
     end


### PR DESCRIPTION
followup-to #754

This makes the image count for the wide search results view look consistent with the one for the narrow view, and makes it always overlay the bottom of the last image so it's more grounded.

Note there is a visible transition after resizing when the count moves to another image (especially when making the screen wider)


Before:
<img width="1060" height="379" alt="Screenshot 2025-09-11 at 4 31 57 PM" src="https://github.com/user-attachments/assets/9cd0977a-4741-45ce-9617-69aa416c6bb9" />
<img width="415" height="552" alt="Screenshot 2025-09-11 at 4 22 13 PM" src="https://github.com/user-attachments/assets/53a3461b-8563-48e4-a66c-4a1c48f11b0c" />

After:
<img width="1327" height="396" alt="Screenshot 2025-09-11 at 4 21 34 PM" src="https://github.com/user-attachments/assets/6ec1ff5f-8921-4c43-9eaf-ea43e342be25" />
<img width="1164" height="380" alt="Screenshot 2025-09-11 at 4 21 44 PM" src="https://github.com/user-attachments/assets/fb89ae3c-f77c-4daa-9997-fcf7cd94041b" />

