### PR TITLE
Remove filter and sort forms when there are no results

### DIFF
--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -174,6 +174,7 @@ defmodule DpulCollectionsWeb.SearchLive do
           />
         </div>
         <.form
+          :if={@total_items > 0}
           id="filter-form"
           phx-change="checked_filter"
           phx-submit="apply_filters"
@@ -208,8 +209,13 @@ defmodule DpulCollectionsWeb.SearchLive do
       </section>
       <section class="content-area">
         <div class="page-y-padding grid grid-flow-row auto-rows-max gap-6">
-          <div id="filters" class="flex flex-wrap gap-4">
-            <form id="sort-form" class="grid md:grid-cols-[auto_200px] gap-2" phx-change="sort">
+          <div class="flex flex-wrap gap-4">
+            <form
+              :if={@total_items > 0}
+              id="sort-form"
+              class="grid md:grid-cols-[auto_200px] gap-2"
+              phx-change="sort"
+            >
               <label class="col-span-1 self-center font-bold uppercase md:text-right" for="sort-by">
                 {gettext("sort by")}:
               </label>

--- a/test/dpul_collections_web/features/locale_test.exs
+++ b/test/dpul_collections_web/features/locale_test.exs
@@ -7,6 +7,9 @@ defmodule DpulCollectionsWeb.Features.LocaleTest do
   # Because the search button is only visible when the input is focused, we use
   # type instead of fill_in
   test "locale persists between pages", %{conn: conn} do
+    Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
+    Solr.soft_commit(active_collection())
+
     conn
     |> visit("/")
     |> assert_has("a", text: "Explore")

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -61,6 +61,14 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
                "#item-counter",
                "No items found"
              )
+
+      # There aren't any filters
+      refute view
+             |> has_element?("#filter-form")
+
+      # There's no sort dropdown
+      refute view
+             |> has_element?("#sort-form")
     end
   end
 


### PR DESCRIPTION
We still can see applied filters if there are any, probably can't get to
that state from the UI though

closes #613

before:
<img width="1944" height="716" alt="Screenshot 2025-10-15 at 4 15 36 PM" src="https://github.com/user-attachments/assets/f3aa66ac-52ff-4544-bc62-8972fa4a6da1" />


after:
<img width="1649" height="541" alt="Screenshot 2025-10-15 at 4 07 51 PM" src="https://github.com/user-attachments/assets/a4f17633-1185-44de-ad06-fd72d784b99f" />
