### PR TITLE
Add project to mock documents so color contrast is tested.

### DIFF
--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -5,7 +5,9 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
   @endpoint DpulCollectionsWeb.Endpoint
 
   setup do
-    Solr.add(SolrTestSupport.mock_solr_documents(), active_collection())
+    # 99 mock documents because it adds one collection, for a total of 100
+    # search results.
+    Solr.add(SolrTestSupport.mock_solr_documents(99), active_collection())
     Solr.soft_commit(active_collection())
     :ok
   end
@@ -93,7 +95,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
       |> Floki.parse_document()
 
     assert document
-           |> Floki.find(~s{a[href="/i/document100/item/100"]})
+           |> Floki.find(~s{a[href="/i/document99/item/99"]})
            |> Enum.any?()
 
     assert document
@@ -110,7 +112,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
            |> Enum.any?()
 
     assert document
-           |> Floki.find(~s{a[href="/i/document100/item/100"]})
+           |> Floki.find(~s{a[href="/i/document99/item/99"]})
            |> Enum.empty?()
   end
 
@@ -130,7 +132,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
            |> Enum.empty?()
 
     assert document
-           |> Floki.find(~s{a[href="/i/document100/item/100"]})
+           |> Floki.find(~s{a[href="/i/document99/item/99"]})
            |> Enum.any?()
   end
 
@@ -293,7 +295,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
            |> Enum.any?()
 
     assert document
-           |> Floki.find(~s{a[href="/i/document100/item/100"]})
+           |> Floki.find(~s{a[href="/i/document99/item/99"]})
            |> Enum.any?()
 
     assert document


### PR DESCRIPTION
Since not all the project metadata is in the item document this'll make sure Axe tests the new tagline feature.

It looks like a lot of changes but most of it is indenting - the key thing is it just adds an `ephemera_project_id_s` to the mock documents that feature tests use, and makes sure that the appropriate project is also indexed.