### PR TITLE
Rename "View" button to "Look closer"

### DIFF
--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -254,7 +254,7 @@ defmodule DpulCollectionsWeb.ItemLive do
       <div class="header-x-padding heading-y-padding bg-accent flex flex-row">
         <h1 class="uppercase text-light-text flex-auto">{gettext("Metadata")}</h1>
         <.link
-          aria-label={gettext("close")}
+          aria-label={gettext("close pane")}
           class="flex-none cursor-pointer justify-end"
           patch={@item.url}
           replace
@@ -339,7 +339,7 @@ defmodule DpulCollectionsWeb.ItemLive do
           </.action_icon>
         </div>
         <.link
-          aria-label={gettext("close")}
+          aria-label={gettext("close pane")}
           class="flex-none cursor-pointer justify-end"
           patch={@item.url}
           replace
@@ -599,7 +599,7 @@ defmodule DpulCollectionsWeb.ItemLive do
         <div class="thumbnail-buttons grid grid-cols-2 gap-2">
           <.arrow_button_left id="viewer-link" patch={"#{@item.viewer_url}/1"} replace>
             <span class="w-max flex gap-2 text-sm sm:text-base">
-              <.icon name="hero-eye" /> {gettext("View")}
+              <.icon name="hero-eye" />{gettext("Look closer")}
             </span>
           </.arrow_button_left>
 

--- a/test/dpul_collections_web/features/content_warnings_test.exs
+++ b/test/dpul_collections_web/features/content_warnings_test.exs
@@ -125,14 +125,14 @@ defmodule DpulCollectionsWeb.Features.ContentWarningsTest do
       |> click_button("View content")
       |> refute_has("img.thumbnail-d4292e58-25d7-4247-bf92-0a5e24ec75d2.obfuscate")
       # Make sure the viewer also knows not to render this.
-      |> click_link("#viewer-link", "View")
+      |> click_link("#viewer-link", "Look closer")
       |> refute_has("h2", text: "Content Warning")
     end
 
     test "in the viewer", %{conn: conn} do
       conn
       |> visit("/item/d4292e58-25d7-4247-bf92-0a5e24ec75d1")
-      |> click_link("#viewer-link", "View")
+      |> click_link("#viewer-link", "Look closer")
       # the large thumbnail is duplicated in the small thumbnail list
       |> assert_has("h2", text: "Content Warning")
       |> click_button("View content")

--- a/test/dpul_collections_web/features/item_test.exs
+++ b/test/dpul_collections_web/features/item_test.exs
@@ -104,7 +104,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
       |> click_link("View all metadata for this item")
       |> click_button("Copy")
       |> assert_has("button#iiif-url-copy", text: "Copied")
-      |> click_link("close")
+      |> click_link("close pane")
       # share copy button has not been triggered
       |> click_button("Share")
       |> assert_has("#share-modal button", text: "Copy")
@@ -116,16 +116,16 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
     |> visit("/i/document1/item/1")
     |> click_link("View all metadata for this item")
     |> assert_path("/i/document1/item/1/metadata")
-    |> click_link("close")
+    |> click_link("close pane")
     |> assert_path("/i/document1/item/1")
   end
 
   test "links to and from viewer page", %{conn: conn} do
     conn
     |> visit("/i/document1/item/1")
-    |> click_link("#viewer-link", "View")
+    |> click_link("#viewer-link", "Look closer")
     |> assert_path("/i/document1/item/1/viewer/1")
-    |> click_link("close")
+    |> click_link("close pane")
     |> assert_path("/i/document1/item/1")
   end
 
@@ -135,7 +135,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
     |> click_link("Document-1")
     |> click_link("View all metadata for this item")
     |> assert_path("/i/document1/item/1/metadata")
-    |> click_link("close")
+    |> click_link("close pane")
     |> assert_path("/i/document1/item/1")
     |> go_back
     |> assert_path("/search")
@@ -145,9 +145,9 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
     conn
     |> visit("/search")
     |> click_link("Document-1")
-    |> click_link("#viewer-link", "View")
+    |> click_link("#viewer-link", "Look closer")
     |> assert_path("/i/document1/item/1/viewer/1")
-    |> click_link("close")
+    |> click_link("close pane")
     |> assert_path("/i/document1/item/1")
     |> go_back
     |> assert_path("/search")
@@ -156,7 +156,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
   test "the viewer pane changes the URL when clicking a new item", %{conn: conn} do
     conn
     |> visit("/item/1")
-    |> click_link("#viewer-link", "View")
+    |> click_link("#viewer-link", "Look closer")
     |> assert_path("/i/document1/item/1/viewer/1")
     |> click_button("figcaption", "2")
     |> assert_path("/i/document1/item/1/viewer/2")


### PR DESCRIPTION
To fix tests I re-labeled the "close" button in panes to "close pane".

It appears that the click-link text uses substring matching, and when
you add a selector it can no longer target the aria label for the match.

closes #830