### PR TITLE
Move sort dropdown to the right side on a row with item count

### DIFF
--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -211,7 +211,10 @@ defmodule DpulCollectionsWeb.SearchLive do
         </.form>
       </section>
       <section class="content-area">
-        <div class="page-y-padding grid grid-flow-row auto-rows-max gap-6">
+        <div class="py-4 flex flex-row justify-between gap-4">
+          <div id="item-counter" class="place-content-center">
+            {@item_counter}
+          </div>
           <div class="flex flex-wrap gap-4">
             <form
               :if={@total_items > 0}
@@ -229,9 +232,6 @@ defmodule DpulCollectionsWeb.SearchLive do
                 )}
               </select>
             </form>
-          </div>
-          <div id="item-counter">
-            <span>{@item_counter}</span>
           </div>
         </div>
         <ul class="grid grid-flow-row auto-rows-max gap-8">


### PR DESCRIPTION
advances designs in #675


before:
<img width="1746" height="655" alt="Screenshot 2025-10-21 at 2 13 35 PM" src="https://github.com/user-attachments/assets/7f72fe6c-0aea-4ad9-b825-30c11cb8dc9b" />


after:
<img width="1650" height="662" alt="Screenshot 2025-10-21 at 2 09 59 PM" src="https://github.com/user-attachments/assets/e69f2294-010a-459a-8a37-b5def846a360" />
