### PR TITLE
Allow confirmation buttons to flex.

### DIFF
--- a/lib/dpul_collections_web/live/user_live/confirmation.ex
+++ b/lib/dpul_collections_web/live/user_live/confirmation.ex
@@ -31,16 +31,18 @@ defmodule DpulCollectionsWeb.UserLive.Confirmation do
             name={@form[:return_to].name}
             value={@form[:return_to].value}
           />
-          <.primary_button
-            name={@form[:remember_me].name}
-            value="true"
-            phx-disable-with="Logging in..."
-          >
-            {gettext("Keep me logged in on this device")}
-          </.primary_button>
-          <.primary_button phx-disable-with="Logging in...">
-            {gettext("Log me in only this time")}
-          </.primary_button>
+          <div class="flex flex-wrap gap-4 justify-center">
+            <.primary_button
+              name={@form[:remember_me].name}
+              value="true"
+              phx-disable-with="Logging in..."
+            >
+              {gettext("Keep me logged in on this device")}
+            </.primary_button>
+            <.primary_button phx-disable-with="Logging in...">
+              {gettext("Log me in only this time")}
+            </.primary_button>
+          </div>
         </.form>
       </div>
     </Layouts.app>


### PR DESCRIPTION
Closes #981

<img width="444" height="509" alt="Screen Shot 2025-11-19 at 1 19 45 PM" src="https://github.com/user-attachments/assets/819949a1-f1b2-4e4a-a2ea-a9e6623000e4" />
