### PR TITLE
Remove extra / dark focus border that only shows on buttons

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -164,9 +164,6 @@
   &:focus {
     @apply enabled:border-0;
   }
-  &:focus-visible {
-    @apply border-4;
-  }
   &:active {
     @apply outline-0 border-1 border-solid border-(--color-princeton-black);
     box-shadow: inset 0 2px 4px 0 rgb(18,18,18,0.8);
@@ -197,9 +194,6 @@
 
 @utility btn-transparent {
   @apply btn-base bg-none text-center;
-  &:focus-visible {
-    @apply border-4;
-  }
 }
 
 /* action_icon utilities */


### PR DESCRIPTION
Just use the default focus border from the browser

closes #749 


## before

<img width="450" alt="Screenshot 2025-11-12 at 12 17 42 PM" src="https://github.com/user-attachments/assets/e1c4df9c-bf66-48a9-b938-aafbb04fa247" />

<img width="300" alt="Screenshot 2025-11-12 at 12 18 38 PM" src="https://github.com/user-attachments/assets/77ca6b88-86e3-4c35-8fb6-e3c3e1dbcdeb" />

## after


<img width="450" alt="Screenshot 2025-11-12 at 12 17 30 PM" src="https://github.com/user-attachments/assets/300b2cd9-334a-4234-9b99-277725e389f6" />

<img width="300" alt="Screenshot 2025-11-12 at 12 17 11 PM" src="https://github.com/user-attachments/assets/2a8d1221-ab1d-4663-bc1d-d03f021dbc20" />
