### PR TITLE
Index project id

### DIFF
--- a/lib/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource.ex
@@ -83,6 +83,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.CombinedFiggyResource do
       digitized_at_dt: digitized_date(data),
       display_date_s: format_date(metadata),
       ephemera_project_title_s: Map.get(project_metadata, "title", []) |> Enum.at(0),
+      ephemera_project_id_s: extract_project_id(related_data),
       file_count_i: file_count(metadata),
       folder_number_txtm: get_in(metadata, ["folder_number"]),
       genre_txt_sort: extract_term("genre", metadata, related_data),
@@ -336,6 +337,22 @@ defmodule DpulCollections.IndexingPipeline.Figgy.CombinedFiggyResource do
   end
 
   defp extract_project_metadata(_), do: %{}
+
+  defp extract_project_id(%{"ancestors" => ancestors}) when map_size(ancestors) > 0 do
+    project = find_ancestor_type(ancestors, "EphemeraProject")
+
+    cond do
+      is_nil(project) ->
+        ""
+
+      true ->
+        project
+        |> elem(1)
+        |> extract_id_from_map()
+    end
+  end
+
+  defp extract_project_id(_), do: %{}
 
   defp find_ancestor_type(ancestors, resource_type) do
     ancestors

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -236,6 +236,7 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
 
       # Parent EphemeraProject
       assert document["ephemera_project_title_s"] == "Woman Life Freedom Movement: Iran 2022"
+      assert document["ephemera_project_id_s"] == "2961c153-54ab-4c6a-b5cd-aa992f4c349b"
 
       # Image URLs
       assert [
@@ -277,6 +278,8 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
       # Parent EphemeraProject
       assert document["ephemera_project_title_s"] ==
                "Guatemala News and Information Bureau Archive (1963-2000)"
+
+      assert document["ephemera_project_id_s"] == "1e63fc3c-f41d-4512-9abc-8ed671a50261"
     end
   end
 


### PR DESCRIPTION
follow up to #819
fixes #838

Once this is deployed we need to re-transform.

To deploy to prod without downtime we'd have to revert #819, then deploy, then retransform, then re-merge #819. It doesn't seem important to do that at this phase.