### PR TITLE
Remove IDs from checkgroups.

### DIFF
--- a/lib/dpul_collections_web/components/core_components.ex
+++ b/lib/dpul_collections_web/components/core_components.ex
@@ -684,7 +684,6 @@ defmodule DpulCollectionsWeb.CoreComponents do
       >
         <input
           type="checkbox"
-          id={"#{@name}-#{option}"}
           name={@name}
           value={option}
           checked={String.downcase(option) in @case_insensitive_value}


### PR DESCRIPTION
Significantly speeds up filters.

To figure this out I had to add a bunch of fake data locally and slowly start deleting HTML until it rendered faster.

Locally the difference is 1.2 seconds to 50ms, checking it soon on staging..

Staging (for me) is 3s to 300ms.

Work towards #1145 