### PR TITLE
Disable filter crawling for bots.

### DIFF
--- a/priv/static/robots.txt
+++ b/priv/static/robots.txt
@@ -8,3 +8,7 @@ User-agent: *
 Disallow: /search*?*filter
 # Don't index the bot challenge page, Google.
 Disallow: /challenge
+# Bots don't browse.
+Disallow: /browse?r
+# Bots can't log in.
+Disallow: /users


### PR DESCRIPTION
We can take the traffic, but preventing them from getting lost in
filters will let them find resources quicker.

From these docs:
https://developers.google.com/search/docs/crawling-indexing/crawling-managing-faceted-navigation
