### PR TITLE
Improve transformation consumer the same way we did HydrationConsumer.

### DIFF
--- a/lib/dpul_collections/indexing_pipeline/figgy/transformation_producer_source.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/transformation_producer_source.ex
@@ -9,7 +9,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationProducerSource do
   def get_cache_entries_since!(last_queried_marker, total_demand, cache_version) do
     IndexingPipeline.get_hydration_cache_entries_since!(
       last_queried_marker,
-      total_demand,
+      max(total_demand, 500),
       cache_version
     )
   end

--- a/test/dpul_collections/indexing_pipeline/database_producer_test.exs
+++ b/test/dpul_collections/indexing_pipeline/database_producer_test.exs
@@ -8,7 +8,7 @@ defmodule DpulCollections.IndexingPipeline.DatabaseProducerTest do
 
   describe "DatabaseProducer" do
     test "handle_demand/2 with initial state and demand > 1 returns hydration cache entries" do
-      {marker1, marker2, _marker3} = FiggyTestFixtures.hydration_cache_markers()
+      {marker1, marker2, marker3} = FiggyTestFixtures.hydration_cache_markers()
 
       {:producer, initial_state} = DatabaseProducer.init({Figgy.TransformationProducerSource, 0})
 
@@ -20,13 +20,15 @@ defmodule DpulCollections.IndexingPipeline.DatabaseProducerTest do
           id
         end)
 
-      assert ids == [marker1.id, marker2.id]
+      # Transformation pulls up to 500 now and buffers.
+      assert ids == [marker1.id, marker2.id, marker3.id]
 
       assert %{
-               last_queried_marker: ^marker2,
+               last_queried_marker: ^marker3,
                pulled_records: [
                  ^marker1,
-                 ^marker2
+                 ^marker2,
+                 ^marker3
                ],
                acked_records: [],
                cache_version: 0,


### PR DESCRIPTION
Buffers 500 records at a time and doesn't pass them through to a batcher.

This brings transformation time from 16 minutes to 7.5.

Similar to #773
