### PR TITLE
Update to Debian Trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG ELIXIR_VERSION=1.18.4
 # renovate: datasource=github-tags depName=erlang packageName=erlang/otp
 ARG OTP_VERSION=27.3.4.3
 # renovate: datasource=docker depName=debian packageName=debian
-ARG DEBIAN_VERSION=bookworm-20260112-slim
+ARG DEBIAN_VERSION=trixie-20260112-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
@@ -87,7 +87,7 @@ RUN mix release
 FROM ${RUNNER_IMAGE}
 
 RUN apt-get update -y && \
-  apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates \
+  apt-get install -y libstdc++6 openssl libncurses6 locales ca-certificates \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 # Set the locale


### PR DESCRIPTION
Work towards https://github.com/pulibrary/dpul-collections/pull/821

Update debian, to see if it will enable us to upgrade nodejs.