### PR TITLE
Fix positioning of action buttons.

### DIFF
--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -310,7 +310,7 @@ defmodule DpulCollectionsWeb.ItemLive do
       phx-hook="ScrollTop"
     >
       <div id="viewer-header" class="header-x-padding heading-y-padding bg-accent flex flex-row">
-        <div class="flex-auto flex flex-row">
+        <div class="flex-auto flex flex-row gap-4">
           <h1 class="uppercase text-light-text flex-none">{gettext("Viewer")}</h1>
           <.action_icon
             icon="hero-share"
@@ -383,7 +383,7 @@ defmodule DpulCollectionsWeb.ItemLive do
   def action_bar(assigns) do
     ~H"""
     <div {@rest}>
-      <div class="flex flex-row justify-left items-center">
+      <div class="flex flex-row justify-left items-center gap-4">
         <.action_icon
           :if={has_dimensions(@item)}
           icon="pepicons-pencil:ruler"
@@ -453,7 +453,7 @@ defmodule DpulCollectionsWeb.ItemLive do
 
   def action_icon(assigns = %{href: _href}) do
     ~H"""
-    <div class="text-sm mr-2 min-w-15 items-center">
+    <div class="flex text-sm items-center">
       <a
         href={@href}
         class="no-underline justify-center items-center flex flex-col text-center"
@@ -470,7 +470,7 @@ defmodule DpulCollectionsWeb.ItemLive do
 
   def action_icon(assigns) do
     ~H"""
-    <div class="text-sm mr-2 min-w-15 items-center">
+    <div class="flex text-sm items-center">
       <button class="justify-center items-center flex flex-col text-center" {@rest}>
         <div class={["cursor-pointer rounded-full flex justify-center items-center", @variant]}>
           <.icon class="w-full h-full" name={@icon} />


### PR DESCRIPTION
Closes #785
<img width="1369" height="725" alt="Screen Shot 2025-09-22 at 9 37 54 AM" src="https://github.com/user-attachments/assets/839bf633-d8ce-4c3d-99cb-741fec351748" />


This also fixes the viewer share button, which was looking like this:

<img width="305" height="126" alt="Screen Shot 2025-09-22 at 9 38 12 AM" src="https://github.com/user-attachments/assets/997c8076-a551-465f-ab02-613e8e72c602" />

Now it's like this:

<img width="1882" height="648" alt="Screen Shot 2025-09-22 at 9 38 38 AM" src="https://github.com/user-attachments/assets/a809606c-9749-433a-b8a6-11573026e840" />
