### PR TITLE
Increase timeout for healthy_deadline and progress_deadline

### DIFF
--- a/config/deploy/production.hcl
+++ b/config/deploy/production.hcl
@@ -10,6 +10,8 @@ job "dpulc-production" {
   node_pool = "production"
   update {
     auto_revert       = true
+    healthy_deadline  = "15m"
+    progress_deadline = "20m"
   }
   priority = 55
   group "web" {

--- a/config/deploy/staging.hcl
+++ b/config/deploy/staging.hcl
@@ -10,6 +10,8 @@ job "dpulc-staging" {
   node_pool = "staging"
   update {
     auto_revert       = true
+    healthy_deadline  = "15m"
+    progress_deadline = "20m"
   }
   group "web" {
     count = 2


### PR DESCRIPTION
If the network's running slow this'll let deploys still work while the
image is pulling.

Closes #1035.
