### PR TITLE
Use square for item thumbnails to prevent stretching

### DIFF
--- a/lib/dpul_collections/workers/cache_thumbnails.ex
+++ b/lib/dpul_collections/workers/cache_thumbnails.ex
@@ -14,11 +14,11 @@ defmodule DpulCollections.Workers.CacheThumbnails do
   defp thumbnail_configurations do
     [
       # Small browse thumbnails
-      {"square", "100", "100"},
+      {"square", "!100", "100"},
       # Browse and search results thumbnails
-      {"square", "350", "350"},
+      {"square", "!350", "350"},
       # Item page thumbnails
-      {"square", "350", "465"}
+      {"square", "!350", "465"}
     ]
   end
 

--- a/lib/dpul_collections_web/components/browse_item.ex
+++ b/lib/dpul_collections_web/components/browse_item.ex
@@ -218,11 +218,11 @@ defmodule DpulCollectionsWeb.BrowseItem do
   end
 
   def thumbnail_url(%{thumb: thumb, thumb_num: thumb_num}) when is_number(thumb_num) do
-    "#{thumb}/square/100,100/0/default.jpg"
+    "#{thumb}/square/!100,100/0/default.jpg"
   end
 
   def thumbnail_url(%{thumb: thumb}) do
-    "#{thumb}/square/350,350/0/default.jpg"
+    "#{thumb}/square/!350,350/0/default.jpg"
   end
 
   def thumbnail_service_url(%{primary_thumbnail_service_url: thumbnail_url})

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -802,7 +802,7 @@ defmodule DpulCollectionsWeb.ItemLive do
             Helpers.obfuscate_item?(assigns) && "obfuscate",
             "thumbnail-#{@item.id}"
           ]}
-          src={"#{@thumb}/square/350,465/0/default.jpg"}
+          src={"#{@thumb}/square/!350,465/0/default.jpg"}
           alt={"image #{@thumb_num}"}
           style="
             background-color: lightgray;"

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -520,10 +520,11 @@ defmodule DpulCollectionsWeb.SearchLive do
       <img
         class={[
           "h-[125px] w-[125px] md:h-[125px] md:w-[125px] border border-solid border-gray-400",
+          "object-cover",
           Helpers.obfuscate_item?(assigns) && "obfuscate",
           "thumbnail-#{@item.id}"
         ]}
-        src={"#{@thumb}/square/350,350/0/default.jpg"}
+        src={"#{@thumb}/square/!350,350/0/default.jpg"}
         alt=""
         style="background-color: lightgray;"
         width="125"

--- a/test/dpul_collections/workers/cache_thumbnails_test.exs
+++ b/test/dpul_collections/workers/cache_thumbnails_test.exs
@@ -48,11 +48,11 @@ defmodule DpulCollections.Workers.CacheThumbnailsTest do
         # Primary thumbnail
         assert cached_paths |> Enum.member?("/iiif/2/image2/full/!453,800/0/default.jpg")
         # Item page thumbnails
-        assert cached_paths |> Enum.member?("/iiif/2/image1/square/350,465/0/default.jpg")
+        assert cached_paths |> Enum.member?("/iiif/2/image1/square/!350,465/0/default.jpg")
         # Browse and search results thumbnails
-        assert cached_paths |> Enum.member?("/iiif/2/image2/square/350,350/0/default.jpg")
+        assert cached_paths |> Enum.member?("/iiif/2/image2/square/!350,350/0/default.jpg")
         # Small browse thumbnails
-        assert cached_paths |> Enum.member?("/iiif/2/image7/square/100,100/0/default.jpg")
+        assert cached_paths |> Enum.member?("/iiif/2/image7/square/!100,100/0/default.jpg")
       end)
     end
 

--- a/test/dpul_collections_web/live/browse_live_test.exs
+++ b/test/dpul_collections_web/live/browse_live_test.exs
@@ -181,7 +181,7 @@ defmodule DpulCollectionsWeb.BrowseLiveTest do
       |> Floki.find("img.thumbnail")
       |> Floki.attribute("src")
 
-    assert src == ["https://example.com/iiif/2/image1/square/350,350/0/default.jpg"]
+    assert src == ["https://example.com/iiif/2/image1/square/!350,350/0/default.jpg"]
   end
 
   test "renders large and small thumbnails that link to records", %{conn: conn} do
@@ -212,8 +212,8 @@ defmodule DpulCollectionsWeb.BrowseLiveTest do
       |> Floki.attribute("src")
 
     assert src == [
-             "https://example.com/iiif/2/image1/square/350,350/0/default.jpg",
-             "https://example.com/iiif/2/image2/square/100,100/0/default.jpg"
+             "https://example.com/iiif/2/image1/square/!350,350/0/default.jpg",
+             "https://example.com/iiif/2/image2/square/!100,100/0/default.jpg"
            ]
 
     first_href =

--- a/test/dpul_collections_web/live/item_live_test.exs
+++ b/test/dpul_collections_web/live/item_live_test.exs
@@ -266,12 +266,12 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
       # Small thumbnails render with links to viewer
       assert view
              |> has_element?(
-               "a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/1'] img[src='https://example.com/iiif/2/image1/square/350,465/0/default.jpg']"
+               "a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/1'] img[src='https://example.com/iiif/2/image1/square/!350,465/0/default.jpg']"
              )
 
       assert view
              |> has_element?(
-               "a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/2'] img[src='https://example.com/iiif/2/image2/square/350,465/0/default.jpg']"
+               "a[href='/i/învăţămîntul-trebuie-urmărească-dez/item/1/viewer/2'] img[src='https://example.com/iiif/2/image2/square/!350,465/0/default.jpg']"
              )
 
       # Large thumbnail links to the correct image when it's not the first image

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -679,7 +679,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
 
       assert document
              |> Floki.attribute("#item-1 .small-thumbnails > :first-child > img", "src") == [
-               "https://example.com/iiif/2/image2/square/350,350/0/default.jpg"
+               "https://example.com/iiif/2/image2/square/!350,350/0/default.jpg"
              ]
 
       # Even numbered documents in test data have a thumbnail id so the order
@@ -691,7 +691,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
 
       assert document
              |> Floki.attribute("#item-2 .small-thumbnails > :first-child > img", "src") == [
-               "https://example.com/iiif/2/image1/square/350,350/0/default.jpg"
+               "https://example.com/iiif/2/image1/square/!350,350/0/default.jpg"
              ]
     end
 


### PR DESCRIPTION
Closes #858

<img width="522" height="559" alt="Screenshot 2025-10-22 at 3 03 17 PM" src="https://github.com/user-attachments/assets/c95701df-2b1e-418a-8110-26e5330e3af5" />
