### PR TITLE
Small adjustments to collection page layout

### DIFF
--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -67,7 +67,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
 
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash} content_class={}>
+    <Layouts.app flash={@flash}>
       <div class="[&>*:nth-child(odd)]:bg-background [&>*:nth-child(even)]:bg-secondary grid grid-flow-row auto-rows-max">
         <!-- Hero Section -->
         <div class="relative overflow-hidden">


### PR DESCRIPTION
- swap buttons
- remove bottom "browse" banner
- Add more padding when about area is expanded

closes #890

before:
<img width="2314" height="2844" alt="Screenshot 2025-10-29 at 14-28-41 South Asian Ephemera" src="https://github.com/user-attachments/assets/3a220b8d-101c-4c03-abcd-5c094004cab1" />


after:
<img width="2314" height="2652" alt="Screenshot 2025-10-29 at 14-29-02 South Asian Ephemera" src="https://github.com/user-attachments/assets/2b957a5e-1f12-4a0f-ab6d-3b3312c76816" />
