### PR TITLE
Use txtm instead of txt_sort for tagline field

### DIFF
--- a/lib/dpul_collections/collection.ex
+++ b/lib/dpul_collections/collection.ex
@@ -47,7 +47,7 @@ defmodule DpulCollections.Collection do
       id: doc["id"],
       slug: doc["authoritative_slug_s"],
       title: title,
-      tagline: doc |> Map.get("tagline_txt_sort", []) |> Enum.at(0),
+      tagline: doc |> Map.get("tagline_txtm", []) |> Enum.at(0),
       description: doc |> Map.get("description_txtm", []) |> Enum.at(0),
       item_count: summary.count,
       categories: summary.categories,

--- a/lib/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource.ex
@@ -56,7 +56,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.CombinedFiggyResource do
       title_txtm: metadata["title"],
       description_txtm: metadata["description"],
       resource_type_s: "collection",
-      tagline_txt_sort: metadata["tagline"],
+      tagline_txtm: metadata["tagline"],
       authoritative_slug_s: Map.get(metadata, "slug", []) |> Enum.at(0),
       genre_txt_sort: ["Digital Collection"]
     }

--- a/lib/dpul_collections/item.ex
+++ b/lib/dpul_collections/item.ex
@@ -166,7 +166,7 @@ defmodule DpulCollections.Item do
       width: doc["width_txtm"] || [],
       metadata_url: generate_metadata_url(id, slug),
       viewer_url: generate_viewer_url(id, slug),
-      tagline: doc["tagline_txt_sort"] || []
+      tagline: doc["tagline_txtm"] || []
     }
   end
 

--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -73,7 +73,7 @@ defmodule DpulCollections.Solr do
     "updated_at_dt",
     "content_warning_s",
     "geographic_origin_txt_sort",
-    "tagline_txt_sort"
+    "tagline_txtm"
   ]
 
   def raw_query(search_state, index \\ Index.read_index()) do

--- a/test/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource_test.exs
@@ -14,7 +14,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.CombinedFiggyResourceTest do
                id: "f99af4de-fed4-4baa-82b1-6e857b230306",
                title_txtm: ["South Asian Ephemera"],
                resource_type_s: "collection",
-               tagline_txt_sort: [
+               tagline_txtm: [
                  "Discover voices of change across South Asia through contemporary pamphlets, flyers, and documents that capture the region's social movements, politics, and cultural expressions."
                ],
                authoritative_slug_s: "sae"

--- a/test/dpul_collections_web/live/item_live_test.exs
+++ b/test/dpul_collections_web/live/item_live_test.exs
@@ -49,7 +49,7 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
           width_txtm: ["200"],
           ephemera_project_title_s: "Test Project",
           ephemera_project_id_s: "similar-to-1-is-a-project",
-          tagline_txt_sort: "This is a tagline.",
+          tagline_txtm: "This is a tagline.",
           pdf_url_s:
             "https://figgy.example.com/concern/ephemera_folders/3da68e1c-06af-4d17-8603-fc73152e1ef7/pdf"
         },
@@ -104,7 +104,7 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
         %{
           id: "similar-to-1-is-a-project",
           title_txtm: "I'm a project",
-          tagline_txt_sort: "This is a tagline.",
+          tagline_txtm: "This is a tagline.",
           description_txtm: ["This is a test description"],
           resource_type_s: "collection"
         }


### PR DESCRIPTION
closes #836

If this is merged and deployed with #840 then it shouldn't be much more disruptive to roll it in with that retransform.