### PR TITLE
Don't query for every canvas in search results.

### DIFF
--- a/lib/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource.ex
@@ -161,7 +161,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.CombinedFiggyResource do
       holding_location_txt_sort: get_in(metadata, ["holding_location"]),
       iiif_manifest_url_s: iiif_manifest_url(id, internal_resource),
       image_canvas_ids_ss: image_canvas_ids(id, data, related_data),
-      image_service_urls_ss: image_service_urls(metadata, related_data),
+      image_service_urls_ss: image_service_urls(metadata, related_data) |> Enum.take(12),
       keywords_txt_sort: get_in(metadata, ["keywords"]),
       page_count_txtm: get_in(metadata, ["page_count"]),
       pdf_url_s: extract_pdf_url(data),

--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -46,7 +46,6 @@ defmodule DpulCollections.Solr do
     "resource_type_s",
     "slug_s",
     "image_service_urls_ss",
-    "image_canvas_ids_ss",
     "primary_thumbnail_service_url_s",
     "digitized_at_dt",
     "format_txt_sort",

--- a/test/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource_test.exs
@@ -30,6 +30,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.CombinedFiggyResourceTest do
         |> Figgy.CombinedFiggyResource.to_solr_document()
 
       assert doc[:mms_id_ss] == "9963573093506421"
+      # We only need 12 - if we have too many it slows down solr requests.
+      assert doc[:image_service_urls_ss] |> length() == 12
     end
 
     test "converting a ScannedResource with MMS-ID metadata but no date doesn't index a date" do


### PR DESCRIPTION
Filters were VERY slow because every islamic manuscript was returning every canvas ID and thumbnail URL for the entire book.
