### PR TITLE
Move title up higher on the search results card

### DIFF
--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -199,18 +199,20 @@ defmodule DpulCollectionsWeb.SearchLive do
             show_images={@show_images}
           />
           <div
-            class="metadata sm:col-span-2 flex flex-col gap-4 p-4"
+            class="metadata sm:col-span-2 flex flex-col gap-2 sm:gap-4 p-4"
             id={"item-metadata-#{@item.id}"}
           >
-            <div
-              data-field="genre"
-              class="flex-none text-gray-600 font-bold text-base uppercase sm:text-right"
-            >
-              {@item.genre}
+            <div class="flex flex-wrap flex-row sm:flex-row justify-between">
+              <h2 dir="auto w-full flex-grow sm:w-fit">
+                {@item.title}
+              </h2>
+              <div
+                data-field="genre"
+                class="w-full sm:w-fit flex-grow sm:flex-none text-gray-600 font-bold text-base uppercase sm:text-right"
+              >
+                {@item.genre}
+              </div>
             </div>
-            <h2 dir="auto">
-              {@item.title}
-            </h2>
             <div
               :if={@sort_by == :recently_updated && @item.updated_at}
               class="updated-at w-full"


### PR DESCRIPTION
Side effect: the genre is now below the title in mobile view, I couldn't
get it to work with flex-row-reverse

follow-up to #754

## before
<img width="1247" height="380" alt="Screenshot 2025-09-11 at 5 09 25 PM" src="https://github.com/user-attachments/assets/157573dd-0a53-442b-812d-feb234ca5017" />

<img width="459" height="550" alt="Screenshot 2025-09-11 at 5 06 00 PM" src="https://github.com/user-attachments/assets/23b84d85-8942-40a5-a6df-f17401d23400" />


## after
<img width="1241" height="375" alt="Screenshot 2025-09-11 at 5 03 00 PM" src="https://github.com/user-attachments/assets/fd7ca0bd-cc28-4590-bce6-687b1819e9c0" />
<img width="410" height="519" alt="Screenshot 2025-09-11 at 5 03 31 PM" src="https://github.com/user-attachments/assets/abce42a6-02b7-41b2-b9bc-aae3beaa837f" />
