### PR TITLE
Add sr-only h2 for metadata area on item page

### DIFF
--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -683,6 +683,7 @@ defmodule DpulCollectionsWeb.ItemLive do
 
   def metadata_table(assigns) do
     ~H"""
+    <h2 class="sr-only">{gettext("Metadata")}</h2>
     <div class="relative overflow-x-auto">
       <dl class="grid items-start gap-x-8 gap-y-4">
         <.metadata_row


### PR DESCRIPTION
I checked with mac voice over and it does read. It also doesn't show in the browser.

closes #832
