### PR TITLE
Try a lighter gray (neutral-600) on the collection page item rows

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -358,7 +358,7 @@
 }
 
 .btn-arrow {
-  @apply arrow bg-accent cursor-pointer;
+  @apply arrow cursor-pointer;
 }
 
 .corner-cut {

--- a/lib/dpul_collections_web/components/browse_item.ex
+++ b/lib/dpul_collections_web/components/browse_item.ex
@@ -12,6 +12,8 @@ defmodule DpulCollectionsWeb.BrowseItem do
   attr :added?, :boolean, default: false
   attr :more_link, :string, default: nil
   attr :color, :string, default: "bg-primary-bright"
+  # can be light or dark
+  attr :arrow_theme, :string, default: "dark"
   attr :layout, :string, default: "content-area"
   attr :rest, :global
   attr :current_scope, :map, required: false, default: nil
@@ -49,7 +51,12 @@ defmodule DpulCollectionsWeb.BrowseItem do
               aria_label={gettext("more items")}
               navigate={@more_link}
             >
-              <div class="btn-arrow h-12 w-12"></div>
+              <div class={[
+                "btn-arrow h-12 w-12",
+                @arrow_theme == "dark" && "bg-accent",
+                @arrow_theme == "light" && "bg-primary-light"
+              ]}>
+              </div>
             </.transparent_button>
           </div>
         </div>

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -85,7 +85,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
     >
       <div
         id="collection-page"
-        class="grid grid-flow-row auto-rows-max -mb-6 [&>*:nth-child(odd)]:bg-background [&>*:nth-child(even)]:bg-dark-gray [&>*:nth-child(even)]:text-light-text"
+        class="grid grid-flow-row auto-rows-max -mb-6 [&>*:nth-child(odd)]:bg-background [&>*:nth-child(even)]:bg-neutral-600 [&>*:nth-child(even)]:text-light-text"
       >
         <!-- Hero Section -->
         <div class="content-area relative">

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -197,6 +197,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
             current_path={@current_path}
             current_scope={@current_scope}
             color=""
+            arrow_theme="light"
           >
           </.browse_item_row>
         </div>
@@ -255,6 +256,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
             added?={true}
             current_path={@current_path}
             color=""
+            arrow_theme="light"
           >
             <p class="my-2">
               {gettext("Explore the latest additions to our growing collection for")} {@collection.title


### PR DESCRIPTION
the dark / light stripe on this page feels very repetitive to me, and it's a bit off-putting that the dark gray is so close in hue to the black header and footer. This is a proposal to lighten that gray a bit, to give the page a slightly less heavy look and also distinguish the content from the header / footer.

Before:

<img width="2152" height="1260" alt="Screenshot 2026-04-21 at 10 55 19 AM" src="https://github.com/user-attachments/assets/91e432ab-c3ff-4a2d-8401-e585e3ac8f8c" />

After:

<img width="2016" height="1268" alt="Screenshot 2026-04-21 at 10 55 31 AM" src="https://github.com/user-attachments/assets/19c6f1b5-5889-419c-bacf-0283fc37cf43" />
