### PR TITLE
Add version.txt file

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -59,6 +59,10 @@ jobs:
           file: Dockerfile
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            DEPLOY_BRANCH=${{ github.ref_name }}
+            DEPLOY_SHA=${{ github.sha }}
+          secret-envs: |
   container-vuln-scan:
     needs: build-and-push-image
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,12 @@ COPY lib lib
 
 COPY assets assets
 
+# Generate a version.txt file
+ARG DEPLOY_BRANCH
+ARG DEPLOY_SHA
+ARG VERSION_MESSAGE="Ref ${DEPLOY_BRANCH} (at ${DEPLOY_SHA})"
+RUN echo ${VERSION_MESSAGE} > priv/static/version.txt
+
 # Compile the release
 RUN mix compile
 

--- a/lib/dpul_collections_web.ex
+++ b/lib/dpul_collections_web.ex
@@ -17,7 +17,7 @@ defmodule DpulCollectionsWeb do
   those modules here.
   """
 
-  def static_paths, do: ~w(assets fonts images favicon.ico robots.txt)
+  def static_paths, do: ~w(assets fonts images favicon.ico robots.txt version.txt)
 
   def router do
     quote do


### PR DESCRIPTION
Closes #703 

- Instead of branch we get ref, which is "pr number/merge" and a I would guess "main" if that's what's deployed. There is no easy way to only get the simple branch name when building. This seems fine to me.
- Shows the commit hash.

https://dpul-collections-staging.lib.princeton.edu/version.txt
<img width="1132" height="248" alt="Screenshot 2025-11-07 at 7 01 33 PM" src="https://github.com/user-attachments/assets/c7833ed1-d429-44c6-8a8e-34e67c012b81" />

