### PR TITLE
Remove Solr 8, fully switch to Solr 9.

### DIFF
--- a/config/deploy/solr/production.json
+++ b/config/deploy/solr/production.json
@@ -1,15 +1,9 @@
 {
   "read": {
-    "base_url": "http://lib-solr8-prod.princeton.edu:8983",
+    "base_url": "http://lib-solr9-prod.princeton.edu:8983",
     "collection": "dpulc-production"
   },
   "write": [
-    {
-      "cache_version": 1,
-      "base_url": "http://lib-solr8-prod.princeton.edu:8983",
-      "collection": "dpulc-production1",
-      "config_set": "dpulc-production"
-    },
     {
       "cache_version": 2,
       "base_url": "http://lib-solr9-prod.princeton.edu:8983",


### PR DESCRIPTION
Closes #543 

This should be merged and deploy at the end of the production solr 9 runbook.