### PR TITLE
Prevent feature tests flaking

### DIFF
--- a/test/dpul_collections_web/features/browse_test.exs
+++ b/test/dpul_collections_web/features/browse_test.exs
@@ -20,6 +20,7 @@ defmodule DpulCollectionsWeb.BrowseTest do
       conn =
         conn
         |> visit("/browse?r=0")
+        |> assert_has(".phx-connected")
         |> click_button(".browse-item:first-child a", "Save")
         |> fill_in("Email", with: user.email)
         |> click_button("Log in with email")
@@ -33,6 +34,7 @@ defmodule DpulCollectionsWeb.BrowseTest do
 
       conn
       |> visit(path)
+      |> assert_has(".phx-connected")
       |> assert_has("h1", text: "Welcome")
       |> click_button("Log me in only this time")
       # Now we should be back at browse
@@ -51,6 +53,7 @@ defmodule DpulCollectionsWeb.BrowseTest do
       conn
       |> FiggyTestSupport.feature_login(user)
       |> visit("/browse?r=0")
+      |> assert_has(".phx-connected")
       |> click_button(".browse-item:first-child button", "Save")
       |> assert_has("h2", text: "Save to Set")
       |> click_button("Create new set")
@@ -88,6 +91,7 @@ defmodule DpulCollectionsWeb.BrowseTest do
 
     conn
     |> visit("/browse?r=0")
+    |> assert_has(".phx-connected")
     |> unwrap(&TestUtils.assert_a11y/1)
   end
 

--- a/test/dpul_collections_web/features/collection_test.exs
+++ b/test/dpul_collections_web/features/collection_test.exs
@@ -42,6 +42,7 @@ defmodule DpulCollectionsWeb.Features.CollectionViewTest do
     test "it has content for the collection", %{conn: conn} do
       conn
       |> visit("/collections/sae")
+      |> assert_has(".phx-connected")
       # Title
       |> assert_has("h1", text: "South Asian Ephemera")
       # Subject summary
@@ -93,6 +94,7 @@ defmodule DpulCollectionsWeb.Features.CollectionViewTest do
     test "it links to filtered search result sets", %{conn: conn} do
       conn
       |> visit("/collections/sae")
+      |> assert_has(".phx-connected")
       |> click_link("Politics and government")
       |> assert_has("h1", text: "Search Results")
       |> assert_has("button.category", text: "Politics and government")
@@ -102,6 +104,7 @@ defmodule DpulCollectionsWeb.Features.CollectionViewTest do
     test "a collection without contributors still displays copyright policy", %{conn: conn} do
       conn
       |> visit("/collections/soviet_posters")
+      |> assert_has(".phx-connected")
       # Title
       |> assert_has("h1", text: "Russian")
       # Contributors
@@ -119,6 +122,7 @@ defmodule DpulCollectionsWeb.Features.CollectionViewTest do
     test "collection page is accessible", %{conn: conn} do
       conn
       |> visit("/collections/sae")
+      |> assert_has(".phx-connected")
       |> unwrap(&TestUtils.assert_a11y/1)
     end
   end
@@ -127,6 +131,7 @@ defmodule DpulCollectionsWeb.Features.CollectionViewTest do
     test "it has content for the collection", %{conn: conn} do
       conn
       |> visit("/collections/islamicmss")
+      |> assert_has(".phx-connected")
       # Title
       |> assert_has("h1", text: "Manuscripts of the Islamic World")
       # Subject summary

--- a/test/dpul_collections_web/features/content_warnings_test.exs
+++ b/test/dpul_collections_web/features/content_warnings_test.exs
@@ -36,6 +36,7 @@ defmodule DpulCollectionsWeb.Features.ContentWarningsTest do
     test "on the home page", %{conn: conn} do
       conn
       |> visit("/")
+      |> assert_has(".phx-connected")
       |> assert_has("img.obfuscate", count: 3)
       |> click_link("Why are the images blurred?")
       |> click_button("View content")
@@ -47,11 +48,13 @@ defmodule DpulCollectionsWeb.Features.ContentWarningsTest do
       # an item without a content warning isn't obfuscated
       conn
       |> visit("/search?q=Document")
+      |> assert_has(".phx-connected")
       |> refute_has("img.obfuscate")
 
       # an item with a content warning is obfuscated
       conn
       |> visit("/search?q=elham+azar")
+      |> assert_has(".phx-connected")
       |> assert_has(".thumbnail-d4292e58-25d7-4247-bf92-0a5e24ec75d1", count: 3)
       |> assert_has("img.obfuscate", count: 3)
       |> click_link("Why are the images blurred?")
@@ -62,6 +65,7 @@ defmodule DpulCollectionsWeb.Features.ContentWarningsTest do
     test "on the standard browse page", %{conn: conn} do
       conn
       |> visit("/browse")
+      |> assert_has(".phx-connected")
       |> assert_has(".thumbnail-d4292e58-25d7-4247-bf92-0a5e24ec75d1", count: 3)
       |> assert_has("img.obfuscate", count: 3)
       |> click_link("Why are the images blurred?")
@@ -72,6 +76,7 @@ defmodule DpulCollectionsWeb.Features.ContentWarningsTest do
     test "on the focused browse page", %{conn: conn} do
       conn
       |> visit("/browse/focus/d4292e58-25d7-4247-bf92-0a5e24ec75d1")
+      |> assert_has(".phx-connected")
       # the tiny thumbnail in the toolbar is also obfuscated
       |> assert_has(".thumbnail-d4292e58-25d7-4247-bf92-0a5e24ec75d1", count: 4)
       |> assert_has("img.obfuscate", count: 4)
@@ -108,6 +113,7 @@ defmodule DpulCollectionsWeb.Features.ContentWarningsTest do
 
       conn
       |> visit("/item/d4292e58-25d7-4247-bf92-0a5e24ec75d1")
+      |> assert_has(".phx-connected")
       # the large thumbnail is duplicated in the small thumbnail list
       |> assert_has("img.thumbnail-d4292e58-25d7-4247-bf92-0a5e24ec75d1.obfuscate", count: 4)
       |> click_link(
@@ -132,6 +138,7 @@ defmodule DpulCollectionsWeb.Features.ContentWarningsTest do
     test "in the viewer", %{conn: conn} do
       conn
       |> visit("/item/d4292e58-25d7-4247-bf92-0a5e24ec75d1")
+      |> assert_has(".phx-connected")
       |> click_link("#viewer-link", "Look closer")
       # the large thumbnail is duplicated in the small thumbnail list
       |> assert_has("h2", text: "Content Warning")
@@ -144,6 +151,7 @@ defmodule DpulCollectionsWeb.Features.ContentWarningsTest do
     test "they are still shown after reload, and on other pages", %{conn: conn} do
       conn
       |> visit("/search?q=elham+azar")
+      |> assert_has(".phx-connected")
       |> assert_has("img.obfuscate")
       |> click_link("Why are the images blurred?")
       |> click_button("View content")
@@ -151,10 +159,13 @@ defmodule DpulCollectionsWeb.Features.ContentWarningsTest do
       |> unwrap(&Frame.evaluate(&1.frame_id, "window.location.reload()"))
       |> refute_has("img.obfuscate")
       |> visit("/item/d4292e58-25d7-4247-bf92-0a5e24ec75d1")
+      |> assert_has(".phx-connected")
       |> refute_has("img.obfuscate")
       |> visit("/browse")
+      |> assert_has(".phx-connected")
       |> refute_has("img.obfuscate")
       |> visit("/browse/focus/d4292e58-25d7-4247-bf92-0a5e24ec75d1")
+      |> assert_has(".phx-connected")
       |> refute_has("img.obfuscate")
     end
   end

--- a/test/dpul_collections_web/features/home_test.exs
+++ b/test/dpul_collections_web/features/home_test.exs
@@ -9,6 +9,7 @@ defmodule DpulCollectionsWeb.Features.HomeTest do
 
     conn
     |> visit("/")
+    |> assert_has(".phx-connected")
     |> assert_has("a", text: "Explore")
     |> unwrap(&TestUtils.assert_a11y/1)
   end
@@ -16,6 +17,7 @@ defmodule DpulCollectionsWeb.Features.HomeTest do
   test "site title is not shown in header, page has it in h1", %{conn: conn} do
     conn
     |> visit("/")
+    |> assert_has(".phx-connected")
     |> refute_has("header", text: "Digital Collections")
     |> assert_has("h1", text: "Digital Collections")
     |> click_link("pamphlets")

--- a/test/dpul_collections_web/features/item_test.exs
+++ b/test/dpul_collections_web/features/item_test.exs
@@ -25,6 +25,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
     test "clicking the share button works", %{conn: conn} do
       conn
       |> visit("/i/document-1/item/1")
+      |> assert_has(".phx-connected")
       |> stub_clipboard
       |> refute_has("#share-modal")
       # opens the modal
@@ -44,6 +45,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
     test "item metdata pane can copy manifest url", %{conn: conn, sham: sham} do
       conn
       |> visit("/i/document1/item/1/metadata")
+      |> assert_has(".phx-connected")
       |> stub_clipboard
       |> assert_has("#iiif-url", text: "http://localhost:#{sham.port}/manifest/1/manifest")
       |> click_button("Copy")
@@ -53,6 +55,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
     test "viewer pane can copy current url", %{conn: conn} do
       conn
       |> visit("/i/document1/item/1/viewer/1")
+      |> assert_has(".phx-connected")
       |> stub_clipboard
       |> assert_has("h1", text: "Viewer")
       |> assert_has("title", text: "Viewer")
@@ -94,6 +97,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
     test "the 2 copy buttons don't interact", %{conn: conn} do
       conn
       |> visit("/i/document-1/item/1")
+      |> assert_has(".phx-connected")
       |> stub_clipboard
       # use share copy button
       |> click_button("Share")
@@ -114,6 +118,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
   test "links to and from metadata page", %{conn: conn} do
     conn
     |> visit("/i/document1/item/1")
+    |> assert_has(".phx-connected")
     |> click_link("View all metadata for this item")
     |> assert_path("/i/document1/item/1/metadata")
     |> click_link("close pane")
@@ -123,6 +128,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
   test "links to and from viewer page", %{conn: conn} do
     conn
     |> visit("/i/document1/item/1")
+    |> assert_has(".phx-connected")
     |> click_link("#viewer-link", "Look closer")
     |> assert_path("/i/document1/item/1/viewer/1")
     |> click_link("close pane")
@@ -132,6 +138,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
   test "the metadata pane is not part of browser history", %{conn: conn} do
     conn
     |> visit("/search")
+    |> assert_has(".phx-connected")
     |> click_link("Document-1")
     |> click_link("View all metadata for this item")
     |> assert_path("/i/document1/item/1/metadata")
@@ -144,6 +151,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
   test "the viewer pane is not part of browser history", %{conn: conn} do
     conn
     |> visit("/search")
+    |> assert_has(".phx-connected")
     |> click_link("Document-1")
     |> click_link("#viewer-link", "Look closer")
     |> assert_path("/i/document1/item/1/viewer/1")
@@ -156,6 +164,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
   test "the viewer pane changes the URL when clicking a new item", %{conn: conn} do
     conn
     |> visit("/item/1")
+    |> assert_has(".phx-connected")
     |> click_link("#viewer-link", "Look closer")
     |> assert_path("/i/document1/item/1/viewer/1")
     |> click_button("figcaption", "2")
@@ -164,24 +173,28 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
     # It defaults to the first page Clover opens if not given one.
     conn
     |> visit("/i/document/item/1/viewer")
+    |> assert_has(".phx-connected")
     |> assert_path("/i/document1/item/1/viewer/1")
   end
 
   test "item page is accessible", %{conn: conn} do
     conn
     |> visit("/i/document-1/item/1")
+    |> assert_has(".phx-connected")
     |> unwrap(&TestUtils.assert_a11y/1)
   end
 
   test "metadata page is accessible", %{conn: conn} do
     conn
     |> visit("/i/document1/item/1/metadata")
+    |> assert_has(".phx-connected")
     |> unwrap(&TestUtils.assert_a11y/1)
   end
 
   test "viewer page is accessible", %{conn: conn} do
     conn
     |> visit("/i/document1/item/1/viewer/1")
+    |> assert_has(".phx-connected")
     |> unwrap(&TestUtils.assert_a11y(&1, CloverFilter))
   end
 
@@ -202,6 +215,7 @@ defmodule DpulCollectionsWeb.Features.ItemViewTest do
 
     conn
     |> visit("/i/document-1/item/1")
+    |> assert_has(".phx-connected")
     |> within("#related-different-collection", fn session ->
       session
       |> assert_has(".card")

--- a/test/dpul_collections_web/features/locale_test.exs
+++ b/test/dpul_collections_web/features/locale_test.exs
@@ -12,6 +12,7 @@ defmodule DpulCollectionsWeb.Features.LocaleTest do
 
     conn
     |> visit("/")
+    |> assert_has(".phx-connected")
     |> assert_has("a", text: "Explore")
     |> click_button("Language")
     |> click_link("Español")
@@ -26,6 +27,7 @@ defmodule DpulCollectionsWeb.Features.LocaleTest do
   test "the language dropdown is accessible", %{conn: conn} do
     conn
     |> visit("/")
+    |> assert_has(".phx-connected")
     |> assert_has("#language-nav button[aria-expanded='false']")
     |> refute_has("#language-menu a li")
     |> click_button("Language")
@@ -49,6 +51,7 @@ defmodule DpulCollectionsWeb.Features.LocaleTest do
 
     conn
     |> visit("/")
+    |> assert_has(".phx-connected")
     |> assert_has("#browse-item-9", text: "Updated 3 months ago")
     |> click_button("Language")
     |> click_link("Español")

--- a/test/dpul_collections_web/features/login_test.exs
+++ b/test/dpul_collections_web/features/login_test.exs
@@ -11,11 +11,13 @@ defmodule DpulCollectionsWeb.LoginTest do
 
     conn
     |> visit("/")
+    |> assert_has(".phx-connected")
     |> click_button("My Account")
     |> click_link("Log in")
     |> fill_in("Email", with: user.email)
     |> click_button("Log in with email")
     |> visit("/users/log-in/#{generate_user_magic_link_token(user) |> elem(0)}")
+    |> assert_has(".phx-connected")
     |> click_button("Keep me logged in on this device")
     # wait until flash has loaded
     |> assert_has("#flash-info", text: "Success")
@@ -29,6 +31,7 @@ defmodule DpulCollectionsWeb.LoginTest do
     out =
       conn
       |> visit("/")
+      |> assert_has(".phx-connected")
       |> click_button("My Account")
       |> click_link("Log in")
       |> fill_in("Email", with: "test@example.com")
@@ -41,6 +44,7 @@ defmodule DpulCollectionsWeb.LoginTest do
 
     out
     |> visit("/users/log-in/#{generate_user_magic_link_token(user) |> elem(0)}")
+    |> assert_has(".phx-connected")
     |> click_button("Log me in only this time")
     # wait until flash has loaded
     |> assert_has("#flash-info", text: "Success")
@@ -55,6 +59,7 @@ defmodule DpulCollectionsWeb.LoginTest do
     conn
     |> FiggyTestSupport.feature_login(user)
     |> visit("/")
+    |> assert_has(".phx-connected")
     |> click_button("My Account")
     |> assert_has("a", text: "Log out")
   end

--- a/test/dpul_collections_web/features/search_bar_test.exs
+++ b/test/dpul_collections_web/features/search_bar_test.exs
@@ -16,6 +16,7 @@ defmodule DpulCollectionsWeb.Features.SearchBarTest do
     test "submitting a search returns results", %{conn: conn} do
       conn
       |> visit("/search")
+      |> assert_has(".phx-connected")
       |> assert_has("#search-button", text: "Search", exact: true)
       |> refute_has("#collection-search-button")
       |> fill_in("Search", with: "Document-3")
@@ -28,6 +29,7 @@ defmodule DpulCollectionsWeb.Features.SearchBarTest do
     test "submitting a search brings you to the results page", %{conn: conn} do
       conn
       |> visit("/")
+      |> assert_has(".phx-connected")
       |> fill_in("Search", with: "Document-3")
       |> click_button("Search")
       |> assert_has("#item-counter", text: "1 - 1 of 1")
@@ -38,6 +40,7 @@ defmodule DpulCollectionsWeb.Features.SearchBarTest do
     test "submitting a search filters to that collection", %{conn: conn} do
       conn
       |> visit("/collections/sae")
+      |> assert_has(".phx-connected")
       |> assert_has("#search-button", text: "Search all", exact: true)
       |> assert_has("#collection-search-button")
       |> click_button("Search in this Collection")

--- a/test/dpul_collections_web/features/search_test.exs
+++ b/test/dpul_collections_web/features/search_test.exs
@@ -9,6 +9,7 @@ defmodule DpulCollectionsWeb.Features.SearchTest do
 
     conn
     |> visit("/search?q=")
+    |> assert_has(".phx-connected")
     |> click_button("Filters")
     |> click_button("Format")
     |> assert_has("label", text: "Pamphlets")
@@ -26,6 +27,7 @@ defmodule DpulCollectionsWeb.Features.SearchTest do
 
     conn
     |> visit("/search?q=")
+    |> assert_has(".phx-connected")
     |> unwrap(&TestUtils.assert_a11y/1)
     |> click_button("Filters")
     |> click_button("Format")
@@ -66,6 +68,7 @@ defmodule DpulCollectionsWeb.Features.SearchTest do
 
     conn
     |> visit("/search?q=")
+    |> assert_has(".phx-connected")
     # when filecount exceeds visible images show image total
     |> assert_has("#item-1", text: "Document-1")
     # when visible images equals filecount don't show image total


### PR DESCRIPTION
Discovered locally -- if a feature test executes an action before the liveview socket is connected, nothing happens and the next assertion will fail.

liveview adds this class to the liveview's div when it is finished connecting. Check for it after each visit.