### PR TITLE
Remove Trivy, use Grype.

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -93,6 +93,7 @@ jobs:
           severity-cutoff: high
           output-format: table
           output-file: "vulnerabilities.table"
+          only-fixed: true
 
       - name: Set variables
         id: scanner

--- a/.github/workflows/nightly-vuln-scanning.yml
+++ b/.github/workflows/nightly-vuln-scanning.yml
@@ -26,6 +26,7 @@ jobs:
           severity-cutoff: high
           output-format: table
           output-file: "vulnerabilities.table"
+          only-fixed: true
       - name: Set variables
         id: scanner
         if: job.steps.runscanner.status == failure()


### PR DESCRIPTION
Trivy's had two major pipeline vulnerabilities now.
