### PR TITLE
Add padding between multiple descriptions in metadata pane

### DIFF
--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -267,6 +267,7 @@ defmodule DpulCollectionsWeb.ItemLive do
           <h2 class="sm:border-t-1 border-accent py-3">{gettext("Item Description")}</h2>
           <p
             :for={description <- @item.description}
+            class="not-last:pb-4"
             dir="auto"
           >
             {description}


### PR DESCRIPTION
Follow up to #846

<img width="1237" height="412" alt="Screenshot 2025-10-13 at 12 20 30 PM" src="https://github.com/user-attachments/assets/80aec53d-f3e7-4027-a4a0-3607831ea54c" />
