### PR TITLE
Trying a couple small hydrator performance improvements

### DIFF
--- a/lib/dpul_collections/indexing_pipeline/database_producer.ex
+++ b/lib/dpul_collections/indexing_pipeline/database_producer.ex
@@ -98,7 +98,7 @@ defmodule DpulCollections.IndexingPipeline.DatabaseProducer do
   end
 
   defp calculate_stored_demand(total_demand, fulfilled_demand)
-       when total_demand == fulfilled_demand do
+       when total_demand <= fulfilled_demand do
     0
   end
 

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_producer_source.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_producer_source.ex
@@ -6,7 +6,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationProducerSource do
   end
 
   def get_cache_entries_since!(last_queried_marker, total_demand, _cache_version) do
-    IndexingPipeline.get_figgy_resources_since!(last_queried_marker, total_demand)
+    IndexingPipeline.get_figgy_resources_since!(last_queried_marker, max(total_demand, 500))
   end
 
   def init(_producer_state) do

--- a/test/dpul_collections/indexing_pipeline/figgy/hydration_consumer_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/hydration_consumer_test.exs
@@ -110,7 +110,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         transformed_messages
         |> Enum.map(&Map.get(&1, :batcher))
 
-      assert message_batchers == [:default, :noop, :noop, :noop, :noop, :noop]
+      assert message_batchers == [:default, :default, :default, :noop, :noop, :noop]
     end
 
     test "handle_batch/3 only processes deletion markers with related resources in the HydrationCache" do

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -183,7 +183,7 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
     assert hydration_entry.cache_order != hydration_entry_again.cache_order
 
     # Ensure metrics are being sent.
-    assert_receive {:hydrator_time_to_poll_hit, %{duration: _}}
+    assert_receive {:hydrator_time_to_poll_hit, %{duration: _}}, 500
     [hydration_metric_1 | _] = IndexMetricsTracker.processor_durations(HydrationProducerSource)
     assert hydration_metric_1.duration > 0
   end


### PR DESCRIPTION
I couldn't help myself looking at the Broadway dashboard and seeing resources get locked up in the batcher processor, the memory max out, and all the time get locked up querying for resources. I wanted to see if I could try this small improvement and see if it makes things better.

This prevents concurrent processors from waiting for records by always fetching at least 500 records in the producer, and prevents memory bloat by persisting records in `handle_message` to prevent sending large combined records to the batcher.