### PR TITLE
Only render filters when expanded.

### DIFF
--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -332,8 +332,9 @@ defmodule DpulCollectionsWeb.SearchLive do
       </button>
 
       <div
+        :if={@expanded}
         id={"#{@field}-panel"}
-        class={["px-4 pb-4 border-t border-rust/10", @expanded && "expanded", !@expanded && "hidden"]}
+        class={["px-4 pb-4 border-t border-rust/10 expanded"]}
       >
         <.filter_input
           field={@field}

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -576,7 +576,9 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
   test "filters aren't case sensitive", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/search?filter[format][]=FOLDERS")
 
-    assert view |> has_element?(".filter.format", "FOLDERS")
+    view
+    |> element("#format-panel-button", "Format")
+    |> render_click()
 
     assert view |> element("input[name='filter[format][]'][value='Folders']") |> render() =~
              "checked"


### PR DESCRIPTION
With this change, on selecting manuscripts collection:

```
toString diff (update): 2.110107421875 ms
app-3d06fa3b8005a5166ec671aa976fee38.js?vsn=d:30 morphdom: 22.034912109375 ms
app-3d06fa3b8005a5166ec671aa976fee38.js?vsn=d:30 full patch complete: 54.3759765625 ms
```

Closes #1154
