### PR TITLE
Add missing relative class for search results links.

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -350,6 +350,7 @@
 .card {
   @apply drop-shadow-[0.25rem_0.25rem_0.25rem_var(--color-sage-300)];
   @apply hover:drop-shadow-[0_0_0.7rem_var(--color-sage-600)];
+  @apply relative;
 
   * {
     @apply no-underline;


### PR DESCRIPTION
Closes #980

Or well, it should. I don't have an iphone emulator to test with.
