### PR TITLE
Retain filters and sort_by when a new search query is submitted

### DIFF
--- a/lib/dpul_collections_web/components/layouts.ex
+++ b/lib/dpul_collections_web/components/layouts.ex
@@ -20,6 +20,7 @@ defmodule DpulCollectionsWeb.Layouts do
     doc: "the current [scope](https://hexdocs.pm/phoenix/scopes.html)"
 
   attr :collection_title, :string, default: ""
+  attr :search_state, :map, default: %{}
 
   attr :content_class, :list, default: ["bg-background", "page-y-padding"]
   attr :display_title, :boolean, default: true
@@ -36,6 +37,7 @@ defmodule DpulCollectionsWeb.Layouts do
           module={DpulCollectionsWeb.SearchBarComponent}
           id="search-bar"
           collection_title={@collection_title}
+          search_state={@search_state}
         />
         <main id="main-content" class={@content_class}>
           <.flash_group flash={@flash} />

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -4,6 +4,7 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
   alias DpulCollectionsWeb.Live.Helpers
 
   attr :collection_title, :string, default: ""
+  attr :search_state, :map, default: %{}
 
   def render(assigns) do
     ~H"""
@@ -11,6 +12,18 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
       <div class="search-browse-container min-h-10 flex flex-wrap bg-search">
         <div class="search-box header-x-padding grow w-full">
           <form id="search-form" class="group w-full h-full" phx-submit="search" phx-target={@myself}>
+
+            <.input
+              :if={Enum.any?(@search_state)}
+              type="hidden"
+              name="applied_filters"
+              value={JSON.encode!(@search_state.filter)} />
+
+            <.input
+              :if={Enum.any?(@search_state)}
+              type="hidden"
+              name="search_state"
+              value={JSON.encode!(@search_state)} />
             <div
               class={[
                 "flex items-center w-full h-full",
@@ -68,8 +81,9 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
     """
   end
 
-  def handle_event("search", %{"search" => "all", "q" => q}, socket) do
-    params = %{q: q} |> Helpers.clean_params()
+  def handle_event("search", params = %{"search" => "all", "q" => q}, socket) do
+    filters = %{filter: params["applied_filters"] |> JSON.decode!()}
+    params = %{q: q} |> Helpers.clean_params() |> Map.merge(filters)
     socket = push_navigate(socket, to: ~p"/search?#{params}")
     {:noreply, socket}
   end

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -12,18 +12,12 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
       <div class="search-browse-container min-h-10 flex flex-wrap bg-search">
         <div class="search-box header-x-padding grow w-full">
           <form id="search-form" class="group w-full h-full" phx-submit="search" phx-target={@myself}>
-
-            <.input
-              :if={Enum.any?(@search_state)}
-              type="hidden"
-              name="applied_filters"
-              value={JSON.encode!(@search_state.filter)} />
-
             <.input
               :if={Enum.any?(@search_state)}
               type="hidden"
               name="search_state"
-              value={JSON.encode!(@search_state)} />
+              value={JSON.encode!(@search_state)}
+            />
             <div
               class={[
                 "flex items-center w-full h-full",
@@ -82,7 +76,8 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
   end
 
   def handle_event("search", params = %{"search" => "all", "q" => q}, socket) do
-    filters = %{filter: params["applied_filters"] |> JSON.decode!()}
+    search_state = params["search_state"] |> JSON.decode!()
+    filters = Map.take(search_state, ["filter", "sort_by"])
     params = %{q: q} |> Helpers.clean_params() |> Map.merge(filters)
     socket = push_navigate(socket, to: ~p"/search?#{params}")
     {:noreply, socket}

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -75,14 +75,25 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
     """
   end
 
-  def handle_event("search", params = %{"search" => "all", "q" => q}, socket) do
-    search_state = params["search_state"] |> JSON.decode!()
-    filters = Map.take(search_state, ["filter", "sort_by"])
+  # Search from results page
+  def handle_event("search", %{"search_state" => search_state, "search" => "all", "q" => q}, socket) do
+    filters =
+      search_state
+      |> JSON.decode!()
+      |> Map.take(["filter", "sort_by"])
     params = %{q: q} |> Helpers.clean_params() |> Map.merge(filters)
     socket = push_navigate(socket, to: ~p"/search?#{params}")
     {:noreply, socket}
   end
 
+  # Brand-new search
+  def handle_event("search", %{"search" => "all", "q" => q}, socket) do
+    params = %{q: q} |> Helpers.clean_params()
+    socket = push_navigate(socket, to: ~p"/search?#{params}")
+    {:noreply, socket}
+  end
+
+  # Search within collection
   def handle_event("search", %{"search" => collection_title, "q" => q}, socket) do
     params = %{q: q, filter: %{collection: [collection_title]}} |> Helpers.clean_params()
     socket = push_navigate(socket, to: ~p"/search?#{params}")

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -76,11 +76,16 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
   end
 
   # Search from results page
-  def handle_event("search", %{"search_state" => search_state, "search" => "all", "q" => q}, socket) do
+  def handle_event(
+        "search",
+        %{"search_state" => search_state, "search" => "all", "q" => q},
+        socket
+      ) do
     filters =
       search_state
       |> JSON.decode!()
       |> Map.take(["filter", "sort_by"])
+
     params = %{q: q} |> Helpers.clean_params() |> Map.merge(filters)
     socket = push_navigate(socket, to: ~p"/search?#{params}")
     {:noreply, socket}

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -112,7 +112,7 @@ defmodule DpulCollectionsWeb.SearchLive do
 
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash} current_scope={@current_scope}>
+    <Layouts.app flash={@flash} current_scope={@current_scope} search_state={@search_state}>
       <div class="content-area page-b-padding">
         <.results_for_keywords_heading keywords={@search_state.q} />
       </div>

--- a/test/dpul_collections_web/features/search_bar_test.exs
+++ b/test/dpul_collections_web/features/search_bar_test.exs
@@ -32,6 +32,7 @@ defmodule DpulCollectionsWeb.Features.SearchBarTest do
       |> assert_has(".phx-connected")
       |> fill_in("Search", with: "Document-3")
       |> click_button("Search")
+      |> assert_has("h1 span", text: "Document-3")
       |> assert_has("#item-counter", text: "1 - 1 of 1")
     end
   end

--- a/test/dpul_collections_web/features/search_bar_test.exs
+++ b/test/dpul_collections_web/features/search_bar_test.exs
@@ -47,10 +47,4 @@ defmodule DpulCollectionsWeb.Features.SearchBarTest do
       |> assert_has("section#filters", text: "Collection South Asian Ephemera")
     end
   end
-
-  test "search results page is accessible", %{conn: conn} do
-    conn
-    |> visit("/search?q=Document-3")
-    |> unwrap(&TestUtils.assert_a11y/1)
-  end
 end

--- a/test/dpul_collections_web/features/search_test.exs
+++ b/test/dpul_collections_web/features/search_test.exs
@@ -74,4 +74,18 @@ defmodule DpulCollectionsWeb.Features.SearchTest do
     # when visible images equals filecount don't show image total
     |> assert_has("#filecount-1", text: "8 Files")
   end
+
+  test "filters are retained when adding a keyword", %{conn: conn} do
+    Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
+    Solr.soft_commit(active_collection())
+
+    conn
+    |> visit("/search?filter[format][]=Pamphlets")
+    |> assert_has(".phx-connected")
+    |> fill_in("Search", with: "Document-3")
+    |> click_button("Search")
+    |> assert_path("/search", query_params: %{q: "Document-3", filter: %{format: ["Pamphlets"]}})
+    |> assert_has("h1 span", text: "Document-3")
+    |> assert_has(".filter.format")
+  end
 end

--- a/test/dpul_collections_web/features/search_test.exs
+++ b/test/dpul_collections_web/features/search_test.exs
@@ -84,8 +84,49 @@ defmodule DpulCollectionsWeb.Features.SearchTest do
     |> assert_has(".phx-connected")
     |> fill_in("Search", with: "Document-3")
     |> click_button("Search")
-    |> assert_path("/search", query_params: %{q: "Document-3", filter: %{format: ["Pamphlets"]}})
+    |> assert_path("/search",
+      query_params: %{q: "Document-3", filter: %{format: ["Pamphlets"]}, sort_by: "relevance"}
+    )
     |> assert_has("h1 span", text: "Document-3")
     |> assert_has(".filter.format")
+  end
+
+  test "sort_by is retained when adding a keyword", %{conn: conn} do
+    Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
+    Solr.soft_commit(active_collection())
+
+    conn
+    |> visit("/search?sort_by=date_asc")
+    |> assert_has(".phx-connected")
+    |> fill_in("Search", with: "Document-3")
+    |> click_button("Search")
+    |> assert_path("/search", query_params: %{q: "Document-3", sort_by: "date_asc"})
+  end
+
+  test "both filters and sort_by are retained when adding a keyword", %{conn: conn} do
+    Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
+    Solr.soft_commit(active_collection())
+
+    conn
+    |> visit("/search?filter[format][]=Pamphlets&sort_by=date_asc")
+    |> assert_has(".phx-connected")
+    |> fill_in("Search", with: "Document-3")
+    |> click_button("Search")
+    |> assert_path("/search",
+      query_params: %{q: "Document-3", sort_by: "date_asc", filter: %{format: ["Pamphlets"]}}
+    )
+  end
+
+  test "successfully submit a new search when no filtering has been done", %{conn: conn} do
+    Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
+    Solr.soft_commit(active_collection())
+
+    conn
+    |> visit("/search?q=Document-1")
+    |> assert_has(".phx-connected")
+    |> fill_in("Search", with: "Document-3")
+    |> click_button("Search")
+    |> assert_path("/search", query_params: %{q: "Document-3", sort_by: "relevance"})
+    |> assert_has("h1 span", text: "Document-3")
   end
 end

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -423,7 +423,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
            |> Floki.text() =~ "1 - 50 of 210"
   end
 
-  test "changing query parameter resets sort_by to default", %{conn: conn} do
+  test "changing query parameter keeps selected sort_by", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/search")
 
     view |> render_click("sort", %{"sort-by" => "date_asc"})
@@ -433,7 +433,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
     |> element("#search-form")
     |> render_submit(%{"search" => "all", "q" => "Document"})
 
-    assert_redirected(view, "/search?q=Document")
+    assert_redirected(view, "/search?q=Document&sort_by=date_asc")
   end
 
   test "when sorting by date, a nil date always sorts last", %{conn: conn} do


### PR DESCRIPTION
- **Remove duplicate accessibility test**
- **Pass search state to search bar component to retain filters**
- **Ensure sort_by is retained when new search query submitted**
- **Fix tests**
