### PR TITLE
Use flex instead of grid for the thumbnail section of cards

### DIFF
--- a/lib/dpul_collections_web/components/browse_item.ex
+++ b/lib/dpul_collections_web/components/browse_item.ex
@@ -100,38 +100,30 @@ defmodule DpulCollectionsWeb.BrowseItem do
       <div class="-outline-offset-1 flex-grow flex flex-col">
         <!-- thumbs -->
         <div class="px-2 pt-2 bg-white overflow-clip">
-          <div class="grid grid-rows-[repeat(4, 25%)] gap-2 h-[24rem]">
-            <!-- main thumbnail, no small thumbs -->
-            <div :if={@thumb_source.file_count == 1 || !@show_small_thumbs?} class="row-span-4">
+          <div class="flex flex-col gap-2 h-[24rem]">
+            <!-- main thumbnail -->
+            <div class="min-h-0 grow">
               <.thumb
                 thumb={thumbnail_service_url(@thumb_source)}
                 item={@thumb_source}
                 show_images={@show_images}
               />
             </div>
-            
-    <!-- main and smaller thumbnails -->
-            <div :if={@show_small_thumbs?}>
-              <div :if={@thumb_source.file_count > 1} class="row-span-3 overflow-hidden h-[18rem]">
-                <.thumb
-                  thumb={thumbnail_service_url(@thumb_source)}
-                  item={@thumb_source}
-                  show_images={@show_images}
-                />
-              </div>
 
-              <div :if={@thumb_source.file_count > 1} class="grid grid-cols-4 gap-2 h-[6rem]">
-                <.thumb
-                  :for={
-                    {thumb, thumb_num} <- thumbnail_service_urls(4, @thumb_source.image_service_urls)
-                  }
-                  :if={@thumb_source.file_count}
-                  thumb={thumb}
-                  thumb_num={thumb_num}
-                  item={@thumb_source}
-                  show_images={@show_images}
-                />
-              </div>
+            <div
+              :if={@show_small_thumbs? && @thumb_source.file_count > 1}
+              class="grid grid-cols-4 gap-2 h-[6rem]"
+            >
+              <.thumb
+                :for={
+                  {thumb, thumb_num} <- thumbnail_service_urls(4, @thumb_source.image_service_urls)
+                }
+                :if={@thumb_source.file_count}
+                thumb={thumb}
+                thumb_num={thumb_num}
+                item={@thumb_source}
+                show_images={@show_images}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Simplifies the thumbnail display logic and fixes the gaps between those
sections.

Closes #901

<img width="434" height="557" alt="Screen Shot 2025-11-06 at 11 15 59 AM" src="https://github.com/user-attachments/assets/5400cc1d-863e-40d0-9f05-34176d2b377b" />
