### PR TITLE
Proposal: Adjust home page filters to have manuscripts & digital collections

### DIFF
--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -42,11 +42,11 @@ defmodule DpulCollectionsWeb.HomeLive do
                 )}
               </div>
               <div class="flex flex-wrap justify-center text-dark-text gap-2">
+                <.format_link filter="digital collection" label={gettext("Digital Collections")} />
                 <.format_link filter="posters" label={gettext("Posters")} />
                 <.format_link filter="pamphlets" label={gettext("Pamphlets")} />
                 <.format_link filter="flyers" label={gettext("Flyers")} />
-                <.format_link filter="leaflets" label={gettext("Leaflets")} />
-                <.format_link filter="photographs" label={gettext("Photographs")} />
+                <.format_link filter="manuscripts" label={gettext("Manuscripts")} />
               </div>
               <div class="content-area bg-primary text-light-text px-0 text-xl">
                 <.primary_button href={~p"/browse"}>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -21,9 +21,9 @@ msgstr ""
 msgid "Hang in there while we get back on track"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:25
-#: lib/dpul_collections_web/components/search_bar_component.ex:31
-#: lib/dpul_collections_web/components/search_bar_component.ex:85
+#: lib/dpul_collections_web/components/search_bar_component.ex:32
+#: lib/dpul_collections_web/components/search_bar_component.ex:38
+#: lib/dpul_collections_web/components/search_bar_component.ex:110
 #: lib/dpul_collections_web/live/search_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Search"
@@ -148,6 +148,7 @@ msgstr ""
 
 #: lib/dpul_collections_web/components/header_component.ex:40
 #: lib/dpul_collections_web/live/home_live.ex:36
+#: lib/dpul_collections_web/live/home_live.ex:45
 #: lib/dpul_collections_web/live/item_live.ex:999
 #: lib/dpul_collections_web/live/item_live.ex:1000
 #: lib/dpul_collections_web/live/item_live.ex:1001
@@ -643,14 +644,9 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:47
-#, elixir-autogen, elixir-format
-msgid "Flyers"
-msgstr ""
-
 #: lib/dpul_collections_web/live/home_live.ex:48
 #, elixir-autogen, elixir-format
-msgid "Leaflets"
+msgid "Flyers"
 msgstr ""
 
 #: lib/dpul_collections_web/live/collections_live.ex:169
@@ -696,17 +692,12 @@ msgstr ""
 msgid "Origin"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:46
+#: lib/dpul_collections_web/live/home_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Pamphlets"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:49
-#, elixir-autogen, elixir-format
-msgid "Photographs"
-msgstr ""
-
-#: lib/dpul_collections_web/live/home_live.ex:45
+#: lib/dpul_collections_web/live/home_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Posters"
 msgstr ""
@@ -1193,12 +1184,17 @@ msgstr ""
 msgid "filters"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:89
+#: lib/dpul_collections_web/components/search_bar_component.ex:114
 #, elixir-autogen, elixir-format
 msgid "Search all"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:48
+#: lib/dpul_collections_web/components/search_bar_component.ex:55
 #, elixir-autogen, elixir-format
 msgid "Search in this Collection"
+msgstr ""
+
+#: lib/dpul_collections_web/live/home_live.ex:49
+#, elixir-autogen, elixir-format
+msgid "Manuscripts"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -21,9 +21,9 @@ msgstr ""
 msgid "Hang in there while we get back on track"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:25
-#: lib/dpul_collections_web/components/search_bar_component.ex:31
-#: lib/dpul_collections_web/components/search_bar_component.ex:85
+#: lib/dpul_collections_web/components/search_bar_component.ex:32
+#: lib/dpul_collections_web/components/search_bar_component.ex:38
+#: lib/dpul_collections_web/components/search_bar_component.ex:110
 #: lib/dpul_collections_web/live/search_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Search"
@@ -148,6 +148,7 @@ msgstr ""
 
 #: lib/dpul_collections_web/components/header_component.ex:40
 #: lib/dpul_collections_web/live/home_live.ex:36
+#: lib/dpul_collections_web/live/home_live.ex:45
 #: lib/dpul_collections_web/live/item_live.ex:999
 #: lib/dpul_collections_web/live/item_live.ex:1000
 #: lib/dpul_collections_web/live/item_live.ex:1001
@@ -643,14 +644,9 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:47
-#, elixir-autogen, elixir-format
-msgid "Flyers"
-msgstr ""
-
 #: lib/dpul_collections_web/live/home_live.ex:48
 #, elixir-autogen, elixir-format
-msgid "Leaflets"
+msgid "Flyers"
 msgstr ""
 
 #: lib/dpul_collections_web/live/collections_live.ex:169
@@ -696,17 +692,12 @@ msgstr ""
 msgid "Origin"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:46
+#: lib/dpul_collections_web/live/home_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Pamphlets"
 msgstr ""
 
-#: lib/dpul_collections_web/live/home_live.ex:49
-#, elixir-autogen, elixir-format
-msgid "Photographs"
-msgstr ""
-
-#: lib/dpul_collections_web/live/home_live.ex:45
+#: lib/dpul_collections_web/live/home_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Posters"
 msgstr ""
@@ -1193,12 +1184,17 @@ msgstr ""
 msgid "filters"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:89
+#: lib/dpul_collections_web/components/search_bar_component.ex:114
 #, elixir-autogen, elixir-format
 msgid "Search all"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:48
+#: lib/dpul_collections_web/components/search_bar_component.ex:55
 #, elixir-autogen, elixir-format
 msgid "Search in this Collection"
+msgstr ""
+
+#: lib/dpul_collections_web/live/home_live.ex:49
+#, elixir-autogen, elixir-format
+msgid "Manuscripts"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -21,9 +21,9 @@ msgstr "¡Error!"
 msgid "Hang in there while we get back on track"
 msgstr "Aguanta mientras volvemos al buen camino"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:25
-#: lib/dpul_collections_web/components/search_bar_component.ex:31
-#: lib/dpul_collections_web/components/search_bar_component.ex:85
+#: lib/dpul_collections_web/components/search_bar_component.ex:32
+#: lib/dpul_collections_web/components/search_bar_component.ex:38
+#: lib/dpul_collections_web/components/search_bar_component.ex:110
 #: lib/dpul_collections_web/live/search_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Search"
@@ -148,6 +148,7 @@ msgstr "navegar"
 
 #: lib/dpul_collections_web/components/header_component.ex:40
 #: lib/dpul_collections_web/live/home_live.ex:36
+#: lib/dpul_collections_web/live/home_live.ex:45
 #: lib/dpul_collections_web/live/item_live.ex:999
 #: lib/dpul_collections_web/live/item_live.ex:1000
 #: lib/dpul_collections_web/live/item_live.ex:1001
@@ -643,15 +644,10 @@ msgstr "Archivos"
 msgid "Filters"
 msgstr "Filtros"
 
-#: lib/dpul_collections_web/live/home_live.ex:47
+#: lib/dpul_collections_web/live/home_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "Flyers"
 msgstr "Prospectos"
-
-#: lib/dpul_collections_web/live/home_live.ex:48
-#, elixir-autogen, elixir-format
-msgid "Leaflets"
-msgstr "Folletos"
 
 #: lib/dpul_collections_web/live/collections_live.ex:169
 #: lib/dpul_collections_web/live/collections_live.ex:208
@@ -696,17 +692,12 @@ msgstr "Mis Conjuntos"
 msgid "Origin"
 msgstr "Origen"
 
-#: lib/dpul_collections_web/live/home_live.ex:46
+#: lib/dpul_collections_web/live/home_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Pamphlets"
 msgstr "Panfletos"
 
-#: lib/dpul_collections_web/live/home_live.ex:49
-#, elixir-autogen, elixir-format
-msgid "Photographs"
-msgstr "Fotografías"
-
-#: lib/dpul_collections_web/live/home_live.ex:45
+#: lib/dpul_collections_web/live/home_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Posters"
 msgstr "Pósteres"
@@ -1193,12 +1184,17 @@ msgstr "Abrir"
 msgid "filters"
 msgstr "Filtros"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:89
+#: lib/dpul_collections_web/components/search_bar_component.ex:114
 #, elixir-autogen, elixir-format
 msgid "Search all"
 msgstr "Buscar todo"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:48
+#: lib/dpul_collections_web/components/search_bar_component.ex:55
 #, elixir-autogen, elixir-format
 msgid "Search in this Collection"
 msgstr "Buscar en esta colección"
+
+#: lib/dpul_collections_web/live/home_live.ex:49
+#, elixir-autogen, elixir-format
+msgid "Manuscripts"
+msgstr "Manuscritos"

--- a/priv/gettext/pt/LC_MESSAGES/default.po
+++ b/priv/gettext/pt/LC_MESSAGES/default.po
@@ -21,9 +21,9 @@ msgstr "Erro!"
 msgid "Hang in there while we get back on track"
 msgstr "Aguarde enquanto voltamos ao normal"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:25
-#: lib/dpul_collections_web/components/search_bar_component.ex:31
-#: lib/dpul_collections_web/components/search_bar_component.ex:85
+#: lib/dpul_collections_web/components/search_bar_component.ex:32
+#: lib/dpul_collections_web/components/search_bar_component.ex:38
+#: lib/dpul_collections_web/components/search_bar_component.ex:110
 #: lib/dpul_collections_web/live/search_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Search"
@@ -148,6 +148,7 @@ msgstr "Navegar"
 
 #: lib/dpul_collections_web/components/header_component.ex:40
 #: lib/dpul_collections_web/live/home_live.ex:36
+#: lib/dpul_collections_web/live/home_live.ex:45
 #: lib/dpul_collections_web/live/item_live.ex:999
 #: lib/dpul_collections_web/live/item_live.ex:1000
 #: lib/dpul_collections_web/live/item_live.ex:1001
@@ -643,15 +644,10 @@ msgstr "Arquivos"
 msgid "Filters"
 msgstr "Filtros"
 
-#: lib/dpul_collections_web/live/home_live.ex:47
+#: lib/dpul_collections_web/live/home_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "Flyers"
 msgstr "Folhetos"
-
-#: lib/dpul_collections_web/live/home_live.ex:48
-#, elixir-autogen, elixir-format
-msgid "Leaflets"
-msgstr "Panfletos"
 
 #: lib/dpul_collections_web/live/collections_live.ex:169
 #: lib/dpul_collections_web/live/collections_live.ex:208
@@ -696,17 +692,12 @@ msgstr "Meus Conjuntos"
 msgid "Origin"
 msgstr "Origem"
 
-#: lib/dpul_collections_web/live/home_live.ex:46
+#: lib/dpul_collections_web/live/home_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Pamphlets"
 msgstr "Panfletos"
 
-#: lib/dpul_collections_web/live/home_live.ex:49
-#, elixir-autogen, elixir-format
-msgid "Photographs"
-msgstr "Fotografias"
-
-#: lib/dpul_collections_web/live/home_live.ex:45
+#: lib/dpul_collections_web/live/home_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Posters"
 msgstr "Pôsteres"
@@ -1193,12 +1184,17 @@ msgstr "Visualizador"
 msgid "filters"
 msgstr "Filtros"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:89
+#: lib/dpul_collections_web/components/search_bar_component.ex:114
 #, elixir-autogen, elixir-format
 msgid "Search all"
 msgstr "Pesquisar tudo"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:48
+#: lib/dpul_collections_web/components/search_bar_component.ex:55
 #, elixir-autogen, elixir-format
 msgid "Search in this Collection"
 msgstr "Pesquisar nesta coleção"
+
+#: lib/dpul_collections_web/live/home_live.ex:49
+#, elixir-autogen, elixir-format
+msgid "Manuscripts"
+msgstr "Manuscritos"

--- a/test/dpul_collections_web/live/home_live_test.exs
+++ b/test/dpul_collections_web/live/home_live_test.exs
@@ -115,7 +115,7 @@ defmodule DpulCollectionsWeb.HomeLiveTest do
   end
 
   test "links to filters", %{conn: conn} do
-    ["photographs", "posters", "pamphlets"]
+    ["manuscripts", "flyers", "posters", "pamphlets"]
     |> Enum.each(fn format ->
       {:ok, view, _} = live(conn, "/")
 


### PR DESCRIPTION
Folks keep asking how to get to the list of collections, and now that we have manuscripts in there we should advertise them. We removed "manuscripts" in the past because we didn't have any in Ephemera.

<img width="1054" height="693" alt="Screenshot 2026-04-16 at 11 18 49 AM" src="https://github.com/user-attachments/assets/2cfc5b9a-5f5a-43fd-b469-a86526333f11" />
