### PR TITLE
Browse cards should navigate if possible.

### DIFF
--- a/lib/dpul_collections_web/components/browse_item.ex
+++ b/lib/dpul_collections_web/components/browse_item.ex
@@ -97,7 +97,8 @@ defmodule DpulCollectionsWeb.BrowseItem do
         </div>
       </div>
       <.link
-        href={@item.url}
+        navigate={!@target && @item.url}
+        href={@target != nil && @item.url}
         target={@target}
         class="-outline-offset-1 flex-grow item-link flex flex-col"
         aria-label={"View #{@item.title |> hd}"}


### PR DESCRIPTION
This has bothered me for a while - it makes browse cards navigate rather
than link, unless it's opening a link in a new tab.

Closes #855 