### PR TITLE
Fix race condition caused by non-serialized writes to markers

### DIFF
--- a/lib/dpul_collections/indexing_pipeline.ex
+++ b/lib/dpul_collections/indexing_pipeline.ex
@@ -77,16 +77,18 @@ defmodule DpulCollections.IndexingPipeline do
       )
       |> where([c], c.source_cache_order <= ^attrs.source_cache_order)
 
-    try do
-      %Figgy.HydrationCacheEntry{}
-      |> Figgy.HydrationCacheEntry.changeset(attrs)
-      |> Repo.insert(
-        on_conflict: conflict_query,
-        conflict_target: [:cache_version, :record_id]
-      )
-    rescue
-      Ecto.StaleEntryError -> {:ok, nil}
-    end
+    Repo.transact(fn ->
+      try do
+        %Figgy.HydrationCacheEntry{}
+        |> Figgy.HydrationCacheEntry.changeset(attrs)
+        |> Repo.insert(
+          on_conflict: conflict_query,
+          conflict_target: [:cache_version, :record_id]
+        )
+      rescue
+        Ecto.StaleEntryError -> {:ok, nil}
+      end
+    end)
   end
 
   @spec get_hydration_cache_entries_since!(
@@ -473,16 +475,18 @@ defmodule DpulCollections.IndexingPipeline do
       )
       |> where([c], c.source_cache_order <= ^attrs.source_cache_order)
 
-    try do
-      %Figgy.TransformationCacheEntry{}
-      |> Figgy.TransformationCacheEntry.changeset(attrs)
-      |> Repo.insert(
-        on_conflict: conflict_query,
-        conflict_target: [:cache_version, :record_id]
-      )
-    rescue
-      Ecto.StaleEntryError -> {:ok, nil}
-    end
+    Repo.transact(fn ->
+      try do
+        %Figgy.TransformationCacheEntry{}
+        |> Figgy.TransformationCacheEntry.changeset(attrs)
+        |> Repo.insert(
+          on_conflict: conflict_query,
+          conflict_target: [:cache_version, :record_id]
+        )
+      rescue
+        Ecto.StaleEntryError -> {:ok, nil}
+      end
+    end)
   end
 
   @doc """

--- a/lib/dpul_collections/indexing_pipeline/database_producer.ex
+++ b/lib/dpul_collections/indexing_pipeline/database_producer.ex
@@ -31,6 +31,12 @@ defmodule DpulCollections.IndexingPipeline.DatabaseProducer do
     # see https://www.erlang.org/doc/apps/erts/erlang.html#process_flag/2
     Process.flag(:trap_exit, true)
 
+    :telemetry.execute(
+      [:database_producer, :init],
+      %{},
+      %{}
+    )
+
     last_queried_marker =
       IndexingPipeline.get_processor_marker!(source_module.processor_marker_key(), cache_version)
 

--- a/lib/dpul_collections/repo.ex
+++ b/lib/dpul_collections/repo.ex
@@ -2,4 +2,19 @@ defmodule DpulCollections.Repo do
   use Ecto.Repo,
     otp_app: :dpul_collections,
     adapter: Ecto.Adapters.Postgres
+
+  def truncate_all() do
+    {:ok, %{rows: table_names}} =
+      __MODULE__.query(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name != 'schema_migrations'"
+      )
+
+    # Flatten the list of lists into a single list of table names
+    table_names = Enum.map(table_names, fn [table_name] -> table_name end)
+
+    # Construct and execute TRUNCATE statements for each table
+    Enum.each(table_names, fn table_name ->
+      __MODULE__.query!("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
+    end)
+  end
 end

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -61,7 +61,11 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
     children = [
       {Figgy.IndexingConsumer,
        cache_version: cache_version, batch_size: 50, solr_index: active_collection()},
-      {Figgy.TransformationConsumer, cache_version: cache_version, batch_size: 50},
+      # We need every transformation cache entry to trigger an index, so we can
+      # track when the acks are done - setting batch size to 1 achieves that.
+      # Otherwise, sometimes it handles two entries for the same ID at the same
+      # time, and the indexing consumer gets one less message.
+      {Figgy.TransformationConsumer, cache_version: cache_version, batch_size: 1},
       {Figgy.HydrationConsumer, cache_version: cache_version, batch_size: 50}
     ]
 

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -19,7 +19,9 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
 
     children = [
       {Figgy.TransformationConsumer, cache_version: cache_version, batch_size: 50},
-      {Figgy.HydrationConsumer, cache_version: cache_version, batch_size: 50}
+      {Figgy.HydrationConsumer, cache_version: cache_version, batch_size: 50},
+      {Figgy.IndexingConsumer,
+       cache_version: cache_version, batch_size: 50, solr_index: active_collection()}
     ]
 
     AckTracker.reset_count!(tracker_pid)
@@ -29,7 +31,7 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
     end)
 
     index_count =
-      FiggyTestSupport.ephemera_folder_count() + FiggyTestSupport.deletion_marker_count()
+      FiggyTestSupport.ephemera_folder_count()
 
     AckTracker.wait_for_indexed_count(index_count)
 

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -61,11 +61,7 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
     children = [
       {Figgy.IndexingConsumer,
        cache_version: cache_version, batch_size: 50, solr_index: active_collection()},
-      # We need every transformation cache entry to trigger an index, so we can
-      # track when the acks are done - setting batch size to 1 achieves that.
-      # Otherwise, sometimes it handles two entries for the same ID at the same
-      # time, and the indexing consumer gets one less message.
-      {Figgy.TransformationConsumer, cache_version: cache_version, batch_size: 1},
+      {Figgy.TransformationConsumer, cache_version: cache_version, batch_size: 50},
       {Figgy.HydrationConsumer, cache_version: cache_version, batch_size: 50}
     ]
 

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -19,10 +19,10 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
 
     children = [
       {Figgy.TransformationConsumer, cache_version: cache_version, batch_size: 50},
-      {Figgy.HydrationConsumer, cache_version: cache_version, batch_size: 50},
-      {Figgy.IndexingConsumer,
-       cache_version: cache_version, batch_size: 50, solr_index: active_collection()}
+      {Figgy.HydrationConsumer, cache_version: cache_version, batch_size: 50}
     ]
+
+    FiggyTestSupport.make_broadway_parallel()
 
     AckTracker.reset_count!(tracker_pid)
 
@@ -33,7 +33,7 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
     index_count =
       FiggyTestSupport.ephemera_folder_count()
 
-    AckTracker.wait_for_indexed_count(index_count)
+    AckTracker.wait_for_transformed_count(index_count)
 
     transformation_cache_entry_count = Repo.aggregate(Figgy.TransformationCacheEntry, :count)
     assert transformation_cache_entry_count == FiggyTestSupport.ephemera_folder_count()

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -30,10 +30,7 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
       start_supervised(child)
     end)
 
-    index_count =
-      FiggyTestSupport.ephemera_folder_count()
-
-    AckTracker.wait_for_transformed_count(index_count)
+    AckTracker.wait_for_pipeline_finished(tracker_pid)
 
     transformation_cache_entry_count = Repo.aggregate(Figgy.TransformationCacheEntry, :count)
     assert transformation_cache_entry_count == FiggyTestSupport.ephemera_folder_count()
@@ -90,15 +87,7 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
       start_supervised(child)
     end)
 
-    # Transformation cache processes 98 ephemera folders, 3 fake records we
-    # inserted into the hydration cache, then 3 real deletion markers.
-    # Indexing pipeline does 98 ephemera folders, 3 fake records we inserted
-    # into transformation cache, result of 3 fake records we put in hydration
-    # cache, then 3 real deletion markers.
-    index_count =
-      FiggyTestSupport.ephemera_folder_count() + 3 * FiggyTestSupport.deletion_marker_count()
-
-    AckTracker.wait_for_indexed_count(index_count)
+    AckTracker.wait_for_pipeline_finished(tracker_pid)
 
     # The hydrator pulled all ephemera folders, terms, deletion markers and
     # removed the hydration cache markers for the deletion marker deleted resource.
@@ -202,7 +191,7 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
 
     Figgy.HydrationConsumer.start_over!(cache_version)
 
-    AckTracker.wait_for_indexed_count(index_count)
+    AckTracker.wait_for_pipeline_finished(tracker_pid)
 
     hydration_entry_again =
       Repo.get_by(Figgy.HydrationCacheEntry, record_id: latest_document["id"])

--- a/test/support/ack_tracker.ex
+++ b/test/support/ack_tracker.ex
@@ -46,6 +46,7 @@ defmodule AckTracker do
       ) do
     state = state |> append_ack(metadata)
     send(pid, {:ack_status, state |> Map.delete(:pid)})
+
     {:noreply, state}
   end
 

--- a/test/support/ack_tracker.ex
+++ b/test/support/ack_tracker.ex
@@ -24,6 +24,13 @@ defmodule AckTracker do
     Solr.soft_commit()
   end
 
+  def wait_for_transformed_count(count) do
+    assert_receive(
+      {:ack_status, %{"figgy_transformer" => %{1 => %{acked_count: ^count}}}},
+      30_000
+    )
+  end
+
   def reset_count!(pid) do
     FiggyTestSupport.flush_messages()
     GenServer.call(pid, {:reset_count})

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -36,8 +36,19 @@ defmodule DpulCollections.DataCase do
   Sets up the sandbox based on the test tags.
   """
   def setup_sandbox(tags) do
-    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(DpulCollections.Repo, shared: not tags[:async])
-    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+    pid =
+      Ecto.Adapters.SQL.Sandbox.start_owner!(DpulCollections.Repo,
+        shared: not tags[:async],
+        sandbox: tags[:sandbox] != false
+      )
+
+    on_exit(fn ->
+      if tags[:sandbox] == false do
+        DpulCollections.Repo.truncate_all()
+      end
+
+      Ecto.Adapters.SQL.Sandbox.stop_owner(pid)
+    end)
   end
 
   @doc """

--- a/test/support/figgy_test_support.ex
+++ b/test/support/figgy_test_support.ex
@@ -204,5 +204,7 @@ defmodule FiggyTestSupport do
       end,
       %{}
     )
+
+    ExUnit.Callbacks.on_exit(fn -> :telemetry.detach({__MODULE__, :broadway_parallel}) end)
   end
 end

--- a/test/support/figgy_test_support.ex
+++ b/test/support/figgy_test_support.ex
@@ -164,4 +164,45 @@ defmodule FiggyTestSupport do
 
     continue || (:timer.sleep(100) && wait_for_indexed_count(count))
   end
+
+  # Makes every Broadway processor/batch processor check out its own independent
+  # connection to the database, which allows for race conditions to happen we
+  # can test for.
+  def make_broadway_parallel() do
+    events = [
+      [:broadway, :processor, :start],
+      [:broadway, :batch_processor, :start],
+      [:broadway, :processor, :stop],
+      [:broadway, :batch_processor, :stop],
+      [:database_producer, :init]
+    ]
+
+    # Make sure every processor and batch processor gets a unique connection to
+    # allow race conditions to happen.
+    :telemetry.attach_many(
+      {__MODULE__, :broadway_parallel},
+      events,
+      fn event, _, _, _ ->
+        case event do
+          [_, _, :start] ->
+            Ecto.Adapters.SQL.Sandbox.checkout(DpulCollections.Repo,
+              shared: false,
+              sandbox: false
+            )
+
+          [_, _, :stop] ->
+            Ecto.Adapters.SQL.Sandbox.checkin(DpulCollections.Repo)
+
+          [_, :init] ->
+            Ecto.Adapters.SQL.Sandbox.checkout(DpulCollections.Repo,
+              shared: false,
+              sandbox: false
+            )
+        end
+
+        :ok
+      end,
+      %{}
+    )
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
+DpulCollections.Repo.truncate_all()
 ExUnit.start(exclude: [:skip])
 Ecto.Adapters.SQL.Sandbox.mode(DpulCollections.Repo, :manual)
 


### PR DESCRIPTION
1. Adds a test.
    * It turns out the problem wasn't the transaction, it was that the Sandbox adapter uses a single database connection for the whole test. To get a race condition to happen, we have to check out multiple connections - one per processor/batch processor. We can do that similar to the Broadway documentation for Ecto, using telemetry to explicitly check out a fresh connection.
2. Adds an advisory lock per cache version to serialize writes