### PR TITLE
Try a hydration optimization

### DIFF
--- a/lib/dpul_collections/indexing_pipeline.ex
+++ b/lib/dpul_collections/indexing_pipeline.ex
@@ -372,7 +372,7 @@ defmodule DpulCollections.IndexingPipeline do
       from r in Figgy.Resource,
         where:
           r.updated_at <= ^max_time and
-            r.internal_resource in @update_record_types and
+            (r.internal_resource == "EphemeraFolder" or r.internal_resource == "DeletionMarker") and
             (r.updated_at >= ^updated_at and (r.updated_at > ^updated_at or r.id > ^id)),
         select: %{
           struct(r, [:id, :updated_at, :internal_resource])
@@ -412,7 +412,9 @@ defmodule DpulCollections.IndexingPipeline do
   def get_figgy_resources_since!(nil, count, max_time) do
     query =
       from r in Figgy.Resource,
-        where: r.updated_at <= ^max_time and r.internal_resource in @update_record_types,
+        where:
+          r.updated_at <= ^max_time and
+            (r.internal_resource == "EphemeraFolder" or r.internal_resource == "DeletionMarker"),
         select: %{
           struct(r, [:id, :updated_at, :internal_resource])
           | visibility: fragment("metadata->'visibility'"),

--- a/lib/dpul_collections/indexing_pipeline.ex
+++ b/lib/dpul_collections/indexing_pipeline.ex
@@ -344,6 +344,7 @@ defmodule DpulCollections.IndexingPipeline do
   @decorate trace()
   def get_figgy_resources_since!(marker, count, max_time \\ nil)
 
+  @decorate trace()
   def get_figgy_resources_since!(%CacheEntryMarker{timestamp: updated_at, id: id}, count, nil) do
     query =
       from r in Figgy.Resource,
@@ -363,6 +364,7 @@ defmodule DpulCollections.IndexingPipeline do
     FiggyRepo.all(query)
   end
 
+  @decorate trace()
   def get_figgy_resources_since!(
         %CacheEntryMarker{timestamp: updated_at, id: id},
         count,
@@ -409,6 +411,7 @@ defmodule DpulCollections.IndexingPipeline do
     FiggyRepo.all(query)
   end
 
+  @decorate trace()
   def get_figgy_resources_since!(nil, count, max_time) do
     query =
       from r in Figgy.Resource,

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -6,6 +6,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   alias DpulCollections.IndexingPipeline
   alias DpulCollections.IndexingPipeline.Figgy
   alias DpulCollections.IndexingPipeline.DatabaseProducer
+  use __MODULE__.Constants
   use Broadway
 
   @type start_opts ::
@@ -87,7 +88,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     process(Figgy.Resource.populate_virtual(resource), cache_version)
   end
 
-  @related_record_types ["EphemeraProject", "EphemeraBox", "EphemeraTerm", "FileSet"]
   def process(resource, cache_version) do
     resource
     # Determine early on if we're deleting, skipping, or updating.

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer/constants.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer/constants.ex
@@ -1,0 +1,8 @@
+defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer.Constants do
+  defmacro __using__(_) do
+    quote do
+      @update_record_types ["EphemeraFolder", "DeletionMarker"]
+      @related_record_types ["EphemeraProject", "EphemeraBox", "EphemeraTerm", "FileSet"]
+    end
+  end
+end

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_producer_source.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_producer_source.ex
@@ -5,8 +5,18 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationProducerSource do
     "figgy_hydrator"
   end
 
-  def get_cache_entries_since!(last_queried_marker, total_demand, _cache_version) do
-    IndexingPipeline.get_figgy_resources_since!(last_queried_marker, max(total_demand, 500))
+  def get_cache_entries_since!(last_queried_marker, total_demand, cache_version, max_time \\ nil)
+
+  def get_cache_entries_since!(last_queried_marker, total_demand, _cache_version, max_time) do
+    IndexingPipeline.get_figgy_resources_since!(
+      last_queried_marker,
+      max(total_demand, 500),
+      max_time
+    )
+  end
+
+  def get_max_bound_timestamp do
+    IndexingPipeline.get_latest_figgy_resource_marker!().timestamp
   end
 
   def init(_producer_state) do

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_producer_source.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_producer_source.ex
@@ -10,7 +10,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationProducerSource do
   def get_cache_entries_since!(last_queried_marker, total_demand, _cache_version, max_time) do
     IndexingPipeline.get_figgy_resources_since!(
       last_queried_marker,
-      max(total_demand, 500),
+      max(total_demand, 100),
       max_time
     )
   end

--- a/lib/dpul_collections/indexing_pipeline/figgy/indexing_producer_source.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/indexing_producer_source.ex
@@ -6,13 +6,17 @@ defmodule DpulCollections.IndexingPipeline.Figgy.IndexingProducerSource do
     "figgy_indexer"
   end
 
-  def get_cache_entries_since!(last_queried_marker, total_demand, cache_version) do
+  def get_cache_entries_since!(last_queried_marker, total_demand, cache_version, max_time \\ nil)
+
+  def get_cache_entries_since!(last_queried_marker, total_demand, cache_version, _max_time) do
     IndexingPipeline.get_transformation_cache_entries_since!(
       last_queried_marker,
       total_demand,
       cache_version
     )
   end
+
+  def get_max_bound_timestamp, do: nil
 
   def init(%{cache_version: cache_version}) do
     # Listen for batch_processor stops, so we know when a transformer we care about

--- a/lib/dpul_collections/indexing_pipeline/figgy/transformation_producer_source.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/transformation_producer_source.ex
@@ -6,13 +6,17 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationProducerSource do
     "figgy_transformer"
   end
 
-  def get_cache_entries_since!(last_queried_marker, total_demand, cache_version) do
+  def get_cache_entries_since!(last_queried_marker, total_demand, cache_version, max_time \\ nil)
+
+  def get_cache_entries_since!(last_queried_marker, total_demand, cache_version, _max_time) do
     IndexingPipeline.get_hydration_cache_entries_since!(
       last_queried_marker,
       max(total_demand, 500),
       cache_version
     )
   end
+
+  def get_max_bound_timestamp, do: nil
 
   def init(%{cache_version: cache_version}) do
     # Listen for batch_processor stops, so we know when a hydrator we care about

--- a/lib/dpul_collections/prom_ex/plugins/indexing_pipeline.ex
+++ b/lib/dpul_collections/prom_ex/plugins/indexing_pipeline.ex
@@ -8,7 +8,7 @@ defmodule DpulCollections.PromEx.Plugins.IndexingPipeline do
     :"get_figgy_resource!/1",
     :"get_figgy_parents/1",
     :"get_figgy_resources/1",
-    :"get_figgy_resources_since!/2",
+    :"get_figgy_resources_since!/3",
     :"get_related_hydration_cache_record_ids!/3"
   ]
 


### PR DESCRIPTION
It'd need a bunch of cleaning up, but the idea is that on a fresh hydration we can safely ignore all resources we're not going to process at query time up until whatever timestamp was at the end when we started the hydration. Then we iterate over every one.

Might not be worth it, but I think it might put fresh rehydration in the minutes, which'd be cool to know about.

## Results

Brings it to 36 minutes, probably not worth the complexity.
