### PR TITLE
Add diagonal element back to subnav

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -115,6 +115,14 @@
   @apply px-4 sm:px-8 lg:px-10;
 }
 
+@utility subnav-l-padding {
+  @apply pl-4 sm:pl-8 lg:pl-10;
+}
+
+@utility subnav-r-padding {
+  @apply pr-6 sm:pr-14 lg:pr-12;
+}
+
 @utility header-y-padding {
   @apply py-4;
 }
@@ -322,39 +330,55 @@
     last:before:absolute last:before:h-full last:before:w-4 last:before:top-0 last:before:-right-4 group-hover:last:before:bg-zinc-50 last:before:sm:rounded-r-xl;
 }
 
-.browse-link {
-  padding-left: 60px;
-  clip-path: polygon(0 50.72px,50.72px 0%, 100% 0%, 100% 100%, 0% 100%);
+@utility subnav-diagonal-left {
+  @apply pr-[70px];
+  clip-path: polygon(0 0, 100% 0, calc(100% - 50px) 100%, 0 100%, 0 100%);
+}
+
+@utility subnav-diagonal-middle {
+  @apply px-[70px];
+  @apply transform-[translateX(50px)];
+  clip-path: polygon(50px 0, 100% 0, calc(100% - 50px) 100%, 0 100%, 0 100%);
+}
+
+@utility subnav-diagonal-right {
+  @apply pl-[70px];
+  clip-path: polygon(50px 0, 100% 0, 100% 100%, 0 100%, 0 100%);
+}
+
+@utility subnav-diagonal-right-pair {
+  @apply max-md:transform-[translateX(-50px)];
+  @apply max-md:pr-[45px];
 }
 
 .diagonal-drop {
   padding-left: 30px;
-  clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 25px 100%);
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 25px 100%);
 }
 
 .diagonal-rise {
   padding-left: 30px;
-  clip-path: polygon(25px 0%, 100% 0%, 100% 100%, 0 100%);
+  clip-path: polygon(25px 0, 100% 0, 100% 100%, 0 100%);
 }
 
 .left-arrow-box {
-  clip-path: polygon(100% 0%, 100% 100%, 40px 100%, 0% 50%, 40px 0%);
+  clip-path: polygon(100% 0, 100% 100%, 40px 100%, 0 50%, 40px 0);
   @apply pl-[20px] bg-primary border-none hover:bg-hover-accent flex justify-center items-center w-full h-14;
 }
 
 .right-arrow-box {
   clip-path: polygon(
-    0% 0%,
-    0% 100%,
+    0 0,
+    0 100%,
     calc(100% - 40px) 100%,
     100% 50%,
-    calc(100% - 40px) 0%
+    calc(100% - 40px) 0
   );
   @apply pr-[20px] bg-primary border-none hover:bg-hover-accent flex justify-center items-center w-full h-14;
 }
 
 @utility arrow {
-  clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
+  clip-path: polygon(0 0, 100% 50%, 0 100%);
 }
 
 .btn-arrow {
@@ -362,7 +386,7 @@
 }
 
 .corner-cut {
-  clip-path: polygon(0 50.72px,50.72px 0,100% 0,100% 50.72px,100% calc(100% - 50.72px),calc(100% - 50.72px) 100%,0 100%,0 calc(100% - 50.72px));
+  clip-path: polygon(0 0, calc(100% - 50px) 0, 100% 50px,100% 100%, 50px 100%,0 calc(100% - 50px));
 }
 
 .recent-container {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -332,23 +332,23 @@
 
 @utility subnav-diagonal-left {
   @apply pr-[70px];
-  clip-path: polygon(0 0, 100% 0, calc(100% - 50px) 100%, 0 100%, 0 100%);
+  clip-path: polygon(0 0, 100% 0, calc(100% - 40px) 100%, 0 100%, 0 100%);
 }
 
 @utility subnav-diagonal-middle {
   @apply px-[70px];
-  @apply transform-[translateX(50px)];
-  clip-path: polygon(50px 0, 100% 0, calc(100% - 50px) 100%, 0 100%, 0 100%);
+  @apply transform-[translateX(40px)];
+  clip-path: polygon(40px 0, 100% 0, calc(100% - 40px) 100%, 0 100%, 0 100%);
 }
 
 @utility subnav-diagonal-right {
   @apply pl-[70px];
-  clip-path: polygon(50px 0, 100% 0, 100% 100%, 0 100%, 0 100%);
+  clip-path: polygon(40px 0, 100% 0, 100% 100%, 0 100%, 0 100%);
 }
 
 @utility subnav-diagonal-right-pair {
-  @apply max-md:transform-[translateX(-50px)];
-  @apply max-md:pr-[45px];
+  @apply max-md:transform-[translateX(-40px)];
+  @apply max-md:pr-[35px];
 }
 
 .diagonal-drop {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -331,6 +331,7 @@
 }
 
 @utility subnav-diagonal-left {
+  @apply pl-[24px];
   @apply pr-[70px];
   clip-path: polygon(0 0, 100% 0, calc(100% - 40px) 100%, 0 100%, 0 100%);
 }
@@ -348,7 +349,6 @@
 
 @utility subnav-diagonal-right-pair {
   @apply max-md:transform-[translateX(-40px)];
-  @apply pr-[35px];
 }
 
 .diagonal-drop {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -348,7 +348,7 @@
 
 @utility subnav-diagonal-right-pair {
   @apply max-md:transform-[translateX(-40px)];
-  @apply max-md:pr-[35px];
+  @apply pr-[35px];
 }
 
 .diagonal-drop {

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -9,10 +9,10 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
   def render(assigns) do
     ~H"""
     <div class="subnav-bar cover-with-pane">
-      <div class="search-container min-h-10 flex flex-wrap bg-search">
+      <div class="search-container min-h-[50px] flex flex-wrap bg-search">
         <form
           id="search-form"
-          class="header-x-padding grow group w-full h-full"
+          class="grow group w-full h-full"
           phx-submit="search"
           phx-target={@myself}
         >
@@ -24,12 +24,12 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
           />
           <div
             class={[
-              "flex items-center w-full h-full",
+              "flex items-stretch w-full h-full",
               String.length(@collection_title) > 0 && "flex-wrap"
             ]}
             role="search"
           >
-            <div class="flex items-center grow">
+            <div class="subnav-l-padding flex items-center grow">
               <span class="flex-none">
                 <.icon name="hero-magnifying-glass" class="h-8 w-8 icon" />
               </span>
@@ -45,7 +45,7 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
             </div>
 
             <div class={[
-              "flex items-stretch space-x-2 my-2 text-sm md:text-md md:w-auto",
+              "subnav-buttons flex items-stretch space-x-1 h-full text-sm md:text-base md:w-auto",
               String.length(@collection_title) > 0 && "w-full"
             ]}>
               <.primary_button
@@ -54,9 +54,9 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
                 type="submit"
                 name="search"
                 value={@collection_title}
-                class="btn-primary px-4 h-8 grow"
+                class="grow max-md:subnav-diagonal-left md:subnav-diagonal-middle"
               >
-                {gettext("Search in this Collection")}
+                {gettext("In this Collection")}
                 <.icon name="hero-arrow-turn-down-left" class="h-4/7 ml-1 hidden md:inline" />
               </.primary_button>
 
@@ -65,7 +65,11 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
                 type="submit"
                 name="search"
                 value="all"
-                class="btn-primary px-4 h-8 mr-2px grow"
+                class={[
+                  "grow subnav-diagonal-right",
+                  String.length(@collection_title) > 0 && "subnav-diagonal-right-pair",
+                  String.length(@collection_title) > 0 || "subnav-r-padding"
+                ]}
               >
                 {search_label(@collection_title)}
               </.primary_button>

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -8,67 +8,70 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
 
   def render(assigns) do
     ~H"""
-    <div class="search-bar cover-with-pane">
-      <div class="search-browse-container min-h-10 flex flex-wrap bg-search">
-        <div class="search-box header-x-padding grow w-full">
-          <form id="search-form" class="group w-full h-full" phx-submit="search" phx-target={@myself}>
-            <.input
-              :if={Enum.any?(@search_state)}
-              type="hidden"
-              name="search_state"
-              value={JSON.encode!(@search_state)}
-            />
-            <div
-              class={[
-                "flex items-center w-full h-full",
-                String.length(@collection_title) > 0 && "flex-wrap"
-              ]}
-              role="search"
-            >
-              <div class="flex items-center grow">
-                <span class="flex-none">
-                  <.icon name="hero-magnifying-glass" class="h-8 w-8 icon" />
-                </span>
-                <label for="q" class="sr-only">{gettext("Search")}</label>
-                <input
-                  class="m-2 px-1 py-0 grow w-full h-full placeholder:text-dark-text/40 bg-transparent border-none placeholder:text-xl text-xl placeholder:font-bold"
-                  type="text"
-                  id="q"
-                  name="q"
-                  placeholder={gettext("Search")}
-                  dir="auto"
-                />
-              </div>
-
-              <div class={[
-                "flex items-stretch space-x-2 my-2 text-sm md:text-md md:w-auto",
-                String.length(@collection_title) > 0 && "w-full"
-              ]}>
-                <.primary_button
-                  :if={String.length(@collection_title) > 0}
-                  id="collection-search-button"
-                  type="submit"
-                  name="search"
-                  value={@collection_title}
-                  class="btn-primary px-4 h-8 grow"
-                >
-                  {gettext("Search in this Collection")}
-                  <.icon name="hero-arrow-turn-down-left" class="h-4/7 ml-1 hidden md:inline" />
-                </.primary_button>
-
-                <.primary_button
-                  id="search-button"
-                  type="submit"
-                  name="search"
-                  value="all"
-                  class="btn-primary px-4 h-8 mr-2px grow"
-                >
-                  {search_label(@collection_title)}
-                </.primary_button>
-              </div>
+    <div class="subnav-bar cover-with-pane">
+      <div class="search-container min-h-10 flex flex-wrap bg-search">
+        <form
+          id="search-form"
+          class="header-x-padding grow group w-full h-full"
+          phx-submit="search"
+          phx-target={@myself}
+        >
+          <.input
+            :if={Enum.any?(@search_state)}
+            type="hidden"
+            name="search_state"
+            value={JSON.encode!(@search_state)}
+          />
+          <div
+            class={[
+              "flex items-center w-full h-full",
+              String.length(@collection_title) > 0 && "flex-wrap"
+            ]}
+            role="search"
+          >
+            <div class="flex items-center grow">
+              <span class="flex-none">
+                <.icon name="hero-magnifying-glass" class="h-8 w-8 icon" />
+              </span>
+              <label for="q" class="sr-only">{gettext("Search")}</label>
+              <input
+                class="m-2 px-1 py-0 grow w-full h-full placeholder:text-dark-text/40 bg-transparent border-none placeholder:text-xl text-xl placeholder:font-bold"
+                type="text"
+                id="q"
+                name="q"
+                placeholder={gettext("Search")}
+                dir="auto"
+              />
             </div>
-          </form>
-        </div>
+
+            <div class={[
+              "flex items-stretch space-x-2 my-2 text-sm md:text-md md:w-auto",
+              String.length(@collection_title) > 0 && "w-full"
+            ]}>
+              <.primary_button
+                :if={String.length(@collection_title) > 0}
+                id="collection-search-button"
+                type="submit"
+                name="search"
+                value={@collection_title}
+                class="btn-primary px-4 h-8 grow"
+              >
+                {gettext("Search in this Collection")}
+                <.icon name="hero-arrow-turn-down-left" class="h-4/7 ml-1 hidden md:inline" />
+              </.primary_button>
+
+              <.primary_button
+                id="search-button"
+                type="submit"
+                name="search"
+                value="all"
+                class="btn-primary px-4 h-8 mr-2px grow"
+              >
+                {search_label(@collection_title)}
+              </.primary_button>
+            </div>
+          </div>
+        </form>
       </div>
       <.content_separator />
     </div>

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -68,8 +68,8 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
                 value="all"
                 class={[
                   "grow subnav-diagonal-right h-[48px]",
-                  String.length(@collection_title) > 0 && "subnav-diagonal-right-pair",
-                  String.length(@collection_title) > 0 || "subnav-r-padding"
+                  "subnav-r-padding",
+                  String.length(@collection_title) > 0 && "subnav-diagonal-right-pair"
                 ]}
               >
                 {search_label(@collection_title)}

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -9,7 +9,7 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
   def render(assigns) do
     ~H"""
     <div class="subnav-bar cover-with-pane">
-      <div class="search-container min-h-[50px] flex flex-wrap bg-search">
+      <div class="search-container min-h-[48px] flex flex-wrap bg-search">
         <form
           id="search-form"
           class="grow group w-full h-full"
@@ -45,7 +45,7 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
             </div>
 
             <div class={[
-              "subnav-buttons flex items-stretch space-x-1 h-full text-sm md:text-base md:w-auto",
+              "subnav-buttons flex items-stretch space-x-1 text-sm md:text-base md:w-auto",
               String.length(@collection_title) > 0 && "w-full"
             ]}>
               <.primary_button
@@ -54,7 +54,7 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
                 type="submit"
                 name="search"
                 value={@collection_title}
-                class="grow max-md:subnav-diagonal-left md:subnav-diagonal-middle"
+                class="grow max-md:subnav-diagonal-left md:subnav-diagonal-middle h-[48px]"
               >
                 {gettext("In this Collection")}
                 <.icon name="hero-arrow-turn-down-left" class="h-4/7 ml-1 hidden md:inline" />
@@ -66,7 +66,7 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
                 name="search"
                 value="all"
                 class={[
-                  "grow subnav-diagonal-right",
+                  "grow subnav-diagonal-right h-[48px]",
                   String.length(@collection_title) > 0 && "subnav-diagonal-right-pair",
                   String.length(@collection_title) > 0 || "subnav-r-padding"
                 ]}

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -9,7 +9,7 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
   def render(assigns) do
     ~H"""
     <div class="subnav-bar cover-with-pane">
-      <div class="search-container min-h-[48px] flex flex-wrap bg-search">
+      <div class="search-container min-h-[48px] bg-search">
         <form
           id="search-form"
           class="grow group w-full h-full"

--- a/lib/dpul_collections_web/components/search_bar_component.ex
+++ b/lib/dpul_collections_web/components/search_bar_component.ex
@@ -24,8 +24,9 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
           />
           <div
             class={[
-              "flex items-stretch w-full h-full",
-              String.length(@collection_title) > 0 && "flex-wrap"
+              "grid md:grid-rows-1 md:grid-cols-[1fr_min-content] items-stretch w-full h-full",
+              String.length(@collection_title) > 0 && "grid-rows-2 grid-cols-1",
+              String.length(@collection_title) > 0 || "grid-rows-1 grid-cols-[1fr_min-content]"
             ]}
             role="search"
           >
@@ -45,8 +46,8 @@ defmodule DpulCollectionsWeb.SearchBarComponent do
             </div>
 
             <div class={[
-              "subnav-buttons flex items-stretch space-x-1 text-sm md:text-base md:w-auto",
-              String.length(@collection_title) > 0 && "w-full"
+              "subnav-buttons flex items-stretch justify-items-stretch space-x-1 text-sm md:text-base md:w-auto",
+              String.length(@collection_title) > 0 && "w-[calc(100%+40px)]"
             ]}>
               <.primary_button
                 :if={String.length(@collection_title) > 0}

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -21,9 +21,9 @@ msgstr ""
 msgid "Hang in there while we get back on track"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:25
-#: lib/dpul_collections_web/components/search_bar_component.ex:31
-#: lib/dpul_collections_web/components/search_bar_component.ex:85
+#: lib/dpul_collections_web/components/search_bar_component.ex:36
+#: lib/dpul_collections_web/components/search_bar_component.ex:42
+#: lib/dpul_collections_web/components/search_bar_component.ex:117
 #: lib/dpul_collections_web/live/search_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Search"
@@ -44,8 +44,8 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:62
-#: lib/dpul_collections/item.ex:83
+#: lib/dpul_collections/item.ex:63
+#: lib/dpul_collections/item.ex:84
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/components/header_component.ex:89
@@ -56,12 +56,12 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:765
+#: lib/dpul_collections_web/live/search_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:735
+#: lib/dpul_collections_web/live/search_live.ex:736
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
@@ -148,9 +148,9 @@ msgstr ""
 
 #: lib/dpul_collections_web/components/header_component.ex:40
 #: lib/dpul_collections_web/live/home_live.ex:36
-#: lib/dpul_collections_web/live/item_live.ex:999
-#: lib/dpul_collections_web/live/item_live.ex:1000
-#: lib/dpul_collections_web/live/item_live.ex:1001
+#: lib/dpul_collections_web/live/item_live.ex:1076
+#: lib/dpul_collections_web/live/item_live.ex:1077
+#: lib/dpul_collections_web/live/item_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Digital Collections"
 msgstr ""
@@ -160,7 +160,7 @@ msgstr ""
 msgid "The Trustees of Princeton University"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:601
+#: lib/dpul_collections_web/live/search_live.ex:602
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -194,8 +194,8 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:50
-#: lib/dpul_collections/item.ex:80
+#: lib/dpul_collections/item.ex:51
+#: lib/dpul_collections/item.ex:81
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -205,8 +205,8 @@ msgstr ""
 msgid "Creator of work"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:63
-#: lib/dpul_collections/item.ex:102
+#: lib/dpul_collections/item.ex:64
+#: lib/dpul_collections/item.ex:103
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -216,8 +216,8 @@ msgstr ""
 msgid "Geographic Origin"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:51
-#: lib/dpul_collections/item.ex:82
+#: lib/dpul_collections/item.ex:52
+#: lib/dpul_collections/item.ex:83
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -227,8 +227,8 @@ msgstr ""
 msgid "Publisher"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:65
-#: lib/dpul_collections/item.ex:99
+#: lib/dpul_collections/item.ex:66
+#: lib/dpul_collections/item.ex:100
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -249,33 +249,33 @@ msgid "No PDF Available"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:361
-#: lib/dpul_collections_web/live/item_live.ex:1000
+#: lib/dpul_collections_web/live/item_live.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Viewer"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:76
+#: lib/dpul_collections/item.ex:77
 #, elixir-autogen, elixir-format
 msgid "Alternative Title"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:116
+#: lib/dpul_collections/item.ex:117
 #, elixir-autogen, elixir-format
 msgid "Barcode"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:114
+#: lib/dpul_collections/item.ex:115
 #, elixir-autogen, elixir-format
 msgid "Box number"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:87
+#: lib/dpul_collections/item.ex:88
 #: lib/dpul_collections_web/live/item_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Content Warning"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:81
+#: lib/dpul_collections/item.ex:82
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -285,7 +285,7 @@ msgstr ""
 msgid "Contributor"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:84
+#: lib/dpul_collections/item.ex:85
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -295,17 +295,17 @@ msgstr ""
 msgid "Date Created"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:72
+#: lib/dpul_collections/item.ex:73
 #, elixir-autogen, elixir-format
 msgid "Descriptive Information"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:97
+#: lib/dpul_collections/item.ex:98
 #, elixir-autogen, elixir-format
 msgid "Discovery Information"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:109
+#: lib/dpul_collections/item.ex:110
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -315,13 +315,13 @@ msgstr ""
 msgid "File Count"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:115
+#: lib/dpul_collections/item.ex:116
 #, elixir-autogen, elixir-format
 msgid "Folder number"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:64
-#: lib/dpul_collections/item.ex:100
+#: lib/dpul_collections/item.ex:65
+#: lib/dpul_collections/item.ex:101
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -331,22 +331,22 @@ msgstr ""
 msgid "Geographic Subject"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:106
+#: lib/dpul_collections/item.ex:107
 #, elixir-autogen, elixir-format
 msgid "Height"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:117
+#: lib/dpul_collections/item.ex:118
 #, elixir-autogen, elixir-format
 msgid "Holding location"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:118
+#: lib/dpul_collections/item.ex:119
 #, elixir-autogen, elixir-format
 msgid "IIIF Manifest URL"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:111
+#: lib/dpul_collections/item.ex:112
 #, elixir-autogen, elixir-format
 msgid "Institutional Information"
 msgstr ""
@@ -356,34 +356,34 @@ msgstr ""
 msgid "Item Summary"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:101
+#: lib/dpul_collections/item.ex:102
 #, elixir-autogen, elixir-format
 msgid "Keywords"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:313
 #: lib/dpul_collections_web/live/item_live.ex:817
-#: lib/dpul_collections_web/live/item_live.ex:999
+#: lib/dpul_collections_web/live/item_live.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Metadata"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:108
+#: lib/dpul_collections/item.ex:109
 #, elixir-autogen, elixir-format
 msgid "Page Count"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:104
+#: lib/dpul_collections/item.ex:105
 #, elixir-autogen, elixir-format
 msgid "Physical Characteristics"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:89
+#: lib/dpul_collections/item.ex:90
 #, elixir-autogen, elixir-format
 msgid "Provenance"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:92
+#: lib/dpul_collections/item.ex:93
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -393,27 +393,27 @@ msgstr ""
 msgid "Rights Statement"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:88
+#: lib/dpul_collections/item.ex:89
 #, elixir-autogen, elixir-format
 msgid "Series"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:77
+#: lib/dpul_collections/item.ex:78
 #, elixir-autogen, elixir-format
 msgid "Sort Title"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:74
+#: lib/dpul_collections/item.ex:75
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:75
+#: lib/dpul_collections/item.ex:76
 #, elixir-autogen, elixir-format
 msgid "Transliterated Title"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:107
+#: lib/dpul_collections/item.ex:108
 #, elixir-autogen, elixir-format
 msgid "Width"
 msgstr ""
@@ -509,12 +509,12 @@ msgstr ""
 msgid "Browse - Digital Collections"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:969
+#: lib/dpul_collections_web/live/item_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:968
+#: lib/dpul_collections_web/live/item_live.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -539,7 +539,7 @@ msgstr ""
 msgid "main image display"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:725
+#: lib/dpul_collections_web/live/search_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr ""
@@ -611,7 +611,7 @@ msgid "Categories"
 msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:212
-#: lib/dpul_collections_web/live/search_live.ex:642
+#: lib/dpul_collections_web/live/search_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
@@ -632,8 +632,8 @@ msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:163
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:626
-#: lib/dpul_collections_web/live/search_live.ex:696
+#: lib/dpul_collections_web/live/search_live.ex:627
+#: lib/dpul_collections_web/live/search_live.ex:697
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr ""
@@ -691,7 +691,7 @@ msgstr ""
 msgid "My Sets"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:649
+#: lib/dpul_collections_web/live/search_live.ex:650
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr ""
@@ -718,8 +718,8 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:660
-#: lib/dpul_collections_web/live/search_live.ex:666
+#: lib/dpul_collections_web/live/search_live.ex:661
+#: lib/dpul_collections_web/live/search_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr ""
@@ -834,7 +834,7 @@ msgstr ""
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr ""
 
-#: lib/dpul_collections/item.ex:113
+#: lib/dpul_collections/item.ex:114
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -953,7 +953,7 @@ msgstr ""
 msgid "Featured Highlights"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:85
+#: lib/dpul_collections/item.ex:86
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/components/browse_item.ex:219
@@ -1051,7 +1051,7 @@ msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:152
 #: lib/dpul_collections_web/live/search_live.ex:524
-#: lib/dpul_collections_web/live/search_live.ex:593
+#: lib/dpul_collections_web/live/search_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr ""
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "Apply Year Range"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:56
+#: lib/dpul_collections/item.ex:57
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -1081,13 +1081,13 @@ msgstr ""
 msgid "Author"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:95
+#: lib/dpul_collections/item.ex:96
 #, elixir-autogen, elixir-format
 msgid "Binding Note"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:49
-#: lib/dpul_collections/item.ex:78
+#: lib/dpul_collections/item.ex:50
+#: lib/dpul_collections/item.ex:79
 #, elixir-autogen, elixir-format
 msgid "Call Number"
 msgstr ""
@@ -1102,12 +1102,12 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:93
+#: lib/dpul_collections/item.ex:94
 #, elixir-autogen, elixir-format
 msgid "Contents"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:58
+#: lib/dpul_collections/item.ex:59
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -1117,7 +1117,7 @@ msgstr ""
 msgid "Donor"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:86
+#: lib/dpul_collections/item.ex:87
 #, elixir-autogen, elixir-format
 msgid "Extent"
 msgstr ""
@@ -1127,17 +1127,17 @@ msgstr ""
 msgid "Filter Results"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:79
+#: lib/dpul_collections/item.ex:80
 #, elixir-autogen, elixir-format
 msgid "Identifier"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:94
+#: lib/dpul_collections/item.ex:95
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:54
+#: lib/dpul_collections/item.ex:55
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr ""
@@ -1148,12 +1148,12 @@ msgstr ""
 msgid "Princeton University Library"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:91
+#: lib/dpul_collections/item.ex:92
 #, elixir-autogen, elixir-format
 msgid "References"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:59
+#: lib/dpul_collections/item.ex:60
 #, elixir-autogen, elixir-format
 msgid "Related Name"
 msgstr ""
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Results"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:57
+#: lib/dpul_collections/item.ex:58
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -1178,7 +1178,7 @@ msgstr ""
 msgid "Search filters..."
 msgstr ""
 
-#: lib/dpul_collections/item.ex:90
+#: lib/dpul_collections/item.ex:91
 #, elixir-autogen, elixir-format
 msgid "Source Acquisition"
 msgstr ""
@@ -1193,12 +1193,12 @@ msgstr ""
 msgid "filters"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:89
+#: lib/dpul_collections_web/components/search_bar_component.ex:121
 #, elixir-autogen, elixir-format
 msgid "Search all"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:48
+#: lib/dpul_collections_web/components/search_bar_component.ex:59
 #, elixir-autogen, elixir-format
-msgid "Search in this Collection"
+msgid "In this Collection"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -21,9 +21,9 @@ msgstr ""
 msgid "Hang in there while we get back on track"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:25
-#: lib/dpul_collections_web/components/search_bar_component.ex:31
-#: lib/dpul_collections_web/components/search_bar_component.ex:85
+#: lib/dpul_collections_web/components/search_bar_component.ex:36
+#: lib/dpul_collections_web/components/search_bar_component.ex:42
+#: lib/dpul_collections_web/components/search_bar_component.ex:117
 #: lib/dpul_collections_web/live/search_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Search"
@@ -44,8 +44,8 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:62
-#: lib/dpul_collections/item.ex:83
+#: lib/dpul_collections/item.ex:63
+#: lib/dpul_collections/item.ex:84
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/components/header_component.ex:89
@@ -56,12 +56,12 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:765
+#: lib/dpul_collections_web/live/search_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:735
+#: lib/dpul_collections_web/live/search_live.ex:736
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
@@ -148,9 +148,9 @@ msgstr ""
 
 #: lib/dpul_collections_web/components/header_component.ex:40
 #: lib/dpul_collections_web/live/home_live.ex:36
-#: lib/dpul_collections_web/live/item_live.ex:999
-#: lib/dpul_collections_web/live/item_live.ex:1000
-#: lib/dpul_collections_web/live/item_live.ex:1001
+#: lib/dpul_collections_web/live/item_live.ex:1076
+#: lib/dpul_collections_web/live/item_live.ex:1077
+#: lib/dpul_collections_web/live/item_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Digital Collections"
 msgstr ""
@@ -160,7 +160,7 @@ msgstr ""
 msgid "The Trustees of Princeton University"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:601
+#: lib/dpul_collections_web/live/search_live.ex:602
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -194,8 +194,8 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:50
-#: lib/dpul_collections/item.ex:80
+#: lib/dpul_collections/item.ex:51
+#: lib/dpul_collections/item.ex:81
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -205,8 +205,8 @@ msgstr ""
 msgid "Creator of work"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:63
-#: lib/dpul_collections/item.ex:102
+#: lib/dpul_collections/item.ex:64
+#: lib/dpul_collections/item.ex:103
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -216,8 +216,8 @@ msgstr ""
 msgid "Geographic Origin"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:51
-#: lib/dpul_collections/item.ex:82
+#: lib/dpul_collections/item.ex:52
+#: lib/dpul_collections/item.ex:83
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -227,8 +227,8 @@ msgstr ""
 msgid "Publisher"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:65
-#: lib/dpul_collections/item.ex:99
+#: lib/dpul_collections/item.ex:66
+#: lib/dpul_collections/item.ex:100
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -249,33 +249,33 @@ msgid "No PDF Available"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:361
-#: lib/dpul_collections_web/live/item_live.ex:1000
+#: lib/dpul_collections_web/live/item_live.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Viewer"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:76
+#: lib/dpul_collections/item.ex:77
 #, elixir-autogen, elixir-format
 msgid "Alternative Title"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:116
+#: lib/dpul_collections/item.ex:117
 #, elixir-autogen, elixir-format
 msgid "Barcode"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:114
+#: lib/dpul_collections/item.ex:115
 #, elixir-autogen, elixir-format
 msgid "Box number"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:87
+#: lib/dpul_collections/item.ex:88
 #: lib/dpul_collections_web/live/item_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Content Warning"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:81
+#: lib/dpul_collections/item.ex:82
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -285,7 +285,7 @@ msgstr ""
 msgid "Contributor"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:84
+#: lib/dpul_collections/item.ex:85
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -295,17 +295,17 @@ msgstr ""
 msgid "Date Created"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:72
+#: lib/dpul_collections/item.ex:73
 #, elixir-autogen, elixir-format
 msgid "Descriptive Information"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:97
+#: lib/dpul_collections/item.ex:98
 #, elixir-autogen, elixir-format
 msgid "Discovery Information"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:109
+#: lib/dpul_collections/item.ex:110
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -315,13 +315,13 @@ msgstr ""
 msgid "File Count"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:115
+#: lib/dpul_collections/item.ex:116
 #, elixir-autogen, elixir-format
 msgid "Folder number"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:64
-#: lib/dpul_collections/item.ex:100
+#: lib/dpul_collections/item.ex:65
+#: lib/dpul_collections/item.ex:101
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -331,22 +331,22 @@ msgstr ""
 msgid "Geographic Subject"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:106
+#: lib/dpul_collections/item.ex:107
 #, elixir-autogen, elixir-format
 msgid "Height"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:117
+#: lib/dpul_collections/item.ex:118
 #, elixir-autogen, elixir-format
 msgid "Holding location"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:118
+#: lib/dpul_collections/item.ex:119
 #, elixir-autogen, elixir-format
 msgid "IIIF Manifest URL"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:111
+#: lib/dpul_collections/item.ex:112
 #, elixir-autogen, elixir-format
 msgid "Institutional Information"
 msgstr ""
@@ -356,34 +356,34 @@ msgstr ""
 msgid "Item Summary"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:101
+#: lib/dpul_collections/item.ex:102
 #, elixir-autogen, elixir-format
 msgid "Keywords"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:313
 #: lib/dpul_collections_web/live/item_live.ex:817
-#: lib/dpul_collections_web/live/item_live.ex:999
+#: lib/dpul_collections_web/live/item_live.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Metadata"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:108
+#: lib/dpul_collections/item.ex:109
 #, elixir-autogen, elixir-format
 msgid "Page Count"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:104
+#: lib/dpul_collections/item.ex:105
 #, elixir-autogen, elixir-format
 msgid "Physical Characteristics"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:89
+#: lib/dpul_collections/item.ex:90
 #, elixir-autogen, elixir-format
 msgid "Provenance"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:92
+#: lib/dpul_collections/item.ex:93
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -393,27 +393,27 @@ msgstr ""
 msgid "Rights Statement"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:88
+#: lib/dpul_collections/item.ex:89
 #, elixir-autogen, elixir-format
 msgid "Series"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:77
+#: lib/dpul_collections/item.ex:78
 #, elixir-autogen, elixir-format
 msgid "Sort Title"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:74
+#: lib/dpul_collections/item.ex:75
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:75
+#: lib/dpul_collections/item.ex:76
 #, elixir-autogen, elixir-format
 msgid "Transliterated Title"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:107
+#: lib/dpul_collections/item.ex:108
 #, elixir-autogen, elixir-format
 msgid "Width"
 msgstr ""
@@ -509,12 +509,12 @@ msgstr ""
 msgid "Browse - Digital Collections"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:969
+#: lib/dpul_collections_web/live/item_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:968
+#: lib/dpul_collections_web/live/item_live.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
@@ -539,7 +539,7 @@ msgstr ""
 msgid "main image display"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:725
+#: lib/dpul_collections_web/live/search_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr ""
@@ -611,7 +611,7 @@ msgid "Categories"
 msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:212
-#: lib/dpul_collections_web/live/search_live.ex:642
+#: lib/dpul_collections_web/live/search_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
@@ -632,8 +632,8 @@ msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:163
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:626
-#: lib/dpul_collections_web/live/search_live.ex:696
+#: lib/dpul_collections_web/live/search_live.ex:627
+#: lib/dpul_collections_web/live/search_live.ex:697
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr ""
@@ -691,7 +691,7 @@ msgstr ""
 msgid "My Sets"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:649
+#: lib/dpul_collections_web/live/search_live.ex:650
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr ""
@@ -718,8 +718,8 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:660
-#: lib/dpul_collections_web/live/search_live.ex:666
+#: lib/dpul_collections_web/live/search_live.ex:661
+#: lib/dpul_collections_web/live/search_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr ""
@@ -834,7 +834,7 @@ msgstr ""
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr ""
 
-#: lib/dpul_collections/item.ex:113
+#: lib/dpul_collections/item.ex:114
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -953,7 +953,7 @@ msgstr ""
 msgid "Featured Highlights"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:85
+#: lib/dpul_collections/item.ex:86
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/components/browse_item.ex:219
@@ -1051,7 +1051,7 @@ msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:152
 #: lib/dpul_collections_web/live/search_live.ex:524
-#: lib/dpul_collections_web/live/search_live.ex:593
+#: lib/dpul_collections_web/live/search_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr ""
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "Apply Year Range"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:56
+#: lib/dpul_collections/item.ex:57
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -1081,13 +1081,13 @@ msgstr ""
 msgid "Author"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:95
+#: lib/dpul_collections/item.ex:96
 #, elixir-autogen, elixir-format
 msgid "Binding Note"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:49
-#: lib/dpul_collections/item.ex:78
+#: lib/dpul_collections/item.ex:50
+#: lib/dpul_collections/item.ex:79
 #, elixir-autogen, elixir-format
 msgid "Call Number"
 msgstr ""
@@ -1102,12 +1102,12 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:93
+#: lib/dpul_collections/item.ex:94
 #, elixir-autogen, elixir-format
 msgid "Contents"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:58
+#: lib/dpul_collections/item.ex:59
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -1117,7 +1117,7 @@ msgstr ""
 msgid "Donor"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:86
+#: lib/dpul_collections/item.ex:87
 #, elixir-autogen, elixir-format
 msgid "Extent"
 msgstr ""
@@ -1127,17 +1127,17 @@ msgstr ""
 msgid "Filter Results"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:79
+#: lib/dpul_collections/item.ex:80
 #, elixir-autogen, elixir-format
 msgid "Identifier"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:94
+#: lib/dpul_collections/item.ex:95
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:54
+#: lib/dpul_collections/item.ex:55
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr ""
@@ -1148,12 +1148,12 @@ msgstr ""
 msgid "Princeton University Library"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:91
+#: lib/dpul_collections/item.ex:92
 #, elixir-autogen, elixir-format
 msgid "References"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:59
+#: lib/dpul_collections/item.ex:60
 #, elixir-autogen, elixir-format
 msgid "Related Name"
 msgstr ""
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Results"
 msgstr ""
 
-#: lib/dpul_collections/item.ex:57
+#: lib/dpul_collections/item.ex:58
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -1178,7 +1178,7 @@ msgstr ""
 msgid "Search filters..."
 msgstr ""
 
-#: lib/dpul_collections/item.ex:90
+#: lib/dpul_collections/item.ex:91
 #, elixir-autogen, elixir-format
 msgid "Source Acquisition"
 msgstr ""
@@ -1193,12 +1193,12 @@ msgstr ""
 msgid "filters"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:89
+#: lib/dpul_collections_web/components/search_bar_component.ex:121
 #, elixir-autogen, elixir-format
 msgid "Search all"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:48
+#: lib/dpul_collections_web/components/search_bar_component.ex:59
 #, elixir-autogen, elixir-format
-msgid "Search in this Collection"
+msgid "In this Collection"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -21,9 +21,9 @@ msgstr "¡Error!"
 msgid "Hang in there while we get back on track"
 msgstr "Aguanta mientras volvemos al buen camino"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:25
-#: lib/dpul_collections_web/components/search_bar_component.ex:31
-#: lib/dpul_collections_web/components/search_bar_component.ex:85
+#: lib/dpul_collections_web/components/search_bar_component.ex:36
+#: lib/dpul_collections_web/components/search_bar_component.ex:42
+#: lib/dpul_collections_web/components/search_bar_component.ex:117
 #: lib/dpul_collections_web/live/search_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Search"
@@ -44,8 +44,8 @@ msgstr "¡Éxito!"
 msgid "close"
 msgstr "cerrar"
 
-#: lib/dpul_collections/item.ex:62
-#: lib/dpul_collections/item.ex:83
+#: lib/dpul_collections/item.ex:63
+#: lib/dpul_collections/item.ex:84
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/components/header_component.ex:89
@@ -56,12 +56,12 @@ msgstr "cerrar"
 msgid "Language"
 msgstr "Idioma"
 
-#: lib/dpul_collections_web/live/search_live.ex:765
+#: lib/dpul_collections_web/live/search_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Proxima"
 
-#: lib/dpul_collections_web/live/search_live.ex:735
+#: lib/dpul_collections_web/live/search_live.ex:736
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Anterior"
@@ -148,9 +148,9 @@ msgstr "navegar"
 
 #: lib/dpul_collections_web/components/header_component.ex:40
 #: lib/dpul_collections_web/live/home_live.ex:36
-#: lib/dpul_collections_web/live/item_live.ex:999
-#: lib/dpul_collections_web/live/item_live.ex:1000
-#: lib/dpul_collections_web/live/item_live.ex:1001
+#: lib/dpul_collections_web/live/item_live.ex:1076
+#: lib/dpul_collections_web/live/item_live.ex:1077
+#: lib/dpul_collections_web/live/item_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Digital Collections"
 msgstr "Colecciones Digitales"
@@ -160,7 +160,7 @@ msgstr "Colecciones Digitales"
 msgid "The Trustees of Princeton University"
 msgstr "Los fideicomisarios de la Universidad de Princeton"
 
-#: lib/dpul_collections_web/live/search_live.ex:601
+#: lib/dpul_collections_web/live/search_live.ex:602
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Añadido"
@@ -194,8 +194,8 @@ msgstr "Año"
 msgid "to"
 msgstr "hasta"
 
-#: lib/dpul_collections/item.ex:50
-#: lib/dpul_collections/item.ex:80
+#: lib/dpul_collections/item.ex:51
+#: lib/dpul_collections/item.ex:81
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -205,8 +205,8 @@ msgstr "hasta"
 msgid "Creator of work"
 msgstr "Creador de la obra"
 
-#: lib/dpul_collections/item.ex:63
-#: lib/dpul_collections/item.ex:102
+#: lib/dpul_collections/item.ex:64
+#: lib/dpul_collections/item.ex:103
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -216,8 +216,8 @@ msgstr "Creador de la obra"
 msgid "Geographic Origin"
 msgstr "Origen geográfico"
 
-#: lib/dpul_collections/item.ex:51
-#: lib/dpul_collections/item.ex:82
+#: lib/dpul_collections/item.ex:52
+#: lib/dpul_collections/item.ex:83
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -227,8 +227,8 @@ msgstr "Origen geográfico"
 msgid "Publisher"
 msgstr "Editor"
 
-#: lib/dpul_collections/item.ex:65
-#: lib/dpul_collections/item.ex:99
+#: lib/dpul_collections/item.ex:66
+#: lib/dpul_collections/item.ex:100
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -249,33 +249,33 @@ msgid "No PDF Available"
 msgstr "PDF no disponible"
 
 #: lib/dpul_collections_web/live/item_live.ex:361
-#: lib/dpul_collections_web/live/item_live.ex:1000
+#: lib/dpul_collections_web/live/item_live.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Viewer"
 msgstr "Abrir"
 
-#: lib/dpul_collections/item.ex:76
+#: lib/dpul_collections/item.ex:77
 #, elixir-autogen, elixir-format
 msgid "Alternative Title"
 msgstr "Título Alternativo"
 
-#: lib/dpul_collections/item.ex:116
+#: lib/dpul_collections/item.ex:117
 #, elixir-autogen, elixir-format
 msgid "Barcode"
 msgstr "Código de barras"
 
-#: lib/dpul_collections/item.ex:114
+#: lib/dpul_collections/item.ex:115
 #, elixir-autogen, elixir-format
 msgid "Box number"
 msgstr "Número de caja"
 
-#: lib/dpul_collections/item.ex:87
+#: lib/dpul_collections/item.ex:88
 #: lib/dpul_collections_web/live/item_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Content Warning"
 msgstr "Advertencia de contenido"
 
-#: lib/dpul_collections/item.ex:81
+#: lib/dpul_collections/item.ex:82
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -285,7 +285,7 @@ msgstr "Advertencia de contenido"
 msgid "Contributor"
 msgstr "Colaborador"
 
-#: lib/dpul_collections/item.ex:84
+#: lib/dpul_collections/item.ex:85
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -295,17 +295,17 @@ msgstr "Colaborador"
 msgid "Date Created"
 msgstr "Fecha de creación"
 
-#: lib/dpul_collections/item.ex:72
+#: lib/dpul_collections/item.ex:73
 #, elixir-autogen, elixir-format
 msgid "Descriptive Information"
 msgstr "Información descriptiva"
 
-#: lib/dpul_collections/item.ex:97
+#: lib/dpul_collections/item.ex:98
 #, elixir-autogen, elixir-format
 msgid "Discovery Information"
 msgstr "Información de descubrimiento"
 
-#: lib/dpul_collections/item.ex:109
+#: lib/dpul_collections/item.ex:110
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -315,13 +315,13 @@ msgstr "Información de descubrimiento"
 msgid "File Count"
 msgstr "Recuento de archivos"
 
-#: lib/dpul_collections/item.ex:115
+#: lib/dpul_collections/item.ex:116
 #, elixir-autogen, elixir-format
 msgid "Folder number"
 msgstr "Número de carpeta"
 
-#: lib/dpul_collections/item.ex:64
-#: lib/dpul_collections/item.ex:100
+#: lib/dpul_collections/item.ex:65
+#: lib/dpul_collections/item.ex:101
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -331,22 +331,22 @@ msgstr "Número de carpeta"
 msgid "Geographic Subject"
 msgstr "Tema geográfico"
 
-#: lib/dpul_collections/item.ex:106
+#: lib/dpul_collections/item.ex:107
 #, elixir-autogen, elixir-format
 msgid "Height"
 msgstr "Altura"
 
-#: lib/dpul_collections/item.ex:117
+#: lib/dpul_collections/item.ex:118
 #, elixir-autogen, elixir-format
 msgid "Holding location"
 msgstr "Ubicación del artículo"
 
-#: lib/dpul_collections/item.ex:118
+#: lib/dpul_collections/item.ex:119
 #, elixir-autogen, elixir-format
 msgid "IIIF Manifest URL"
 msgstr "URL del manifiesto IIIF"
 
-#: lib/dpul_collections/item.ex:111
+#: lib/dpul_collections/item.ex:112
 #, elixir-autogen, elixir-format
 msgid "Institutional Information"
 msgstr "Información institucional"
@@ -356,34 +356,34 @@ msgstr "Información institucional"
 msgid "Item Summary"
 msgstr "Resumen del artículo"
 
-#: lib/dpul_collections/item.ex:101
+#: lib/dpul_collections/item.ex:102
 #, elixir-autogen, elixir-format
 msgid "Keywords"
 msgstr "Palabras clave"
 
 #: lib/dpul_collections_web/live/item_live.ex:313
 #: lib/dpul_collections_web/live/item_live.ex:817
-#: lib/dpul_collections_web/live/item_live.ex:999
+#: lib/dpul_collections_web/live/item_live.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Metadata"
 msgstr "Metadatos"
 
-#: lib/dpul_collections/item.ex:108
+#: lib/dpul_collections/item.ex:109
 #, elixir-autogen, elixir-format
 msgid "Page Count"
 msgstr "Número de páginas"
 
-#: lib/dpul_collections/item.ex:104
+#: lib/dpul_collections/item.ex:105
 #, elixir-autogen, elixir-format
 msgid "Physical Characteristics"
 msgstr "Características físicas"
 
-#: lib/dpul_collections/item.ex:89
+#: lib/dpul_collections/item.ex:90
 #, elixir-autogen, elixir-format
 msgid "Provenance"
 msgstr "Procedencia"
 
-#: lib/dpul_collections/item.ex:92
+#: lib/dpul_collections/item.ex:93
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -393,27 +393,27 @@ msgstr "Procedencia"
 msgid "Rights Statement"
 msgstr "Derechos"
 
-#: lib/dpul_collections/item.ex:88
+#: lib/dpul_collections/item.ex:89
 #, elixir-autogen, elixir-format
 msgid "Series"
 msgstr "Serie"
 
-#: lib/dpul_collections/item.ex:77
+#: lib/dpul_collections/item.ex:78
 #, elixir-autogen, elixir-format
 msgid "Sort Title"
 msgstr "Título de ordenar"
 
-#: lib/dpul_collections/item.ex:74
+#: lib/dpul_collections/item.ex:75
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Título"
 
-#: lib/dpul_collections/item.ex:75
+#: lib/dpul_collections/item.ex:76
 #, elixir-autogen, elixir-format
 msgid "Transliterated Title"
 msgstr "Título transliterado"
 
-#: lib/dpul_collections/item.ex:107
+#: lib/dpul_collections/item.ex:108
 #, elixir-autogen, elixir-format
 msgid "Width"
 msgstr "Anchura"
@@ -509,12 +509,12 @@ msgstr "Explorar"
 msgid "Browse - Digital Collections"
 msgstr "Explorar - Colecciones digitales"
 
-#: lib/dpul_collections_web/live/item_live.ex:969
+#: lib/dpul_collections_web/live/item_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Copiado"
 
-#: lib/dpul_collections_web/live/item_live.ex:968
+#: lib/dpul_collections_web/live/item_live.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Copiar"
@@ -539,7 +539,7 @@ msgstr "Ver elementos aleatorios"
 msgid "main image display"
 msgstr "visualización de la imagen principal"
 
-#: lib/dpul_collections_web/live/search_live.ex:725
+#: lib/dpul_collections_web/live/search_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr "Resultados de la búsqueda por"
@@ -611,7 +611,7 @@ msgid "Categories"
 msgstr "Categorías"
 
 #: lib/dpul_collections_web/components/browse_item.ex:212
-#: lib/dpul_collections_web/live/search_live.ex:642
+#: lib/dpul_collections_web/live/search_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Fecha"
@@ -632,8 +632,8 @@ msgstr "Destacado"
 
 #: lib/dpul_collections_web/components/browse_item.ex:163
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:626
-#: lib/dpul_collections_web/live/search_live.ex:696
+#: lib/dpul_collections_web/live/search_live.ex:627
+#: lib/dpul_collections_web/live/search_live.ex:697
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr "Archivos"
@@ -691,7 +691,7 @@ msgstr "Mi Cuenta"
 msgid "My Sets"
 msgstr "Mis Conjuntos"
 
-#: lib/dpul_collections_web/live/search_live.ex:649
+#: lib/dpul_collections_web/live/search_live.ex:650
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr "Origen"
@@ -718,8 +718,8 @@ msgstr "Pósteres"
 msgid "Save"
 msgstr "Guardar"
 
-#: lib/dpul_collections_web/live/search_live.ex:660
-#: lib/dpul_collections_web/live/search_live.ex:666
+#: lib/dpul_collections_web/live/search_live.ex:661
+#: lib/dpul_collections_web/live/search_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr "Resultados de la búsqueda"
@@ -834,7 +834,7 @@ msgstr "Debe volver a autenticarse para acceder a esta página."
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr "Necesitas volver a autenticarte para realizar acciones confidenciales en tu cuenta."
 
-#: lib/dpul_collections/item.ex:113
+#: lib/dpul_collections/item.ex:114
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -953,7 +953,7 @@ msgstr "Explore las últimas incorporaciones a nuestra creciente colección de"
 msgid "Featured Highlights"
 msgstr "Destacado"
 
-#: lib/dpul_collections/item.ex:85
+#: lib/dpul_collections/item.ex:86
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/components/browse_item.ex:219
@@ -1051,7 +1051,7 @@ msgstr "contactar a la Biblioteca de la Universidad de Princeton"
 
 #: lib/dpul_collections_web/live/item_live.ex:152
 #: lib/dpul_collections_web/live/search_live.ex:524
-#: lib/dpul_collections_web/live/search_live.ex:593
+#: lib/dpul_collections_web/live/search_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr "formato"
@@ -1071,7 +1071,7 @@ msgstr "Filtros Activos"
 msgid "Apply Year Range"
 msgstr "Aplicar Rango de Años"
 
-#: lib/dpul_collections/item.ex:56
+#: lib/dpul_collections/item.ex:57
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -1081,13 +1081,13 @@ msgstr "Aplicar Rango de Años"
 msgid "Author"
 msgstr "Autor"
 
-#: lib/dpul_collections/item.ex:95
+#: lib/dpul_collections/item.ex:96
 #, elixir-autogen, elixir-format
 msgid "Binding Note"
 msgstr "Nota Vinculante"
 
-#: lib/dpul_collections/item.ex:49
-#: lib/dpul_collections/item.ex:78
+#: lib/dpul_collections/item.ex:50
+#: lib/dpul_collections/item.ex:79
 #, elixir-autogen, elixir-format
 msgid "Call Number"
 msgstr "Número de Llamada"
@@ -1102,12 +1102,12 @@ msgstr "Borrar todo"
 msgid "Close"
 msgstr "cerrar"
 
-#: lib/dpul_collections/item.ex:93
+#: lib/dpul_collections/item.ex:94
 #, elixir-autogen, elixir-format
 msgid "Contents"
 msgstr "Contenido"
 
-#: lib/dpul_collections/item.ex:58
+#: lib/dpul_collections/item.ex:59
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -1117,7 +1117,7 @@ msgstr "Contenido"
 msgid "Donor"
 msgstr "Donante"
 
-#: lib/dpul_collections/item.ex:86
+#: lib/dpul_collections/item.ex:87
 #, elixir-autogen, elixir-format
 msgid "Extent"
 msgstr "Medida"
@@ -1127,17 +1127,17 @@ msgstr "Medida"
 msgid "Filter Results"
 msgstr "Filtros"
 
-#: lib/dpul_collections/item.ex:79
+#: lib/dpul_collections/item.ex:80
 #, elixir-autogen, elixir-format
 msgid "Identifier"
 msgstr "Identificador"
 
-#: lib/dpul_collections/item.ex:94
+#: lib/dpul_collections/item.ex:95
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr "Notas"
 
-#: lib/dpul_collections/item.ex:54
+#: lib/dpul_collections/item.ex:55
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "Gente"
@@ -1148,12 +1148,12 @@ msgstr "Gente"
 msgid "Princeton University Library"
 msgstr "Biblioteca de la Universidad de Princeton"
 
-#: lib/dpul_collections/item.ex:91
+#: lib/dpul_collections/item.ex:92
 #, elixir-autogen, elixir-format
 msgid "References"
 msgstr "Referencias"
 
-#: lib/dpul_collections/item.ex:59
+#: lib/dpul_collections/item.ex:60
 #, elixir-autogen, elixir-format
 msgid "Related Name"
 msgstr "Nombre Relacionado"
@@ -1163,7 +1163,7 @@ msgstr "Nombre Relacionado"
 msgid "Results"
 msgstr "Resultados"
 
-#: lib/dpul_collections/item.ex:57
+#: lib/dpul_collections/item.ex:58
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -1178,7 +1178,7 @@ msgstr "Escriba"
 msgid "Search filters..."
 msgstr "Filtros de búsqueda..."
 
-#: lib/dpul_collections/item.ex:90
+#: lib/dpul_collections/item.ex:91
 #, elixir-autogen, elixir-format
 msgid "Source Acquisition"
 msgstr "Adquisición de Fuente"
@@ -1193,12 +1193,12 @@ msgstr "Abrir"
 msgid "filters"
 msgstr "Filtros"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:89
+#: lib/dpul_collections_web/components/search_bar_component.ex:121
 #, elixir-autogen, elixir-format
 msgid "Search all"
 msgstr "Buscar todo"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:48
+#: lib/dpul_collections_web/components/search_bar_component.ex:59
 #, elixir-autogen, elixir-format
-msgid "Search in this Collection"
-msgstr "Buscar en esta colección"
+msgid "In this Collection"
+msgstr "En esta colección"

--- a/priv/gettext/pt/LC_MESSAGES/default.po
+++ b/priv/gettext/pt/LC_MESSAGES/default.po
@@ -21,9 +21,9 @@ msgstr "Erro!"
 msgid "Hang in there while we get back on track"
 msgstr "Aguarde enquanto voltamos ao normal"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:25
-#: lib/dpul_collections_web/components/search_bar_component.ex:31
-#: lib/dpul_collections_web/components/search_bar_component.ex:85
+#: lib/dpul_collections_web/components/search_bar_component.ex:36
+#: lib/dpul_collections_web/components/search_bar_component.ex:42
+#: lib/dpul_collections_web/components/search_bar_component.ex:117
 #: lib/dpul_collections_web/live/search_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Search"
@@ -44,8 +44,8 @@ msgstr "Sucesso!"
 msgid "close"
 msgstr "fechar"
 
-#: lib/dpul_collections/item.ex:62
-#: lib/dpul_collections/item.ex:83
+#: lib/dpul_collections/item.ex:63
+#: lib/dpul_collections/item.ex:84
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/components/header_component.ex:89
@@ -56,12 +56,12 @@ msgstr "fechar"
 msgid "Language"
 msgstr "Idioma"
 
-#: lib/dpul_collections_web/live/search_live.ex:765
+#: lib/dpul_collections_web/live/search_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Próxima"
 
-#: lib/dpul_collections_web/live/search_live.ex:735
+#: lib/dpul_collections_web/live/search_live.ex:736
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Anterior"
@@ -148,9 +148,9 @@ msgstr "Navegar"
 
 #: lib/dpul_collections_web/components/header_component.ex:40
 #: lib/dpul_collections_web/live/home_live.ex:36
-#: lib/dpul_collections_web/live/item_live.ex:999
-#: lib/dpul_collections_web/live/item_live.ex:1000
-#: lib/dpul_collections_web/live/item_live.ex:1001
+#: lib/dpul_collections_web/live/item_live.ex:1076
+#: lib/dpul_collections_web/live/item_live.ex:1077
+#: lib/dpul_collections_web/live/item_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Digital Collections"
 msgstr "Coleções Digitais"
@@ -160,7 +160,7 @@ msgstr "Coleções Digitais"
 msgid "The Trustees of Princeton University"
 msgstr "Os Curadores da Universidade de Princeton"
 
-#: lib/dpul_collections_web/live/search_live.ex:601
+#: lib/dpul_collections_web/live/search_live.ex:602
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Adicionado"
@@ -194,8 +194,8 @@ msgstr "Ano"
 msgid "to"
 msgstr "a"
 
-#: lib/dpul_collections/item.ex:50
-#: lib/dpul_collections/item.ex:80
+#: lib/dpul_collections/item.ex:51
+#: lib/dpul_collections/item.ex:81
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -205,8 +205,8 @@ msgstr "a"
 msgid "Creator of work"
 msgstr "Criador da obra"
 
-#: lib/dpul_collections/item.ex:63
-#: lib/dpul_collections/item.ex:102
+#: lib/dpul_collections/item.ex:64
+#: lib/dpul_collections/item.ex:103
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -216,8 +216,8 @@ msgstr "Criador da obra"
 msgid "Geographic Origin"
 msgstr "Origem Geográfica"
 
-#: lib/dpul_collections/item.ex:51
-#: lib/dpul_collections/item.ex:82
+#: lib/dpul_collections/item.ex:52
+#: lib/dpul_collections/item.ex:83
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -227,8 +227,8 @@ msgstr "Origem Geográfica"
 msgid "Publisher"
 msgstr "Editora"
 
-#: lib/dpul_collections/item.ex:65
-#: lib/dpul_collections/item.ex:99
+#: lib/dpul_collections/item.ex:66
+#: lib/dpul_collections/item.ex:100
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -249,33 +249,33 @@ msgid "No PDF Available"
 msgstr "Nenhum PDF disponível"
 
 #: lib/dpul_collections_web/live/item_live.ex:361
-#: lib/dpul_collections_web/live/item_live.ex:1000
+#: lib/dpul_collections_web/live/item_live.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Viewer"
 msgstr "Visualizador"
 
-#: lib/dpul_collections/item.ex:76
+#: lib/dpul_collections/item.ex:77
 #, elixir-autogen, elixir-format
 msgid "Alternative Title"
 msgstr "Título Alternativo"
 
-#: lib/dpul_collections/item.ex:116
+#: lib/dpul_collections/item.ex:117
 #, elixir-autogen, elixir-format
 msgid "Barcode"
 msgstr "Código de Barras"
 
-#: lib/dpul_collections/item.ex:114
+#: lib/dpul_collections/item.ex:115
 #, elixir-autogen, elixir-format
 msgid "Box number"
 msgstr "Número da Caixa"
 
-#: lib/dpul_collections/item.ex:87
+#: lib/dpul_collections/item.ex:88
 #: lib/dpul_collections_web/live/item_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Content Warning"
 msgstr "Aviso de Conteúdo"
 
-#: lib/dpul_collections/item.ex:81
+#: lib/dpul_collections/item.ex:82
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -285,7 +285,7 @@ msgstr "Aviso de Conteúdo"
 msgid "Contributor"
 msgstr "Contribuinte"
 
-#: lib/dpul_collections/item.ex:84
+#: lib/dpul_collections/item.ex:85
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -295,17 +295,17 @@ msgstr "Contribuinte"
 msgid "Date Created"
 msgstr "Data de Criação"
 
-#: lib/dpul_collections/item.ex:72
+#: lib/dpul_collections/item.ex:73
 #, elixir-autogen, elixir-format
 msgid "Descriptive Information"
 msgstr "Informações Descritivas"
 
-#: lib/dpul_collections/item.ex:97
+#: lib/dpul_collections/item.ex:98
 #, elixir-autogen, elixir-format
 msgid "Discovery Information"
 msgstr "Informações de Descoberta"
 
-#: lib/dpul_collections/item.ex:109
+#: lib/dpul_collections/item.ex:110
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -315,13 +315,13 @@ msgstr "Informações de Descoberta"
 msgid "File Count"
 msgstr "Contagem de Arquivos"
 
-#: lib/dpul_collections/item.ex:115
+#: lib/dpul_collections/item.ex:116
 #, elixir-autogen, elixir-format
 msgid "Folder number"
 msgstr "Número da Pasta"
 
-#: lib/dpul_collections/item.ex:64
-#: lib/dpul_collections/item.ex:100
+#: lib/dpul_collections/item.ex:65
+#: lib/dpul_collections/item.ex:101
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -331,22 +331,22 @@ msgstr "Número da Pasta"
 msgid "Geographic Subject"
 msgstr "Assunto Geográfico"
 
-#: lib/dpul_collections/item.ex:106
+#: lib/dpul_collections/item.ex:107
 #, elixir-autogen, elixir-format
 msgid "Height"
 msgstr "Altura"
 
-#: lib/dpul_collections/item.ex:117
+#: lib/dpul_collections/item.ex:118
 #, elixir-autogen, elixir-format
 msgid "Holding location"
 msgstr "Local de Armazenamento"
 
-#: lib/dpul_collections/item.ex:118
+#: lib/dpul_collections/item.ex:119
 #, elixir-autogen, elixir-format
 msgid "IIIF Manifest URL"
 msgstr "URL do Manifesto IIIF"
 
-#: lib/dpul_collections/item.ex:111
+#: lib/dpul_collections/item.ex:112
 #, elixir-autogen, elixir-format
 msgid "Institutional Information"
 msgstr "Informações Institucionais"
@@ -356,34 +356,34 @@ msgstr "Informações Institucionais"
 msgid "Item Summary"
 msgstr "Resumo do Item"
 
-#: lib/dpul_collections/item.ex:101
+#: lib/dpul_collections/item.ex:102
 #, elixir-autogen, elixir-format
 msgid "Keywords"
 msgstr "Palavras-chave"
 
 #: lib/dpul_collections_web/live/item_live.ex:313
 #: lib/dpul_collections_web/live/item_live.ex:817
-#: lib/dpul_collections_web/live/item_live.ex:999
+#: lib/dpul_collections_web/live/item_live.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Metadata"
 msgstr "Metadados"
 
-#: lib/dpul_collections/item.ex:108
+#: lib/dpul_collections/item.ex:109
 #, elixir-autogen, elixir-format
 msgid "Page Count"
 msgstr "Contagem de Páginas"
 
-#: lib/dpul_collections/item.ex:104
+#: lib/dpul_collections/item.ex:105
 #, elixir-autogen, elixir-format
 msgid "Physical Characteristics"
 msgstr "Características Físicas"
 
-#: lib/dpul_collections/item.ex:89
+#: lib/dpul_collections/item.ex:90
 #, elixir-autogen, elixir-format
 msgid "Provenance"
 msgstr "Proveniência"
 
-#: lib/dpul_collections/item.ex:92
+#: lib/dpul_collections/item.ex:93
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -393,27 +393,27 @@ msgstr "Proveniência"
 msgid "Rights Statement"
 msgstr "Declaração de Direitos"
 
-#: lib/dpul_collections/item.ex:88
+#: lib/dpul_collections/item.ex:89
 #, elixir-autogen, elixir-format
 msgid "Series"
 msgstr "Série"
 
-#: lib/dpul_collections/item.ex:77
+#: lib/dpul_collections/item.ex:78
 #, elixir-autogen, elixir-format
 msgid "Sort Title"
 msgstr "Título de Ordenação"
 
-#: lib/dpul_collections/item.ex:74
+#: lib/dpul_collections/item.ex:75
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Título"
 
-#: lib/dpul_collections/item.ex:75
+#: lib/dpul_collections/item.ex:76
 #, elixir-autogen, elixir-format
 msgid "Transliterated Title"
 msgstr "Título Transliterado"
 
-#: lib/dpul_collections/item.ex:107
+#: lib/dpul_collections/item.ex:108
 #, elixir-autogen, elixir-format
 msgid "Width"
 msgstr "Largura"
@@ -509,12 +509,12 @@ msgstr "Explorar"
 msgid "Browse - Digital Collections"
 msgstr "Navegar - Coleções Digitais"
 
-#: lib/dpul_collections_web/live/item_live.ex:969
+#: lib/dpul_collections_web/live/item_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Copiado"
 
-#: lib/dpul_collections_web/live/item_live.ex:968
+#: lib/dpul_collections_web/live/item_live.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Copiar"
@@ -539,7 +539,7 @@ msgstr "Ver Itens Aleatórios"
 msgid "main image display"
 msgstr "exibição da imagem principal"
 
-#: lib/dpul_collections_web/live/search_live.ex:725
+#: lib/dpul_collections_web/live/search_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr "Navegação da Página de Resultados da Pesquisa"
@@ -611,7 +611,7 @@ msgid "Categories"
 msgstr "Categorias"
 
 #: lib/dpul_collections_web/components/browse_item.ex:212
-#: lib/dpul_collections_web/live/search_live.ex:642
+#: lib/dpul_collections_web/live/search_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Data"
@@ -632,8 +632,8 @@ msgstr "Destaques"
 
 #: lib/dpul_collections_web/components/browse_item.ex:163
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:626
-#: lib/dpul_collections_web/live/search_live.ex:696
+#: lib/dpul_collections_web/live/search_live.ex:627
+#: lib/dpul_collections_web/live/search_live.ex:697
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr "Arquivos"
@@ -691,7 +691,7 @@ msgstr "Minha Conta"
 msgid "My Sets"
 msgstr "Meus Conjuntos"
 
-#: lib/dpul_collections_web/live/search_live.ex:649
+#: lib/dpul_collections_web/live/search_live.ex:650
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr "Origem"
@@ -718,8 +718,8 @@ msgstr "Pôsteres"
 msgid "Save"
 msgstr "Salvar"
 
-#: lib/dpul_collections_web/live/search_live.ex:660
-#: lib/dpul_collections_web/live/search_live.ex:666
+#: lib/dpul_collections_web/live/search_live.ex:661
+#: lib/dpul_collections_web/live/search_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr "Resultados da Pesquisa"
@@ -834,7 +834,7 @@ msgstr "Você deve se reautenticar para acessar esta página."
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr "Você precisa se reautenticar para realizar ações confidenciais em sua conta."
 
-#: lib/dpul_collections/item.ex:113
+#: lib/dpul_collections/item.ex:114
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -953,7 +953,7 @@ msgstr "Explore as últimas adições à nossa crescente coleção de"
 msgid "Featured Highlights"
 msgstr "Destaques"
 
-#: lib/dpul_collections/item.ex:85
+#: lib/dpul_collections/item.ex:86
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/components/browse_item.ex:219
@@ -1051,7 +1051,7 @@ msgstr "entrar em contato com a Biblioteca da Universidade de Princeton"
 
 #: lib/dpul_collections_web/live/item_live.ex:152
 #: lib/dpul_collections_web/live/search_live.ex:524
-#: lib/dpul_collections_web/live/search_live.ex:593
+#: lib/dpul_collections_web/live/search_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr "formato"
@@ -1071,7 +1071,7 @@ msgstr "Filtros Ativos"
 msgid "Apply Year Range"
 msgstr "Aplicar Faixa Anual"
 
-#: lib/dpul_collections/item.ex:56
+#: lib/dpul_collections/item.ex:57
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -1081,13 +1081,13 @@ msgstr "Aplicar Faixa Anual"
 msgid "Author"
 msgstr "Autor"
 
-#: lib/dpul_collections/item.ex:95
+#: lib/dpul_collections/item.ex:96
 #, elixir-autogen, elixir-format
 msgid "Binding Note"
 msgstr "Nota Vinculativa"
 
-#: lib/dpul_collections/item.ex:49
-#: lib/dpul_collections/item.ex:78
+#: lib/dpul_collections/item.ex:50
+#: lib/dpul_collections/item.ex:79
 #, elixir-autogen, elixir-format
 msgid "Call Number"
 msgstr "Número de Chamada"
@@ -1102,12 +1102,12 @@ msgstr "Limpar Tudo"
 msgid "Close"
 msgstr "fechar"
 
-#: lib/dpul_collections/item.ex:93
+#: lib/dpul_collections/item.ex:94
 #, elixir-autogen, elixir-format
 msgid "Contents"
 msgstr "Conteúdo"
 
-#: lib/dpul_collections/item.ex:58
+#: lib/dpul_collections/item.ex:59
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -1117,7 +1117,7 @@ msgstr "Conteúdo"
 msgid "Donor"
 msgstr "Doador"
 
-#: lib/dpul_collections/item.ex:86
+#: lib/dpul_collections/item.ex:87
 #, elixir-autogen, elixir-format
 msgid "Extent"
 msgstr "Extensão"
@@ -1127,17 +1127,17 @@ msgstr "Extensão"
 msgid "Filter Results"
 msgstr "Filtros"
 
-#: lib/dpul_collections/item.ex:79
+#: lib/dpul_collections/item.ex:80
 #, elixir-autogen, elixir-format
 msgid "Identifier"
 msgstr "Identificador"
 
-#: lib/dpul_collections/item.ex:94
+#: lib/dpul_collections/item.ex:95
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr "Notas"
 
-#: lib/dpul_collections/item.ex:54
+#: lib/dpul_collections/item.ex:55
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "Pessoas"
@@ -1148,12 +1148,12 @@ msgstr "Pessoas"
 msgid "Princeton University Library"
 msgstr "Biblioteca da Universidade de Princeton"
 
-#: lib/dpul_collections/item.ex:91
+#: lib/dpul_collections/item.ex:92
 #, elixir-autogen, elixir-format
 msgid "References"
 msgstr "Referências"
 
-#: lib/dpul_collections/item.ex:59
+#: lib/dpul_collections/item.ex:60
 #, elixir-autogen, elixir-format
 msgid "Related Name"
 msgstr "Nome Relacionado"
@@ -1163,7 +1163,7 @@ msgstr "Nome Relacionado"
 msgid "Results"
 msgstr "Resultados"
 
-#: lib/dpul_collections/item.ex:57
+#: lib/dpul_collections/item.ex:58
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
 #: lib/dpul_collections_web/live/item_live.ex:2
@@ -1178,7 +1178,7 @@ msgstr "Escriba"
 msgid "Search filters..."
 msgstr "Filtros de pesquisa..."
 
-#: lib/dpul_collections/item.ex:90
+#: lib/dpul_collections/item.ex:91
 #, elixir-autogen, elixir-format
 msgid "Source Acquisition"
 msgstr "Aquisição de Fonte"
@@ -1193,12 +1193,12 @@ msgstr "Visualizador"
 msgid "filters"
 msgstr "Filtros"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:89
+#: lib/dpul_collections_web/components/search_bar_component.ex:121
 #, elixir-autogen, elixir-format
 msgid "Search all"
 msgstr "Pesquisar tudo"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:48
+#: lib/dpul_collections_web/components/search_bar_component.ex:59
 #, elixir-autogen, elixir-format
-msgid "Search in this Collection"
-msgstr "Pesquisar nesta coleção"
+msgid "In this Collection"
+msgstr "Nesta coleção"

--- a/test/dpul_collections_web/features/search_bar_test.exs
+++ b/test/dpul_collections_web/features/search_bar_test.exs
@@ -44,7 +44,7 @@ defmodule DpulCollectionsWeb.Features.SearchBarTest do
       |> assert_has(".phx-connected")
       |> assert_has("#search-button", text: "Search all", exact: true)
       |> assert_has("#collection-search-button")
-      |> click_button("Search in this Collection")
+      |> click_button("In this Collection")
       |> assert_has("section#filters", text: "Collection South Asian Ephemera")
     end
   end


### PR DESCRIPTION
closes #1140

Switched hero text area corner cut to the opposite corners so the eye doesn't pull to whether those diagonals are precisely the same as the ones in the subnav.

Changed "search in this collection" to "in this collection" -- it's clear from the context of the "search all" button.

Screenshots:
<img width="1774" height="815" alt="Screenshot 2026-05-01 at 2 46 36 PM" src="https://github.com/user-attachments/assets/9eec8ea2-a707-4085-b674-8b7717ea1bdd" />
<img width="300" alt="Screenshot 2026-05-01 at 2 46 43 PM" src="https://github.com/user-attachments/assets/8daf75f8-80ab-409c-80e0-d75fd9378d5d" />
<img width="300" alt="Screenshot 2026-05-01 at 2 47 17 PM" src="https://github.com/user-attachments/assets/2a1c3fb9-d154-4578-b2d9-0d8fe2996ba5" />
<img width="1289" height="950" alt="Screenshot 2026-05-01 at 2 46 56 PM" src="https://github.com/user-attachments/assets/475ff2cc-85d6-489e-8a69-a21125d742ac" />
<img width="400" alt="Screenshot 2026-05-01 at 2 47 04 PM" src="https://github.com/user-attachments/assets/725a66d5-119c-4547-944f-ade6e3042122" />


