### PR TITLE
Removes MSS Transliterated Titles from title display in Search Results

### DIFF
--- a/lib/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource.ex
@@ -170,6 +170,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.CombinedFiggyResource do
       rights_statement_txtm: extract_rights_statement(metadata),
       series_txt_sort: get_in(metadata, ["series"]),
       sort_title_txtm: get_in(metadata, ["sort_title"]),
+      transliterated_title_txtm: extract_transliterated_title(metadata),
       updated_at_dt: updated_date(data),
       width_txtm: get_in(metadata, ["width"]),
       years_is: extract_years(data),
@@ -492,7 +493,12 @@ defmodule DpulCollections.IndexingPipeline.Figgy.CombinedFiggyResource do
   end
 
   defp extract_title(%{"title" => title}) do
-    title |> Enum.map(&extract_rdf_title/1)
+    title
+    |> Enum.filter(fn
+      %{"@language" => lang} -> not String.ends_with?(lang, "-latn")
+      _ -> true
+    end)
+    |> Enum.map(&extract_rdf_title/1)
   end
 
   defp extract_rdf_title(title) do
@@ -500,6 +506,17 @@ defmodule DpulCollections.IndexingPipeline.Figgy.CombinedFiggyResource do
       %{"@value" => value} -> value
       _ -> title
     end
+  end
+
+  defp extract_transliterated_title(%{"title" => title}) do
+    title
+    |> Enum.find_value(fn
+      %{"@language" => lang, "@value" => value} ->
+        if String.ends_with?(lang, "-latn"), do: value, else: nil
+
+      _ ->
+        nil
+    end)
   end
 
   defp extract_rights_statement(%{"rights_statement" => [%{"@id" => url}]}) when is_binary(url) do

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -512,9 +512,7 @@ defmodule DpulCollectionsWeb.SearchLive do
           id={"item-metadata-#{@item.id}"}
         >
           <div class="flex flex-wrap flex-row sm:flex-row justify-between">
-            <h2
-              dir="auto w-full flex-grow sm:w-fit"
-            >
+            <h2 dir="auto w-full flex-grow sm:w-fit">
               <.link
                 navigate={@item.url}
                 class="card-link"

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -512,12 +512,15 @@ defmodule DpulCollectionsWeb.SearchLive do
           id={"item-metadata-#{@item.id}"}
         >
           <div class="flex flex-wrap flex-row sm:flex-row justify-between">
-            <h2 dir="auto w-full flex-grow sm:w-fit">
+            <h2
+              :for={title <- @item.title}
+              dir="auto w-full flex-grow sm:w-fit"
+            >
               <.link
                 navigate={@item.url}
                 class="card-link"
               >
-                {@item.title}
+                {title}
               </.link>
             </h2>
             <span
@@ -585,6 +588,7 @@ defmodule DpulCollectionsWeb.SearchLive do
               <.link
                 navigate={@item.url}
                 class="card-link"
+                id={"item-title-#{@item.id}"}
               >
                 {@item.title}
               </.link>

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -513,14 +513,13 @@ defmodule DpulCollectionsWeb.SearchLive do
         >
           <div class="flex flex-wrap flex-row sm:flex-row justify-between">
             <h2
-              :for={title <- @item.title}
               dir="auto w-full flex-grow sm:w-fit"
             >
               <.link
                 navigate={@item.url}
                 class="card-link"
               >
-                {title}
+                {@item.title}
               </.link>
             </h2>
             <span

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -376,9 +376,12 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
       indexer |> Broadway.stop(:normal)
 
       assert document["title_txtm"] == [
-               "المحاسن المجتمعة في فضل فضايل الخلفاء الاربعة / للشيخ علي الصفوري.",
-               "al-Maḥāsin al-mujtamaʻah fī faḍl faḍāyil al-khulafāʼ al-arbaʻah / lil-Shaykh ʻAlī al-Ṣaffūrī."
+               "المحاسن المجتمعة في فضل فضايل الخلفاء الاربعة / للشيخ علي الصفوري."
              ]
+
+      assert document["transliterated_title_txtm"] == [
+                "al-Maḥāsin al-mujtamaʻah fī faḍl faḍāyil al-khulafāʼ al-arbaʻah / lil-Shaykh ʻAlī al-Ṣaffūrī."
+              ]
 
       # These are the same author, one a transliteration. We'll need better data
       # to index better than this.

--- a/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/full_integration_test.exs
@@ -380,8 +380,8 @@ defmodule DpulCollections.IndexingPipeline.FiggyFullIntegrationTest do
              ]
 
       assert document["transliterated_title_txtm"] == [
-                "al-Maḥāsin al-mujtamaʻah fī faḍl faḍāyil al-khulafāʼ al-arbaʻah / lil-Shaykh ʻAlī al-Ṣaffūrī."
-              ]
+               "al-Maḥāsin al-mujtamaʻah fī faḍl faḍāyil al-khulafāʼ al-arbaʻah / lil-Shaykh ʻAlī al-Ṣaffūrī."
+             ]
 
       # These are the same author, one a transliteration. We'll need better data
       # to index better than this.

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -798,6 +798,21 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
       assert html =~ "Document-1"
     end
 
+test "display titles and transliterated titles", %{conn: conn} do
+      {:ok, _view, html} = live(conn, "/search?")
+
+      {:ok, document} =
+        html
+        |> Floki.parse_document()
+
+      # There should be a title
+      assert document |> Floki.find(".item-1_title") |> Enum.count() == 1
+
+      # There should be a transliterated title
+       assert document |> Floki.find(".item-1_title_transliterated") |> Enum.count() == 1
+
+    end
+
     test "display large and small thumbnails", %{conn: conn} do
       {:ok, _view, html} = live(conn, "/search?")
 

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -798,7 +798,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
       assert html =~ "Document-1"
     end
 
-    test "display titles and transliterated titles", %{conn: conn} do
+    test "displays a title for a record", %{conn: conn} do
       FiggyTestSupport.index_record_id_directly("27fd4d29-1170-47a5-891b-f2743873bcef")
       Solr.soft_commit()
 

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -798,19 +798,20 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
       assert html =~ "Document-1"
     end
 
-test "display titles and transliterated titles", %{conn: conn} do
-      {:ok, _view, html} = live(conn, "/search?")
+    test "display titles and transliterated titles", %{conn: conn} do
+      FiggyTestSupport.index_record_id_directly("27fd4d29-1170-47a5-891b-f2743873bcef")
+      Solr.soft_commit()
+
+      {:ok, _view, html} = live(conn, "/search?q=27fd4d29-1170-47a5-891b-f2743873bcef")
 
       {:ok, document} =
         html
         |> Floki.parse_document()
 
       # There should be a title
-      assert document |> Floki.find(".item-1_title") |> Enum.count() == 1
-
-      # There should be a transliterated title
-       assert document |> Floki.find(".item-1_title_transliterated") |> Enum.count() == 1
-
+      assert document
+             |> Floki.find("#item-title-27fd4d29-1170-47a5-891b-f2743873bcef")
+             |> Enum.count() == 1
     end
 
     test "display large and small thumbnails", %{conn: conn} do


### PR DESCRIPTION
Fixes #1108 