### PR TITLE
Don't query for canvas in search results / Don't parallelize

### DIFF
--- a/lib/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource.ex
@@ -161,7 +161,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.CombinedFiggyResource do
       holding_location_txt_sort: get_in(metadata, ["holding_location"]),
       iiif_manifest_url_s: iiif_manifest_url(id, internal_resource),
       image_canvas_ids_ss: image_canvas_ids(id, data, related_data),
-      image_service_urls_ss: image_service_urls(metadata, related_data),
+      image_service_urls_ss: image_service_urls(metadata, related_data) |> Enum.take(12),
       keywords_txt_sort: get_in(metadata, ["keywords"]),
       page_count_txtm: get_in(metadata, ["page_count"]),
       pdf_url_s: extract_pdf_url(data),

--- a/lib/dpul_collections/search_result.ex
+++ b/lib/dpul_collections/search_result.ex
@@ -15,13 +15,6 @@ defmodule DpulCollections.SearchResult do
     }
   end
 
-  def from_solr(%{"response" => response}) do
-    %__MODULE__{
-      results: response["docs"] |> Enum.map(&Item.from_solr/1),
-      total_items: response["numFound"]
-    }
-  end
-
   @spec facets_to_filter_data(%{filter_key => [filter_value_datum]}) :: %{
           filter_key => %{label: filter_label :: String.t(), data: [filter_value_datum]}
         }

--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -121,23 +121,10 @@ defmodule DpulCollections.Solr do
   end
 
   def search(search_state, index \\ Index.read_index()) do
-    search_results(search_state, index)
-    |> Map.put(:filter_data, filter_data(search_state, index))
-  end
-
-  def search_results(search_state, index \\ Index.read_index()) do
     search_state
-    |> raw_query(index)
-    |> to_search_result()
-  end
-
-  def filter_data(search_state, index \\ Index.read_index()) do
-    search_state
-    |> Map.put(:per_page, 0)
     |> SearchState.add_filter_count_fields(@filter_fields)
     |> raw_query(index)
     |> to_search_result()
-    |> Map.get(:filter_data)
   end
 
   defp to_search_result(solr_response) do

--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -46,7 +46,6 @@ defmodule DpulCollections.Solr do
     "resource_type_s",
     "slug_s",
     "image_service_urls_ss",
-    "image_canvas_ids_ss",
     "primary_thumbnail_service_url_s",
     "digitized_at_dt",
     "format_txt_sort",

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -13,17 +13,6 @@ defmodule DpulCollectionsWeb.SearchLive do
     {:ok, socket}
   end
 
-  # We've searched before - split filters/items to speed things up.
-  def handle_params(params, _uri, socket = %{assigns: %{items: _items}}) do
-    socket = assign_search_state(socket, params)
-    search_state = socket.assigns.search_state
-
-    {:noreply,
-     socket
-     |> start_async(:fetch_filter_data, fn -> Solr.filter_data(search_state) end)
-     |> start_async(:fetch_results, fn -> Solr.search_results(search_state) end)}
-  end
-
   def handle_params(params, _uri, socket) do
     socket = assign_search_state(socket, params)
     search_state = socket.assigns.search_state
@@ -46,22 +35,6 @@ defmodule DpulCollectionsWeb.SearchLive do
      |> assign_new(
        :expanded_filter,
        fn -> nil end
-     )}
-  end
-
-  def handle_async(:fetch_filter_data, {:ok, filter_data}, socket) do
-    {:noreply,
-     socket
-     |> assign(filter_data: with_year_filter(filter_data))}
-  end
-
-  def handle_async(:fetch_results, {:ok, %{results: items, total_items: total_items}}, socket) do
-    {:noreply,
-     socket
-     |> assign(
-       item_counter: item_counter(socket.assigns.search_state, total_items),
-       items: items,
-       total_items: total_items
      )}
   end
 

--- a/test/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/combined_figgy_resource_test.exs
@@ -30,6 +30,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.CombinedFiggyResourceTest do
         |> Figgy.CombinedFiggyResource.to_solr_document()
 
       assert doc[:mms_id_ss] == "9963573093506421"
+      # We only need 12 - if we have too many it slows down solr requests.
+      assert doc[:image_service_urls_ss] |> length() == 12
     end
 
     test "converting a ScannedResource with MMS-ID metadata but no date doesn't index a date" do


### PR DESCRIPTION
Parallelizing filters/items resulted in this strange disconnect between what loaded when, and performance issues were more likely related to loading all the canvas IDs for multi-hundred page manuscripts in a result set, not loading filters.

Closes #1144