### PR TITLE
Refactor to centralize type lists into a registry

### DIFF
--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -5,6 +5,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   alias DpulCollections.IndexingPipeline.DatabaseProducer.CacheEntryMarker
   alias DpulCollections.IndexingPipeline
   alias DpulCollections.IndexingPipeline.Figgy
+  alias DpulCollections.IndexingPipeline.Figgy.ResourceTypeRegistry
   alias DpulCollections.IndexingPipeline.DatabaseProducer
   use Broadway
 
@@ -87,13 +88,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     process(Figgy.Resource.populate_virtual(resource), cache_version)
   end
 
-  # Resource types that are indexable
-  @indexable_resource_types ["EphemeraFolder", "ScannedResource"]
-
-  @allowed_collections Figgy.Resource.allowed_collections()
-  @allowed_scanned_resources Figgy.Resource.allowed_scanned_resources()
-
-  @related_record_types ["EphemeraProject", "EphemeraBox", "EphemeraTerm", "FileSet"]
+  @indexable_resource_types ResourceTypeRegistry.indexable_types()
+  @related_record_types ResourceTypeRegistry.related_record_types()
   def process(resource, cache_version) do
     resource
     # Determine early on if we're deleting, skipping, or updating.
@@ -116,7 +112,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
 
       # Collections need to both update
       %{internal_resource: "Collection"} ->
-        if id in @allowed_collections do
+        if ResourceTypeRegistry.allowed_collection?(id) do
           {:update, resource}
         else
           {:skip, resource}
@@ -163,7 +159,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   end
 
   defp classify_open_resource(%{id: id, internal_resource: "ScannedResource"} = resource) do
-    if member_of_allowed_collection?(resource) && id in @allowed_scanned_resources do
+    if member_of_allowed_collection?(resource) &&
+         ResourceTypeRegistry.allowed_scanned_resource?(id) do
       {:update, resource}
     else
       {:skip, resource}
@@ -174,7 +171,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
 
   defp member_of_allowed_collection?(resource) do
     collection_ids = Enum.map(resource.member_of_collection_ids, & &1["id"])
-    Enum.any?(collection_ids, &(&1 in @allowed_collections))
+    Enum.any?(collection_ids, &ResourceTypeRegistry.allowed_collection?/1)
   end
 
   # If we got a list of them, enrich each one.

--- a/lib/dpul_collections/indexing_pipeline/figgy/resource.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/resource.ex
@@ -6,6 +6,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.Resource do
   alias DpulCollections.IndexingPipeline.DatabaseProducer.CacheEntryMarker
   alias DpulCollections.IndexingPipeline
   alias DpulCollections.IndexingPipeline.Figgy
+  alias DpulCollections.IndexingPipeline.Figgy.ResourceTypeRegistry
   @derive {Jason.Encoder, except: [:__meta__]}
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -23,20 +24,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.Resource do
     field :metadata_resource_id, {:array, :map}, virtual: true
     field :metadata_resource_type, {:array, :string}, virtual: true
   end
-
-  @allowed_collections [
-    # Islamic Manuscripts
-    "52abe8f7-e2a1-46e9-9d13-3dc4fbc0bf0a"
-  ]
-
-  # While we work on integrating scanned resources, we only want to index
-  # specific resources. We will remove this restriction later.
-  @allowed_scanned_resources [
-    "27fd4d29-1170-47a5-891b-f2743873bcef"
-  ]
-
-  def allowed_collections, do: @allowed_collections
-  def allowed_scanned_resources, do: @allowed_scanned_resources
 
   @type related_data() :: %{optional(field_name :: String.t()) => related_resource_map()}
   @type related_resource_map() :: %{
@@ -232,7 +219,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.Resource do
     collections =
       member_of_collection_ids
       |> Enum.map(&extract_ids_from_value/1)
-      |> Enum.filter(&(&1 in @allowed_collections))
+      |> Enum.filter(&ResourceTypeRegistry.allowed_collection?/1)
       |> IndexingPipeline.get_figgy_resources()
 
     Enum.reduce(collections, resource_map, fn col, acc ->

--- a/lib/dpul_collections/indexing_pipeline/figgy/resource_type_registry.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/resource_type_registry.ex
@@ -1,0 +1,28 @@
+defmodule DpulCollections.IndexingPipeline.Figgy.ResourceTypeRegistry do
+  @moduledoc """
+  Registry for the Figgy resource types that the pipeline handles
+  """
+
+  # Primary item resource types
+  @indexable_types ["EphemeraFolder", "ScannedResource"]
+
+  # Types of resources that behave as collections
+  @collection_types ["EphemeraProject", "Collection"]
+
+  # Types that trigger re-indexing of related records
+  @related_record_types ["EphemeraProject", "EphemeraBox", "EphemeraTerm", "FileSet"]
+
+  # Types used in the transformation pipeline
+  @transformable_types @indexable_types ++ @collection_types
+
+  # Temporary restrictions to allow gradual ingest of different types
+  @allowed_collections ["52abe8f7-e2a1-46e9-9d13-3dc4fbc0bf0a"]
+  @allowed_scanned_resources ["27fd4d29-1170-47a5-891b-f2743873bcef"]
+
+  def indexable_types, do: @indexable_types
+  def collection_types, do: @collection_types
+  def related_record_types, do: @related_record_types
+  def transformable_types, do: @transformable_types
+  def allowed_collection?(id), do: id in @allowed_collections
+  def allowed_scanned_resource?(id), do: id in @allowed_scanned_resources
+end

--- a/lib/dpul_collections/indexing_pipeline/figgy/transformation_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/transformation_consumer.ex
@@ -4,6 +4,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationConsumer do
   them into Solr documents, and caches them in a database.
   """
   alias DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntry
+  alias DpulCollections.IndexingPipeline.Figgy.ResourceTypeRegistry
   alias DpulCollections.IndexingPipeline
   alias DpulCollections.IndexingPipeline.Figgy
   alias DpulCollections.IndexingPipeline.DatabaseProducer
@@ -88,12 +89,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationConsumer do
     )
   end
 
-  @transformable_resource_types [
-    "EphemeraFolder",
-    "EphemeraProject",
-    "ScannedResource",
-    "Collection"
-  ]
+  @transformable_resource_types ResourceTypeRegistry.transformable_types()
 
   def initial_classification(
         resource = %HydrationCacheEntry{data: %{"internal_resource" => internal_resource}},

--- a/test/dpul_collections/indexing_pipeline/figgy/resource_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/resource_test.exs
@@ -16,20 +16,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.ResourceTest do
     end
   end
 
-  describe "allowed lists" do
-    test "allowed_collections returns the allowed collection IDs" do
-      assert Figgy.Resource.allowed_collections() == [
-               "52abe8f7-e2a1-46e9-9d13-3dc4fbc0bf0a"
-             ]
-    end
-
-    test "allowed_scanned_resources returns the allowed scanned resource IDs" do
-      assert Figgy.Resource.allowed_scanned_resources() == [
-               "27fd4d29-1170-47a5-891b-f2743873bcef"
-             ]
-    end
-  end
-
   describe ".to_combined()" do
     test "it grabs vocabularies/categories into related_data" do
       folder = IndexingPipeline.get_figgy_resource!("26713a31-d615-49fd-adfc-93770b4f66b3")

--- a/test/dpul_collections/indexing_pipeline/figgy/resource_type_registry_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/resource_type_registry_test.exs
@@ -1,0 +1,38 @@
+defmodule DpulCollections.IndexingPipeline.Figgy.ResourceTypeRegistryTest do
+  use ExUnit.Case, async: true
+  alias DpulCollections.IndexingPipeline.Figgy.ResourceTypeRegistry
+
+  describe "indexable types" do
+    test "indexable_types returns a list" do
+      assert ResourceTypeRegistry.indexable_types() == ["EphemeraFolder", "ScannedResource"]
+    end
+  end
+
+  describe "collection types" do
+    test "collection_types returns the list" do
+      assert ResourceTypeRegistry.collection_types() == ["EphemeraProject", "Collection"]
+    end
+  end
+
+  describe "related record types" do
+    test "related_record_types returns a list" do
+      assert ResourceTypeRegistry.related_record_types() == [
+               "EphemeraProject",
+               "EphemeraBox",
+               "EphemeraTerm",
+               "FileSet"
+             ]
+    end
+  end
+
+  describe "transformable types" do
+    test "transformable_types returns a list" do
+      assert ResourceTypeRegistry.transformable_types() == [
+               "EphemeraFolder",
+               "ScannedResource",
+               "EphemeraProject",
+               "Collection"
+             ]
+    end
+  end
+end


### PR DESCRIPTION
Creates a registry module to set the types of Figgy resources our pipeline uses during the indexing process. The aim to work towards consolidating bits of logic that are spread through different modules in the pipeline that make adding new resource types difficult.