### PR TITLE
Redirect to Collection

### DIFF
--- a/lib/dpul_collections/item.ex
+++ b/lib/dpul_collections/item.ex
@@ -201,8 +201,6 @@ defmodule DpulCollections.Item do
     |> Helpers.clean_params()
   end
 
-  def meta_properties(_item), do: %{}
-
   def meta_description([]), do: nil
 
   def meta_description([description | _rest]) do

--- a/test/dpul_collections_web/live/item_live_test.exs
+++ b/test/dpul_collections_web/live/item_live_test.exs
@@ -159,6 +159,13 @@ defmodule DpulCollectionsWeb.ItemLiveTest do
         get(conn, "/item/badid1")
       end
     end
+
+    test "/item/{:id} redirects to a collection when the id refers to an ephemera project", %{
+      conn: conn
+    } do
+      conn = get(conn, "/item/similar-to-1-is-a-project")
+      assert redirected_to(conn, 302) == "/collections/project"
+    end
   end
 
   describe "og:metadata" do


### PR DESCRIPTION
Closes #1007 

When an item url is crafted with a UUID that points to project/collection, dpul-c will redirect to collection instead of erroring.