### PR TITLE
Fix flaky tests

### DIFF
--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -118,6 +118,8 @@ defmodule DpulCollections.Solr do
           Map.merge(
             search_state.filter,
             %{
+              # Similar adds a MoreLikeThis query to the query, to restrict to
+              # items like the given id.
               "similar" => id,
               "file_count" => %{"from" => 1}
             }
@@ -127,10 +129,6 @@ defmodule DpulCollections.Solr do
       |> Map.put(:extra_params, mm: 1)
 
     query(search_state, index)
-  end
-
-  def mlt_query(id) do
-    "{!mlt qf=genre_txt_sort,subject_txt_sort,geo_subject_txt_sort,geographic_origin_txt_sort,language_txt_sort,keywords_txt_sort,description_txtm mintf=1}#{id}"
   end
 
   def recently_updated(
@@ -181,7 +179,7 @@ defmodule DpulCollections.Solr do
   end
 
   def mlt_focus(%{filter: %{"similar" => id}}) do
-    mlt_query(id)
+    "{!mlt qf=genre_txt_sort,subject_txt_sort,geo_subject_txt_sort,geographic_origin_txt_sort,language_txt_sort,keywords_txt_sort,description_txtm mintf=1}#{id}"
   end
 
   def mlt_focus(_search_state) do

--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -121,7 +121,8 @@ defmodule DpulCollections.Solr do
               # Similar adds a MoreLikeThis query to the query, to restrict to
               # items like the given id.
               "similar" => id,
-              "file_count" => %{"from" => 1}
+              # No collections.
+              "resource_type" => "-collection"
             }
           ),
         "per_page" => "#{rows}"

--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -338,7 +338,7 @@ defmodule DpulCollections.Solr do
       json: %{delete: %{query: "*:*"}}
     )
 
-    commit(index)
+    soft_commit(index)
   end
 
   @spec delete_batch(list(), %Index{}) ::

--- a/lib/dpul_collections/solr/constants.ex
+++ b/lib/dpul_collections/solr/constants.ex
@@ -106,6 +106,11 @@ defmodule DpulCollections.Solr.Constants do
           solr_field: "featurable_b",
           label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Featured"),
           value_function: &Function.identity/1
+        },
+        "file_count" => %{
+          solr_field: "file_count_i",
+          label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "File Count"),
+          value_function: &Function.identity/1
         }
       }
 

--- a/lib/dpul_collections/solr/constants.ex
+++ b/lib/dpul_collections/solr/constants.ex
@@ -111,6 +111,11 @@ defmodule DpulCollections.Solr.Constants do
           solr_field: "resource_type_s",
           label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Type"),
           value_function: &Function.identity/1
+        },
+        "file_count" => %{
+          solr_field: "file_count_i",
+          label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "File Count"),
+          value_function: &Function.identity/1
         }
       }
 

--- a/lib/dpul_collections/solr/constants.ex
+++ b/lib/dpul_collections/solr/constants.ex
@@ -107,9 +107,9 @@ defmodule DpulCollections.Solr.Constants do
           label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Featured"),
           value_function: &Function.identity/1
         },
-        "file_count" => %{
-          solr_field: "file_count_i",
-          label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "File Count"),
+        "resource_type" => %{
+          solr_field: "resource_type_s",
+          label: Gettext.Macros.gettext_with_backend(DpulCollectionsWeb.Gettext, "Type"),
           value_function: &Function.identity/1
         }
       }

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -256,7 +256,7 @@ defmodule DpulCollectionsWeb.SearchLive do
       </div>
       <div class="grid-rows-2 bg-sage-100 grid sm:grid-rows-1 sm:grid-cols-4 gap-0">
         <.large_thumb
-          :if={@item.file_count}
+          :if={@item.file_count && length(@item.image_service_urls) > 0}
           thumb={elem(hd(thumbnail_service_urls(0, 1, @item)), 0)}
           thumb_num={0}
           item={@item}

--- a/test/dpul_collections/indexing_pipeline/coherence_test.exs
+++ b/test/dpul_collections/indexing_pipeline/coherence_test.exs
@@ -4,16 +4,6 @@ defmodule DpulCollections.IndexingPipeline.CoherenceTest do
   alias DpulCollections.IndexingPipeline
   alias DpulCollections.IndexingPipeline.Coherence
 
-  import SolrTestSupport
-
-  setup do
-    Solr.delete_all(active_collection())
-
-    on_exit(fn ->
-      Solr.delete_all(active_collection())
-    end)
-  end
-
   test "index_parity?/0 is false when the old index is fresher than the new index" do
     {marker1, marker2, _marker3} = FiggyTestFixtures.hydration_cache_markers(1)
     FiggyTestFixtures.hydration_cache_markers(2)
@@ -94,9 +84,9 @@ defmodule DpulCollections.IndexingPipeline.CoherenceTest do
     }
 
     Solr.add([doc, doc2], old_index)
-    Solr.commit(old_index)
+    Solr.soft_commit(old_index)
     Solr.add([doc], new_index)
-    Solr.commit(new_index)
+    Solr.soft_commit(new_index)
 
     assert Coherence.document_count_report() == [
              %{cache_version: 1, collection: "dpulc1", document_count: 2},

--- a/test/dpul_collections/indexing_pipeline/integration/figgy/hydration_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/figgy/hydration_integration_test.exs
@@ -48,7 +48,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationIntegrationTest do
     hydrator = start_producer()
 
     MockFiggyHydrationProducer.process(1)
-    assert_receive {:ack_done}
+    assert_receive {:ack_done}, 1_000
 
     cache_entry = IndexingPipeline.list_hydration_cache_entries() |> hd
     assert cache_entry.record_id == marker1.id
@@ -87,7 +87,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationIntegrationTest do
     hydrator = start_producer()
 
     MockFiggyHydrationProducer.process(1)
-    assert_receive {:ack_done}
+    assert_receive {:ack_done}, 1_000
 
     cache_entry = IndexingPipeline.list_hydration_cache_entries() |> hd
     assert cache_entry.record_id == marker1.id
@@ -108,7 +108,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationIntegrationTest do
     hydrator = start_producer(cache_version)
 
     MockFiggyHydrationProducer.process(1, cache_version)
-    assert_receive {:ack_done}
+    assert_receive {:ack_done}, 1_000
 
     cache_entry = IndexingPipeline.list_hydration_cache_entries() |> hd
     assert cache_entry.record_id == marker1.id
@@ -141,7 +141,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationIntegrationTest do
     # Process that past record.
     hydrator = start_producer()
     MockFiggyHydrationProducer.process(1)
-    assert_receive {:ack_done}
+    assert_receive {:ack_done}, 1_000
     hydrator |> Broadway.stop(:normal)
     # Ensure there's only one hydration cache entry.
     entries = IndexingPipeline.list_hydration_cache_entries()
@@ -166,7 +166,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationIntegrationTest do
     # Process that past record.
     hydrator = start_producer()
     MockFiggyHydrationProducer.process(1)
-    assert_receive {:ack_done}
+    assert_receive {:ack_done}, 1_000
     hydrator |> Broadway.stop(:normal)
     # Ensure there's only one hydration cache entry.
     entries = IndexingPipeline.list_hydration_cache_entries()
@@ -193,7 +193,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationIntegrationTest do
     hydrator = start_producer()
     # Make sure the first record that comes back is what we expect
     MockFiggyHydrationProducer.process(1)
-    assert_receive {:ack_done}
+    assert_receive {:ack_done}, 1_000
     cache_entry = IndexingPipeline.list_hydration_cache_entries() |> hd
     assert cache_entry.record_id == marker2.id
     assert cache_entry.cache_version == 0

--- a/test/dpul_collections/indexing_pipeline/integration/figgy/indexing_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/figgy/indexing_integration_test.exs
@@ -6,13 +6,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.IndexingIntegrationTest do
   alias DpulCollections.Solr
   alias DpulCollections.Solr.Index
 
-  import SolrTestSupport
-
-  setup do
-    Solr.delete_all(active_collection())
-    :ok
-  end
-
   def start_indexing_producer(cache_version \\ 0) do
     pid = self()
 
@@ -43,7 +36,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.IndexingIntegrationTest do
     MockFiggyIndexingProducer.process(1)
     assert_receive {:ack_done}, 500
 
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
     assert Solr.document_count() == 1
 
     indexer |> Broadway.stop(:normal)
@@ -87,7 +80,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.IndexingIntegrationTest do
     assert_receive {:ack_done}, 500
     indexer |> Broadway.stop(:normal)
     # Ensure there's only one solr document
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
     assert Solr.document_count() == 1
     # Ensure that entry has the new title
     doc = Solr.find_by_id(marker1.id)
@@ -109,7 +102,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.IndexingIntegrationTest do
     indexer = start_indexing_producer()
     MockFiggyIndexingProducer.process(1)
     assert_receive {:ack_done}, 500
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
     # Make sure the first record that comes back is what we expect
     doc = Solr.find_by_id(marker2.id)
     assert doc["title_ss"] == ["test title 2"]

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -57,6 +57,8 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
         nil
       )
 
+    on_exit(fn -> :telemetry.detach("hydration-full-run") end)
+
     AckTracker.reset_count!(tracker_pid)
 
     Enum.each(children, fn child ->

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -57,6 +57,8 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
         nil
       )
 
+    # When we run tests with --repeat-until-failure the above attachment fails
+    # on the second run if we haven't detached it.
     on_exit(fn -> :telemetry.detach("hydration-full-run") end)
 
     AckTracker.reset_count!(tracker_pid)

--- a/test/dpul_collections/solr/management_test.exs
+++ b/test/dpul_collections/solr/management_test.exs
@@ -1,13 +1,12 @@
 defmodule DpulCollections.Solr.ManagementTest do
   use DpulCollections.DataCase
-  alias DpulCollections.Solr
   alias DpulCollections.Solr.Index
   alias DpulCollections.Solr.Management
-  import SolrTestSupport
 
   setup do
-    Solr.delete_all(active_collection())
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
+    write_index = Index.write_indexes() |> hd
+    Management.delete_collection(%Index{write_index | collection: "new_index1"})
+    :ok
   end
 
   test "create a new collection, set alias, delete a collection" do

--- a/test/dpul_collections/solr/management_test.exs
+++ b/test/dpul_collections/solr/management_test.exs
@@ -5,6 +5,9 @@ defmodule DpulCollections.Solr.ManagementTest do
 
   setup do
     write_index = Index.write_indexes() |> hd
+    # If the test below crashes or is force killed `new_index1` might be sitting
+    # around, so delete it beforehand just in case so we have a fresh testing
+    # environment.
     Management.delete_collection(%Index{write_index | collection: "new_index1"})
     :ok
   end

--- a/test/dpul_collections/solr_test.exs
+++ b/test/dpul_collections/solr_test.exs
@@ -52,28 +52,32 @@ defmodule DpulCollections.SolrTest do
           "title_txtm" => ["test title 1"],
           "genre_txt_sort" => ["pamphlets"],
           "subject_txt_sort" => ["folk art", "museum exhibits"],
-          "ephemera_project_title_s" => "Latin American Ephemera"
+          "ephemera_project_title_s" => "Latin American Ephemera",
+          "file_count_i" => 1
         },
         %{
           "id" => "similar",
           "title_txtm" => ["similar item"],
           "genre_txt_sort" => ["pamphlets"],
           "subject_txt_sort" => ["folk art", "music"],
-          "ephemera_project_title_s" => "Latin American Ephemera"
+          "ephemera_project_title_s" => "Latin American Ephemera",
+          "file_count_i" => 1
         },
         %{
           "id" => "less-similar",
           "title_txtm" => ["item that's not as similar"],
           "genre_txt_sort" => ["pamphlets"],
           "subject_txt_sort" => ["education", "music"],
-          "ephemera_project_title_s" => "Latin American Ephemera"
+          "ephemera_project_title_s" => "Latin American Ephemera",
+          "file_count_i" => 1
         },
         %{
           "id" => "other-project",
           "title_txtm" => ["similar item"],
           "genre_txt_sort" => ["pamphlets"],
           "subject_txt_sort" => ["folk art", "music"],
-          "ephemera_project_title_s" => "South Asian Ephemera"
+          "ephemera_project_title_s" => "South Asian Ephemera",
+          "file_count_i" => 1
         }
       ]
 
@@ -97,28 +101,39 @@ defmodule DpulCollections.SolrTest do
           "title_txtm" => ["test title 1"],
           "genre_txt_sort" => ["pamphlets"],
           "subject_txt_sort" => ["folk art", "museum exhibits"],
-          "ephemera_project_title_s" => "Latin American Ephemera"
+          "ephemera_project_title_s" => "Latin American Ephemera",
+          "file_count_i" => 1
+        },
+        %{
+          "id" => "similar-project",
+          "title_txtm" => ["similar project"],
+          "resource_type_s" => "collection",
+          "genre_txt_sort" => ["pamphlets"],
+          "subject_txt_sort" => ["folk art", "museum exhibits"]
         },
         %{
           "id" => "similar",
           "title_txtm" => ["similar item"],
           "genre_txt_sort" => ["pamphlets"],
           "subject_txt_sort" => ["folk art", "music"],
-          "ephemera_project_title_s" => "Latin American Ephemera"
+          "ephemera_project_title_s" => "Latin American Ephemera",
+          "file_count_i" => 1
         },
         %{
           "id" => "less-similar",
           "title_txtm" => ["item that's not as similar"],
           "genre_txt_sort" => ["pamphlets"],
           "subject_txt_sort" => ["education", "music"],
-          "ephemera_project_title_s" => "Latin American Ephemera"
+          "ephemera_project_title_s" => "Latin American Ephemera",
+          "file_count_i" => 1
         },
         %{
           "id" => "other-project",
           "title_txtm" => ["similar item"],
           "genre_txt_sort" => ["pamphlets"],
           "subject_txt_sort" => ["folk art", "music"],
-          "ephemera_project_title_s" => "South Asian Ephemera"
+          "ephemera_project_title_s" => "South Asian Ephemera",
+          "file_count_i" => 1
         }
       ]
 

--- a/test/dpul_collections/solr_test.exs
+++ b/test/dpul_collections/solr_test.exs
@@ -3,13 +3,7 @@ defmodule DpulCollections.SolrTest do
   use DpulCollections.DataCase
   alias DpulCollections.Item
   alias DpulCollections.Solr
-  import SolrTestSupport
   import ExUnit.CaptureLog
-
-  setup do
-    Solr.delete_all(active_collection())
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
-  end
 
   test ".document_count/0" do
     assert Solr.document_count() == 0
@@ -24,7 +18,7 @@ defmodule DpulCollections.SolrTest do
     }
 
     Solr.add([doc], active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     assert Solr.find_by_id("3cb7627b-defc-401b-9959-42ebc4488f74")["title_txtm"] ==
              doc["title_txtm"]
@@ -39,7 +33,7 @@ defmodule DpulCollections.SolrTest do
     assert Solr.document_count() == 0
 
     Solr.add([doc], active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     assert Solr.document_count() == 1
   end
@@ -82,7 +76,7 @@ defmodule DpulCollections.SolrTest do
       ]
 
       Solr.add(docs, active_collection())
-      Solr.commit(active_collection())
+      Solr.soft_commit(active_collection())
 
       results =
         Solr.related_items(%Item{id: "reference", project: "Latin American Ephemera"}, %{
@@ -138,7 +132,7 @@ defmodule DpulCollections.SolrTest do
       ]
 
       Solr.add(docs, active_collection())
-      Solr.commit(active_collection())
+      Solr.soft_commit(active_collection())
 
       results =
         Solr.related_items(%Item{id: "reference", project: "Latin American Ephemera"}, %{
@@ -178,7 +172,7 @@ defmodule DpulCollections.SolrTest do
       }
 
       Solr.add([doc1, doc2, doc3], active_collection())
-      Solr.commit(active_collection())
+      Solr.soft_commit(active_collection())
 
       records =
         Solr.recently_updated(
@@ -215,7 +209,7 @@ defmodule DpulCollections.SolrTest do
       }
 
       Solr.add([doc1, doc2, doc3], active_collection())
-      Solr.commit(active_collection())
+      Solr.soft_commit(active_collection())
 
       records = Solr.recently_updated(1) |> Map.get("docs")
 
@@ -225,7 +219,7 @@ defmodule DpulCollections.SolrTest do
 
   test ".random/3 with two different seeds returns different results" do
     Solr.add(SolrTestSupport.mock_solr_documents(), active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     set1 = Solr.random(5, "100")
     set2 = Solr.random(5, "999")
@@ -234,7 +228,7 @@ defmodule DpulCollections.SolrTest do
 
   test ".random/3 with the same seed returns the same results" do
     Solr.add(SolrTestSupport.mock_solr_documents(), active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     set1 = Solr.random(5, "100")
     set2 = Solr.random(5, "100")
@@ -250,7 +244,7 @@ defmodule DpulCollections.SolrTest do
     assert Solr.latest_document() == nil
 
     Solr.add([doc], active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     assert Solr.latest_document()["id"] == doc["id"]
 
@@ -260,7 +254,7 @@ defmodule DpulCollections.SolrTest do
     }
 
     Solr.add([doc_2], active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     assert Solr.latest_document()["id"] == doc_2["id"]
   end
@@ -272,7 +266,7 @@ defmodule DpulCollections.SolrTest do
     }
 
     Solr.add([doc], active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
     assert Solr.document_count() == 1
 
     Solr.delete_all(active_collection())
@@ -291,7 +285,7 @@ defmodule DpulCollections.SolrTest do
     }
 
     Solr.add([doc], active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     assert Solr.find_by_id("3cb7627b-defc-401b-9959-42ebc4488f74")["slug_s"] ==
              "zilele-vor-mai-niciodată"
@@ -304,7 +298,7 @@ defmodule DpulCollections.SolrTest do
     }
 
     Solr.add([doc], active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     assert Solr.find_by_id("3cb7627b-defc-401b-9959-42ebc4488f74")["slug_s"] == "this-is-a-title"
   end
@@ -316,7 +310,7 @@ defmodule DpulCollections.SolrTest do
     }
 
     Solr.add([doc], active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     assert Solr.find_by_id("3cb7627b-defc-401b-9959-42ebc4488f74")["slug_s"] ==
              "玉機微義-五十卷-徐用誠輯-劉純續輯"
@@ -329,7 +323,7 @@ defmodule DpulCollections.SolrTest do
     }
 
     Solr.add([doc], active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     assert Solr.find_by_id("3cb7627b-defc-401b-9959-42ebc4488f74")["slug_s"] ==
              "ديوان-القاضي-ناصح-الدين-ابي"
@@ -342,7 +336,7 @@ defmodule DpulCollections.SolrTest do
     }
 
     Solr.add([doc], active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     assert Solr.find_by_id("3cb7627b-defc-401b-9959-42ebc4488f74")["slug_s"] ==
              "паук-семейства-сои"
@@ -355,7 +349,7 @@ defmodule DpulCollections.SolrTest do
     }
 
     Solr.add([doc], active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     assert Solr.find_by_id("3cb7627b-defc-401b-9959-42ebc4488f74")["slug_s"] ==
              "él-no-responde-mis-mensajes"
@@ -368,7 +362,7 @@ defmodule DpulCollections.SolrTest do
     }
 
     Solr.add([doc], active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     assert Solr.find_by_id("3cb7627b-defc-401b-9959-42ebc4488f74")["slug_s"] ==
              "cómo-reforma-educacional-beneficia"
@@ -398,7 +392,7 @@ defmodule DpulCollections.SolrTest do
     assert capture_log(fn -> Solr.add([valid_doc, invalid_doc], active_collection()) end) =~
              "error indexing solr document"
 
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
     assert Solr.find_by_id(valid_doc["id"])["id"] == valid_doc["id"]
   end
 

--- a/test/dpul_collections/workers/cache_mosaic_images_test.exs
+++ b/test/dpul_collections/workers/cache_mosaic_images_test.exs
@@ -3,17 +3,12 @@ defmodule DpulCollections.Workers.CacheMosaicImagesTest do
   alias DpulCollections.Solr
   import SolrTestSupport
 
-  setup do
-    Solr.delete_all(active_collection())
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
-  end
-
   describe ".perform/" do
     test "mosaic images are cached" do
       Oban.Testing.with_testing_mode(:inline, fn ->
         doc = SolrTestSupport.mock_solr_documents(1) |> hd
         Solr.add([doc], active_collection())
-        Solr.commit(active_collection())
+        Solr.soft_commit(active_collection())
 
         Req.Test.stub(DpulCollections.Workers.CacheMosaicImages, fn conn ->
           conn

--- a/test/dpul_collections_web/controllers/iiif_content_state_controller_test.exs
+++ b/test/dpul_collections_web/controllers/iiif_content_state_controller_test.exs
@@ -1,9 +1,8 @@
 defmodule DpulCollectionsWeb.IiifContentStateControllerTest do
   use DpulCollectionsWeb.ConnCase
   alias DpulCollections.Solr
-  import SolrTestSupport
 
-  setup_all do
+  setup do
     Solr.add([
       %{
         id: 1,
@@ -29,8 +28,8 @@ defmodule DpulCollectionsWeb.IiifContentStateControllerTest do
       }
     ])
 
-    Solr.commit(active_collection())
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
+    Solr.soft_commit(active_collection())
+    :ok
   end
 
   describe "show/2" do

--- a/test/dpul_collections_web/controllers/iiif_content_state_controller_test.exs
+++ b/test/dpul_collections_web/controllers/iiif_content_state_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule DpulCollectionsWeb.IiifContentStateControllerTest do
-  use DpulCollectionsWeb.ConnCase, async: true
+  use DpulCollectionsWeb.ConnCase
   alias DpulCollections.Solr
   import SolrTestSupport
 

--- a/test/dpul_collections_web/features/browse_test.exs
+++ b/test/dpul_collections_web/features/browse_test.exs
@@ -1,20 +1,18 @@
 defmodule DpulCollectionsWeb.BrowseTest do
-  use ExUnit.Case
+  use DpulCollections.DataCase
   use PhoenixTest.Playwright.Case
   alias PhoenixTest.Playwright.Frame
   alias DpulCollections.Solr
-  import SolrTestSupport
 
   setup do
     Solr.add(SolrTestSupport.mock_solr_documents(20), active_collection())
-    Solr.commit(active_collection())
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
+    Solr.soft_commit(active_collection())
     {:ok, %{}}
   end
 
   test "browse page is accessible", %{conn: conn} do
     Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     conn
     |> visit("/browse?r=0")

--- a/test/dpul_collections_web/features/content_warnings_test.exs
+++ b/test/dpul_collections_web/features/content_warnings_test.exs
@@ -1,11 +1,10 @@
 defmodule DpulCollectionsWeb.Features.ContentWarningsTest do
-  use ExUnit.Case
+  use DpulCollections.DataCase
   use PhoenixTest.Playwright.Case
-  import SolrTestSupport
   alias PhoenixTest.Playwright.Frame
   alias DpulCollections.Solr
 
-  setup_all do
+  setup do
     Solr.add(SolrTestSupport.mock_solr_documents(50), active_collection())
 
     Solr.add(
@@ -29,8 +28,8 @@ defmodule DpulCollectionsWeb.Features.ContentWarningsTest do
       active_collection()
     )
 
-    Solr.commit(active_collection())
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
+    Solr.soft_commit(active_collection())
+    :ok
   end
 
   describe "when there's a content warning, thumbnails are obfuscated" do
@@ -105,11 +104,7 @@ defmodule DpulCollectionsWeb.Features.ContentWarningsTest do
         active_collection()
       )
 
-      Solr.commit(active_collection())
-
-      on_exit(fn ->
-        Solr.delete_batch(["d4292e58-25d7-4247-bf92-0a5e24ec75d2"], active_collection())
-      end)
+      Solr.soft_commit(active_collection())
 
       conn
       |> visit("/item/d4292e58-25d7-4247-bf92-0a5e24ec75d1")

--- a/test/dpul_collections_web/features/home_test.exs
+++ b/test/dpul_collections_web/features/home_test.exs
@@ -1,16 +1,11 @@
 defmodule DpulCollectionsWeb.Features.HomeTest do
-  use ExUnit.Case
+  use DpulCollections.DataCase
   use PhoenixTest.Playwright.Case
-  import SolrTestSupport
   alias DpulCollections.Solr
-
-  setup do
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
-  end
 
   test "home page is accessible", %{conn: conn} do
     Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     conn
     |> visit("/")

--- a/test/dpul_collections_web/features/item_test.exs
+++ b/test/dpul_collections_web/features/item_test.exs
@@ -1,16 +1,14 @@
 defmodule DpulCollectionsWeb.Features.ItemViewTest do
-  use ExUnit.Case
+  use DpulCollections.DataCase
   use PhoenixTest.Playwright.Case
   alias PhoenixTest.Playwright.Frame
   alias PhoenixTest.Playwright
-  import SolrTestSupport
   alias DpulCollections.Solr
 
   setup do
     sham = Sham.start()
     Solr.add(SolrTestSupport.mock_solr_documents(1, true, sham), active_collection())
-    Solr.commit(active_collection())
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
+    Solr.soft_commit(active_collection())
     {:ok, sham: sham}
   end
 

--- a/test/dpul_collections_web/features/locale_test.exs
+++ b/test/dpul_collections_web/features/locale_test.exs
@@ -1,8 +1,7 @@
 defmodule DpulCollectionsWeb.Features.LocaleTest do
-  use ExUnit.Case
+  use DpulCollections.DataCase
   use PhoenixTest.Playwright.Case
   alias PhoenixTest.Playwright
-  import SolrTestSupport
   alias DpulCollections.Solr
 
   # Because the search button is only visible when the input is focused, we use
@@ -41,7 +40,7 @@ defmodule DpulCollectionsWeb.Features.LocaleTest do
   # Testing because these translations happen in a separate library and are not handled by Gettext
   test "renders time-ago language with translation", %{conn: conn} do
     Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     conn
     |> visit("/")

--- a/test/dpul_collections_web/features/search_bar_test.exs
+++ b/test/dpul_collections_web/features/search_bar_test.exs
@@ -1,14 +1,13 @@
 defmodule DpulCollectionsWeb.Features.SearchBarTest do
-  use ExUnit.Case
+  use DpulCollections.DataCase
   use PhoenixTest.Playwright.Case
   alias PhoenixTest.Playwright
-  import SolrTestSupport
   alias DpulCollections.Solr
 
   setup do
     Solr.add(SolrTestSupport.mock_solr_documents(), active_collection())
-    Solr.commit(active_collection())
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
+    Solr.soft_commit(active_collection())
+    :ok
   end
 
   # Because the search button is only visible when the input is focused, we use

--- a/test/dpul_collections_web/features/search_test.exs
+++ b/test/dpul_collections_web/features/search_test.exs
@@ -1,12 +1,7 @@
 defmodule DpulCollectionsWeb.Features.SearchTest do
-  use ExUnit.Case
+  use DpulCollections.DataCase
   use PhoenixTest.Playwright.Case
-  import SolrTestSupport
   alias DpulCollections.Solr
-
-  setup do
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
-  end
 
   test "image counts are shown when total files outnumber visible images", %{conn: conn} do
     Solr.add(
@@ -38,7 +33,7 @@ defmodule DpulCollectionsWeb.Features.SearchTest do
       active_collection()
     )
 
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     conn
     |> visit("/search?q=")

--- a/test/dpul_collections_web/live/browse_live_test.exs
+++ b/test/dpul_collections_web/live/browse_live_test.exs
@@ -1,7 +1,6 @@
 defmodule DpulCollectionsWeb.BrowseLiveTest do
   use DpulCollectionsWeb.ConnCase
   import Phoenix.LiveViewTest
-  import SolrTestSupport
   alias DpulCollections.Solr
   @endpoint DpulCollectionsWeb.Endpoint
 
@@ -27,7 +26,7 @@ defmodule DpulCollectionsWeb.BrowseLiveTest do
 
   test "browse from random", %{conn: conn} do
     Solr.add(SolrTestSupport.mock_solr_documents(200), active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     {:ok, view, html} = live(conn, "/browse?r=0")
 
@@ -82,7 +81,7 @@ defmodule DpulCollectionsWeb.BrowseLiveTest do
 
   test "focused browse from link", %{conn: conn} do
     Solr.add(SolrTestSupport.mock_solr_documents(90), active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     {:ok, _view, html} = live(conn, "/browse/focus/1")
 
@@ -91,7 +90,7 @@ defmodule DpulCollectionsWeb.BrowseLiveTest do
 
   test "click random button", %{conn: conn} do
     Solr.add(SolrTestSupport.mock_solr_documents(90), active_collection())
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     {:ok, view, html} = live(conn, "/browse?r=0")
 
@@ -128,7 +127,7 @@ defmodule DpulCollectionsWeb.BrowseLiveTest do
       active_collection()
     )
 
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     {:ok, view, _html} = live(conn, "/browse?r=0")
 
@@ -148,7 +147,7 @@ defmodule DpulCollectionsWeb.BrowseLiveTest do
       active_collection()
     )
 
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     {:ok, view, _html} = live(conn, "/browse?r=0")
 
@@ -172,7 +171,7 @@ defmodule DpulCollectionsWeb.BrowseLiveTest do
       active_collection()
     )
 
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     {:ok, _view, html} = live(conn, "/browse?r=0")
 
@@ -202,7 +201,7 @@ defmodule DpulCollectionsWeb.BrowseLiveTest do
       active_collection()
     )
 
-    Solr.commit(active_collection())
+    Solr.soft_commit(active_collection())
 
     {:ok, _view, html} = live(conn, "/browse?r=0")
 
@@ -252,7 +251,7 @@ defmodule DpulCollectionsWeb.BrowseLiveTest do
         active_collection()
       )
 
-      Solr.commit(active_collection())
+      Solr.soft_commit(active_collection())
 
       {:ok, view, _html} = live(conn, "/browse?r=0")
 

--- a/test/dpul_collections_web/live/home_live_test.exs
+++ b/test/dpul_collections_web/live/home_live_test.exs
@@ -5,10 +5,6 @@ defmodule DpulCollectionsWeb.HomeLiveTest do
   alias DpulCollections.Solr
   @endpoint DpulCollectionsWeb.Endpoint
 
-  setup do
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
-  end
-
   test "GET /", %{conn: conn} do
     conn = get(conn, ~p"/")
     assert html_response(conn, 200) =~ "Digital Collections"
@@ -40,7 +36,7 @@ defmodule DpulCollectionsWeb.HomeLiveTest do
   describe "recent item blocks" do
     test "renders 5 cards", %{conn: conn} do
       Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
-      Solr.commit(active_collection())
+      Solr.soft_commit(active_collection())
 
       {:ok, _view, html} = live(conn, "/")
 
@@ -55,7 +51,7 @@ defmodule DpulCollectionsWeb.HomeLiveTest do
 
     test "link to recently updated", %{conn: conn} do
       Solr.add(SolrTestSupport.mock_solr_documents(100), active_collection())
-      Solr.commit(active_collection())
+      Solr.soft_commit(active_collection())
 
       {:ok, view, _} = live(conn, "/")
 
@@ -78,7 +74,7 @@ defmodule DpulCollectionsWeb.HomeLiveTest do
 
     test "recently updated thumbnails link to record", %{conn: conn} do
       Solr.add(SolrTestSupport.mock_solr_documents(3), active_collection())
-      Solr.commit(active_collection())
+      Solr.soft_commit(active_collection())
 
       {:ok, view, _} = live(conn, "/")
 

--- a/test/dpul_collections_web/live/item_live_metadata_test.exs
+++ b/test/dpul_collections_web/live/item_live_metadata_test.exs
@@ -1,11 +1,10 @@
 defmodule DpulCollectionsWeb.ItemLiveMetadataTest do
   use DpulCollectionsWeb.ConnCase
   import Phoenix.LiveViewTest
-  import SolrTestSupport
   alias DpulCollections.Solr
   @endpoint DpulCollectionsWeb.Endpoint
 
-  setup_all do
+  setup do
     Solr.add(
       [
         %{
@@ -49,8 +48,8 @@ defmodule DpulCollectionsWeb.ItemLiveMetadataTest do
       active_collection()
     )
 
-    Solr.commit(active_collection())
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
+    Solr.soft_commit(active_collection())
+    :ok
   end
 
   test "/item/{:id}/metadata displays all the metadata fields and has links for linkable fields",

--- a/test/dpul_collections_web/live/item_live_test.exs
+++ b/test/dpul_collections_web/live/item_live_test.exs
@@ -1,12 +1,11 @@
 defmodule DpulCollectionsWeb.ItemLiveTest do
   use DpulCollectionsWeb.ConnCase
   import Phoenix.LiveViewTest
-  import SolrTestSupport
   alias DpulCollections.Solr
   alias DpulCollectionsWeb.ItemLive
   @endpoint DpulCollectionsWeb.Endpoint
 
-  setup_all do
+  setup do
     Solr.add(SolrTestSupport.mock_solr_documents())
 
     Solr.add(
@@ -110,8 +109,8 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
       active_collection()
     )
 
-    Solr.commit(active_collection())
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
+    Solr.soft_commit(active_collection())
+    :ok
   end
 
   describe "url paths and routing" do

--- a/test/dpul_collections_web/live/item_live_test.exs
+++ b/test/dpul_collections_web/live/item_live_test.exs
@@ -83,6 +83,7 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
         %{
           id: "similar-to-1",
           title_txtm: "Similar Item Same Project",
+          file_count_i: 1,
           ephemera_project_title_s: "Test Project",
           genre_txt_sort: ["genre"],
           subject_txt_sort: ["subject"],
@@ -93,10 +94,17 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
         },
         %{
           id: "similar-to-1-diff-project",
+          file_count_i: 1,
           title_txtm: "Similar Item Different Project",
           ephemera_project_title_s: "Different Project",
           genre_txt_sort: ["genre"],
           subject_txt_sort: ["subject"]
+        },
+        %{
+          id: "similar-to-1-is-a-project",
+          title_txtm: "I'm a project",
+          description_txtm: ["This is a test description"],
+          resource_type_s: "collection"
         }
       ],
       active_collection()

--- a/test/dpul_collections_web/live/item_live_test.exs
+++ b/test/dpul_collections_web/live/item_live_test.exs
@@ -387,7 +387,7 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
   end
 
   describe "related items" do
-    test "shows some related items", %{conn: conn} do
+    test "shows some related items, but no collections", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/i/învăţămîntul-trebuie-urmărească-dez/item/1")
 
       assert view |> has_element?("#related-same-project a", "Similar Item Same Project")

--- a/test/dpul_collections_web/live/item_live_viewer_test.exs
+++ b/test/dpul_collections_web/live/item_live_viewer_test.exs
@@ -1,11 +1,10 @@
 defmodule DpulCollectionsWeb.ItemLiveViewerTest do
   use DpulCollectionsWeb.ConnCase
   import Phoenix.LiveViewTest
-  import SolrTestSupport
   alias DpulCollections.Solr
   @endpoint DpulCollectionsWeb.Endpoint
 
-  setup_all do
+  setup do
     Solr.add(
       [
         %{
@@ -25,8 +24,8 @@ defmodule DpulCollectionsWeb.ItemLiveViewerTest do
       active_collection()
     )
 
-    Solr.commit(active_collection())
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
+    Solr.soft_commit(active_collection())
+    :ok
   end
 
   test "GET /item/{:id}/viewer", %{conn: conn} do

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -1,14 +1,13 @@
 defmodule DpulCollectionsWeb.SearchLiveTest do
   use DpulCollectionsWeb.ConnCase
   import Phoenix.LiveViewTest
-  import SolrTestSupport
   alias DpulCollections.Solr
   @endpoint DpulCollectionsWeb.Endpoint
 
   setup do
     Solr.add(SolrTestSupport.mock_solr_documents(), active_collection())
-    Solr.commit(active_collection())
-    on_exit(fn -> Solr.delete_all(active_collection()) end)
+    Solr.soft_commit(active_collection())
+    :ok
   end
 
   describe "GET /search" do
@@ -261,7 +260,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
       active_collection()
     )
 
-    Solr.commit()
+    Solr.soft_commit()
 
     {:ok, view, _html} = live(conn, "/search?sort_by=date_desc&page=3")
 
@@ -530,7 +529,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
       sae_ids
       |> Enum.each(&FiggyTestSupport.index_record_id_directly/1)
 
-      Solr.commit()
+      Solr.soft_commit()
       sae_id = "f99af4de-fed4-4baa-82b1-6e857b230306"
 
       {:ok, view, _html} = live(conn, ~p"/search?#{%{q: "South Asian Ephemera"}}")
@@ -572,7 +571,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
         active_collection()
       )
 
-      Solr.commit()
+      Solr.soft_commit()
 
       {:ok, view, _html} = live(conn, "/search?q=movement")
 

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -554,16 +554,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
     test "link to record page", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/search?q=")
 
-      html = render(view)
-
-      first_href =
-        html
-        |> Floki.parse_document!()
-        |> Floki.find(".card a")
-        |> Enum.flat_map(&Floki.attribute(&1, "href"))
-        |> Enum.at(0)
-
-      assert first_href == "/i/document1/item/1"
+      assert view |> element(".card a[href='/i/document1/item/1']") |> has_element? == true
     end
 
     test "show some metadata", %{conn: conn} do

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -248,12 +248,14 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
       [
         %{
           id: "nildate",
-          title_txtm: "Document-nildate"
+          title_txtm: "Document-nildate",
+          file_count_i: 1
         },
         %{
           id: "emptydate",
           title_txtm: "Document-emptydate",
-          years_is: []
+          years_is: [],
+          file_count_i: 1
         }
       ],
       active_collection()

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -36,6 +36,7 @@ defmodule DpulCollectionsWeb.ConnCase do
     if !tags[:async] do
       DpulCollections.Solr.delete_all(SolrTestSupport.active_collection())
     end
+
     :ok
   end
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -32,14 +32,6 @@ defmodule DpulCollectionsWeb.ConnCase do
     end
   end
 
-  setup_all tags do
-    if !tags[:async] do
-      DpulCollections.Solr.delete_all(SolrTestSupport.active_collection())
-    end
-
-    :ok
-  end
-
   setup tags do
     DpulCollections.DataCase.setup_sandbox(tags)
     {:ok, conn: Phoenix.ConnTest.build_conn()}

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -28,7 +28,13 @@ defmodule DpulCollectionsWeb.ConnCase do
       import Plug.Conn
       import Phoenix.ConnTest
       import DpulCollectionsWeb.ConnCase
+      import SolrTestSupport
     end
+  end
+
+  setup_all do
+    DpulCollections.Solr.delete_all(SolrTestSupport.active_collection())
+    :ok
   end
 
   setup tags do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -32,8 +32,10 @@ defmodule DpulCollectionsWeb.ConnCase do
     end
   end
 
-  setup_all do
-    DpulCollections.Solr.delete_all(SolrTestSupport.active_collection())
+  setup_all tags do
+    if !tags[:async] do
+      DpulCollections.Solr.delete_all(SolrTestSupport.active_collection())
+    end
     :ok
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -33,14 +33,6 @@ defmodule DpulCollections.DataCase do
     :ok
   end
 
-  setup_all tags do
-    if !tags[:async] do
-      DpulCollections.Solr.delete_all(SolrTestSupport.active_collection())
-    end
-
-    :ok
-  end
-
   @doc """
   Sets up the sandbox based on the test tags.
   """

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -24,6 +24,7 @@ defmodule DpulCollections.DataCase do
       import Ecto.Changeset
       import Ecto.Query
       import DpulCollections.DataCase
+      import SolrTestSupport
     end
   end
 
@@ -32,11 +33,17 @@ defmodule DpulCollections.DataCase do
     :ok
   end
 
+  setup_all do
+    DpulCollections.Solr.delete_all(SolrTestSupport.active_collection())
+    :ok
+  end
+
   @doc """
   Sets up the sandbox based on the test tags.
   """
   def setup_sandbox(tags) do
     pid = Ecto.Adapters.SQL.Sandbox.start_owner!(DpulCollections.Repo, shared: not tags[:async])
+    on_exit(fn -> DpulCollections.Solr.delete_all(SolrTestSupport.active_collection()) end)
     on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -33,8 +33,11 @@ defmodule DpulCollections.DataCase do
     :ok
   end
 
-  setup_all do
-    DpulCollections.Solr.delete_all(SolrTestSupport.active_collection())
+  setup_all tags do
+    if !tags[:async] do
+      DpulCollections.Solr.delete_all(SolrTestSupport.active_collection())
+    end
+
     :ok
   end
 
@@ -43,7 +46,12 @@ defmodule DpulCollections.DataCase do
   """
   def setup_sandbox(tags) do
     pid = Ecto.Adapters.SQL.Sandbox.start_owner!(DpulCollections.Repo, shared: not tags[:async])
-    on_exit(fn -> DpulCollections.Solr.delete_all(SolrTestSupport.active_collection()) end)
+
+    if !tags[:async] do
+      DpulCollections.Solr.delete_all(SolrTestSupport.active_collection())
+      on_exit(fn -> DpulCollections.Solr.delete_all(SolrTestSupport.active_collection()) end)
+    end
+
     on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
   end
 

--- a/test/support/figgy_test_support.ex
+++ b/test/support/figgy_test_support.ex
@@ -94,7 +94,7 @@ defmodule FiggyTestSupport do
     })
 
     Solr.add(solr_doc)
-    Solr.commit()
+    Solr.soft_commit()
 
     solr_doc
   end
@@ -161,7 +161,7 @@ defmodule FiggyTestSupport do
 
   def wait_for_indexed_count(count) do
     index = Solr.Index.read_index()
-    DpulCollections.Solr.commit(index)
+    DpulCollections.Solr.soft_commit(index)
 
     continue =
       if DpulCollections.Solr.document_count() == count do


### PR DESCRIPTION
- **Remove async: true from ContentStateController, it uses Solr.**
- **Projects should not appear in related items.**
- **Telemetry should be disconnected when the tests end.**
- **Use AckTracker for Hydration Integration Test.**
- **Don't depend on order for blank query search tests.**
- **Consistently clear Solr before every test module, and after each test.**

Closes #815 

This is draft until I've run the test suite 60 times without failure: `mix test --repeat-until-failure 60 --max-failures 1`