### PR TITLE
Two-panel digital collection "Learn More"

### DIFF
--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -189,7 +189,6 @@ Hooks.ResponsivePills = {
     // Don't recalculate if expanded
     if (this.isExpanded) return
 
-    const ul = this.el.querySelector('.group')
     const allPillItems = this.el.querySelectorAll('.pill-item')
     const pillItemArray = [...allPillItems]
 
@@ -197,11 +196,10 @@ Hooks.ResponsivePills = {
     allPillItems.forEach(item => item.classList.remove('hidden'))
     // The goal is get "more" to show up, so hide all of them from the end until
     // that happens.
-    const ulRectangle = ul.getBoundingClientRect()
     let removedCount = 0
+    let maxRemoveCount = pillItemArray.length - 5
     pillItemArray.reverse().forEach((pill) => {
-      let moreButtonRectangle = this.moreButton.getBoundingClientRect()
-      if(moreButtonRectangle.top > ulRectangle.bottom) {
+      if(removedCount < maxRemoveCount) {
         removedCount++
         pill.classList.add("hidden")
       } else {

--- a/lib/dpul_collections/collection.ex
+++ b/lib/dpul_collections/collection.ex
@@ -48,7 +48,7 @@ defmodule DpulCollections.Collection do
       slug: doc["authoritative_slug_s"],
       title: title,
       tagline: doc |> Map.get("tagline_txtm", []) |> Enum.at(0),
-      summary: doc |> Map.get("summary_txtm", []) |> Enum.at(0),
+      summary: doc |> Map.get("summary_txtm", []) |> Enum.at(0) |> process_summary(),
       item_count: summary.count,
       categories: summary.categories,
       formats: summary.formats,
@@ -59,6 +59,16 @@ defmodule DpulCollections.Collection do
       url: "/collections/#{doc["authoritative_slug_s"]}",
       contributors: get_contributors(doc["authoritative_slug_s"])
     }
+  end
+
+  defp process_summary(nil), do: nil
+
+  defp process_summary(summary) do
+    summary
+    # Take all <h# tags and replace them with h3
+    |> String.replace(~r/<([\/]?)h[0-9]/, "<\\1h3")
+    # Get id of <br> - let our page flow handle it.
+    |> String.replace("<br>", "")
   end
 
   def get_contributors("sae") do

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -31,8 +31,8 @@ defmodule DpulCollectionsWeb.CollectionsLive do
   defp pill_section(assigns) do
     ~H"""
     <div :if={length(@items) > 0}>
-      <div class="flex items-center gap-3 mb-2 mt-4">
-        <h2 id={"#{@container_id}-header"} class="text-sm font-sans font-medium">
+      <div class="flex items-center gap-3 mb-2">
+        <h2 id={"#{@container_id}-header"} class="heading text-sm">
           {@title}
         </h2>
       </div>
@@ -42,13 +42,13 @@ defmodule DpulCollectionsWeb.CollectionsLive do
       >
         <ul
           aria-labelledby={"#{@container_id}-header"}
-          class="group max-h-[2.5rem] [&.expanded]:max-h-none flex flex-wrap gap-2 overflow-hidden"
+          class="group flex flex-wrap gap-2"
         >
           <%= for {{value, count}, idx} <- Enum.with_index(@items) do %>
             <li
               aria-setsize={length(@items) + 2}
               aria-posinset={idx + 1}
-              class="pill-item group-[.expanded]:block"
+              class="h-10 pill-item group-[.expanded]:block"
             >
               <.filter_link_button
                 filter_name={@unit}
@@ -201,7 +201,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
           </.browse_item_row>
         </div>
         <!-- Learn More -->
-        <div id="learn-more" class="grid-flow-row text-dark-text auto-rows-max">
+        <div id="learn-more" class="grid-flow-row text-dark-text auto-rows-max page-b-padding">
           <.content_separator />
           <div class="content-area">
             <h2 class="uppercase font-semibold text-4xl py-6">
@@ -210,9 +210,9 @@ defmodule DpulCollectionsWeb.CollectionsLive do
           </div>
           <div
             id="collection-summary"
-            class="content-area grid grid-cols-1 gap-6 font-serif"
+            class="content-area grid grid-cols-1 md:grid-cols-3 items-baseline gap-6 font-serif"
           >
-            <div>
+            <div class="col-1 md:col-2 md:col-span-1 flex flex-col gap-6">
               <.pill_section
                 title={gettext("Subject Areas")}
                 unit="category"
@@ -233,7 +233,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                 collection_title={@collection.title |> hd}
               />
             </div>
-            <div class="[&_a]:text-accent w-full text-lg page-t-padding">
+            <div class="[&_a]:text-accent w-full text-lg row-2 md:row-1 md:col-1 md:col-span-2">
               <div class="collection-summary leading-relaxed pb-6">
                 {@collection.summary |> raw}
               </div>

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -30,9 +30,9 @@ defmodule DpulCollectionsWeb.CollectionsLive do
 
   defp pill_section(assigns) do
     ~H"""
-    <div :if={length(@items) > 0}>
-      <div class="flex items-center gap-3 mb-2">
-        <h2 id={"#{@container_id}-header"} class="heading text-sm">
+    <div :if={length(@items) > 0} class="flex flex-col gap-4">
+      <div class="flex items-center gap-3">
+        <h2 id={"#{@container_id}-header"} class="heading text-sm text-end">
           {@title}
         </h2>
       </div>
@@ -212,7 +212,12 @@ defmodule DpulCollectionsWeb.CollectionsLive do
             id="collection-summary"
             class="content-area grid grid-cols-1 md:grid-cols-3 items-baseline gap-6 font-serif"
           >
-            <div class="col-1 md:col-2 md:col-span-1 flex flex-col gap-6">
+            <div class="[&_a]:text-accent text-lg md:col-span-2">
+              <div class="collection-summary pb-6 flex flex-col gap-4 [&_h3]:heading [&_h3]:text-md">
+                {@collection.summary |> raw}
+              </div>
+            </div>
+            <div class="flex flex-col gap-6">
               <.pill_section
                 title={gettext("Subject Areas")}
                 unit="category"
@@ -232,11 +237,6 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                 button_class="bg-cloud/80 hover:bg-cloud/60"
                 collection_title={@collection.title |> hd}
               />
-            </div>
-            <div class="[&_a]:text-accent w-full text-lg row-2 md:row-1 md:col-1 md:col-span-2">
-              <div class="collection-summary leading-relaxed pb-6">
-                {@collection.summary |> raw}
-              </div>
             </div>
           </div>
         </div>

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -212,12 +212,12 @@ defmodule DpulCollectionsWeb.CollectionsLive do
             id="collection-summary"
             class="content-area grid grid-cols-1 md:grid-cols-3 items-baseline gap-6 font-serif"
           >
-            <div class="[&_a]:text-accent text-lg md:col-span-2">
+            <div class="[&_a]:text-accent text-lg row-2 md:col-span-2">
               <div class="collection-summary pb-6 flex flex-col gap-4 [&_h3]:heading [&_h3]:text-md">
                 {@collection.summary |> raw}
               </div>
             </div>
-            <div class="flex flex-col gap-6">
+            <div class="flex flex-col gap-6 row-1 md:row-2">
               <.pill_section
                 title={gettext("Subject Areas")}
                 unit="category"

--- a/test/dpul_collections/collection_test.exs
+++ b/test/dpul_collections/collection_test.exs
@@ -25,6 +25,17 @@ defmodule DpulCollections.CollectionTest do
 
       assert length(collection.recently_added) == 1
     end
+
+    test "converts headings" do
+      FiggyTestSupport.index_record_id_directly("f99af4de-fed4-4baa-82b1-6e857b230306")
+      Solr.soft_commit()
+
+      collection = Collection.from_slug("sae")
+
+      assert collection.summary =~ "<h3"
+      assert collection.summary =~ "</h3"
+      refute collection.summary =~ "<br>"
+    end
   end
 
   describe ".get_contributors/1" do


### PR DESCRIPTION
* Fixes Headings
* Removes `<br>`, so our page flow takes over.
* Makes top 5 subjects/formats show.
* Re-adds two-column layout and does some styling work to try to make it closer to the original mockup in https://github.com/pulibrary/dpul-collections/issues/888

## Before

<img width="1353" height="696" alt="Screenshot 2026-04-23 at 6 10 25 PM" src="https://github.com/user-attachments/assets/4c44e471-9627-422e-a2be-4cade630297a" />


## After

<img width="1624" height="881" alt="Screenshot 2026-04-23 at 6 09 48 PM" src="https://github.com/user-attachments/assets/95cbfd58-3419-4f79-8442-2d79e65203f2" />

Closes #903 