### PR TITLE
Tighten up filters quite a lot.

### DIFF
--- a/lib/dpul_collections_web/components/core_components.ex
+++ b/lib/dpul_collections_web/components/core_components.ex
@@ -514,7 +514,7 @@ defmodule DpulCollectionsWeb.CoreComponents do
       closedBy="any"
       class="drawer pointer-events-none backdrop:bg-black/50 fixed inset-0 m-0 max-h-full max-w-full h-full w-full bg-transparent open:flex open:justify-end"
     >
-      <div class="pointer-events-auto w-full sm:max-w-2xl h-full bg-background shadow-xl flex flex-col">
+      <div class="pointer-events-auto w-full sm:max-w-lg h-full bg-background shadow-xl flex flex-col">
         <div class="flex items-center justify-between px-4 py-4 border-b border-rust/20 bg-sage-100">
           <h2 id={"#{@id}-label"} class="text-lg font-bold">
             {@label}


### PR DESCRIPTION
Small iteration towards #1159

## Before

<img width="1284" height="720" alt="Screenshot 2026-04-28 at 10 34 18 AM" src="https://github.com/user-attachments/assets/83c7c136-e1d5-4d12-aba2-6e8f8f68ea24" />


## After


<img width="1286" height="714" alt="Screenshot 2026-04-28 at 10 33 52 AM" src="https://github.com/user-attachments/assets/e91ba7cb-c0aa-4216-8e75-14ff136aeec4" />
