### PR TITLE
Collection Header Sizing

### DIFF
--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -52,7 +52,8 @@ defmodule DpulCollections.Solr do
     "updated_at_dt",
     "content_warning_s",
     "geographic_origin_txt_sort",
-    "tagline_txtm"
+    "tagline_txtm",
+    "primary_thumbnail_h_w_ratio_f"
   ]
 
   def raw_query(search_state, index \\ Index.read_index()) do

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -101,41 +101,40 @@ defmodule DpulCollectionsWeb.CollectionsLive do
             </h1>
           </div>
           <div class="page-y-padding relative z-30">
-            <div class="hero-container-collection flex md:flex-row-reverse w-full gap-0">
-              <!-- Right Column: Featured Items Mosaic -->
+            <div class="hero-container-collection flex flex-col md:flex-row-reverse w-full">
               <div
                 id="collection-mosaic"
-                class="flex flex-col gap-4 grow shrink-0"
+                class="flex gap-4 flex-col md:h-full md:shrink-0"
                 phx-update="ignore"
               >
-                <div class="p-2 card-darkdrop bg-white/75 flex justify-center">
-                  <div>
-                    <.link
-                      :if={@mosaic_title_item}
-                      href={@mosaic_title_item.url}
-                      aria-label={"View #{@mosaic_title_item.title |> hd}"}
-                    >
-                      <img
-                        src={"#{@mosaic_title_item.primary_thumbnail_service_url}/full/!#{@mosaic_title_item.primary_thumbnail_width},#{@mosaic_title_item.primary_thumbnail_height}/0/default.jpg"}
-                        width={@mosaic_title_item.primary_thumbnail_width}
-                        height={@mosaic_title_item.primary_thumbnail_height}
-                        class="object-contain object-top max-h-[600px]"
-                        alt={@mosaic_title_item.title |> hd}
-                      />
-                    </.link>
-                  </div>
+                <div class="p-2 card-darkdrop bg-white/75 flex justify-center flex-1 min-h-0">
+                  <.link
+                    :if={@mosaic_title_item}
+                    href={@mosaic_title_item.url}
+                    aria-label={"View #{@mosaic_title_item.title |> hd}"}
+                    class="block h-full max-w-full"
+                  >
+                    <img
+                      src={"#{@mosaic_title_item.primary_thumbnail_service_url}/full/!#{@mosaic_title_item.primary_thumbnail_width},#{@mosaic_title_item.primary_thumbnail_height}/0/default.jpg"}
+                      width={@mosaic_title_item.primary_thumbnail_width}
+                      height={@mosaic_title_item.primary_thumbnail_height}
+                      class="object-contain object-top h-full w-auto max-w-full"
+                      alt={@mosaic_title_item.title |> hd}
+                    />
+                  </.link>
                 </div>
-                <div class="flex justify-items-end">
+
+                <div class="flex justify-end">
                   <.primary_button
                     href={~p"/search?#{%{filter: %{collection: [@collection.title |> hd]}}}"}
-                    class="btn-primary hidden md:flex ml-auto"
+                    class="btn-primary hidden md:flex"
                   >
                     {gettext("Browse Collection")}
                   </.primary_button>
                 </div>
               </div>
-              <!-- Left Column: Content -->
-              <div class="grow-0 shrink-5">
+
+              <div class="grow flex-1 min-w-0 overflow-y-auto">
                 <div class="w-full relative z-30">
                   <div class="flex flex-wrap gap-4 p-5 relative z-50 bg-white/75">
                     <p class="text-lg text-dark-text pb-2">
@@ -161,14 +160,12 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                   </div>
                 </div>
                 <div class="flex flex-wrap gap-4 py-4">
-                  <a
-                    href="#learn-more"
-                    class="btn-secondary grow md:grow-0"
-                  >
+                  <a href="#learn-more" class="btn-secondary grow md:grow-0">
                     {gettext("Learn More")}
                   </a>
                 </div>
               </div>
+
               <div class="grid-cols-1 col-span-2 static md:hidden">
                 <.primary_button
                   href={~p"/search?#{%{filter: %{collection: [@collection.title |> hd]}}}"}

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -104,7 +104,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
             <div class="hero-container-collection flex flex-col md:flex-row-reverse w-full">
               <div
                 id="collection-mosaic"
-                class="flex items-center md:items-start gap-4 flex-col md:max-w-[70%]"
+                class="flex items-center md:items-end gap-4 flex-col md:max-w-[70%]"
                 phx-update="ignore"
               >
                 <div class="p-2 card-darkdrop bg-white/75">

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -117,7 +117,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                       src={"#{@mosaic_title_item.primary_thumbnail_service_url}/full/!#{@mosaic_title_item.primary_thumbnail_width},#{@mosaic_title_item.primary_thumbnail_height}/0/default.jpg"}
                       width={@mosaic_title_item.primary_thumbnail_width}
                       height={@mosaic_title_item.primary_thumbnail_height}
-                      class="max-h-[50dvh] max-w-full w-auto h-auto"
+                      class="h-[50dvh] max-h-[50dvh] max-w-full w-auto"
                       alt={@mosaic_title_item.title |> hd}
                     />
                   </.link>

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -104,21 +104,20 @@ defmodule DpulCollectionsWeb.CollectionsLive do
             <div class="hero-container-collection flex flex-col md:flex-row-reverse w-full">
               <div
                 id="collection-mosaic"
-                class="flex gap-4 flex-col md:h-full md:shrink-0"
+                class="flex items-center md:items-start gap-4 flex-col md:max-w-[70%]"
                 phx-update="ignore"
               >
-                <div class="p-2 card-darkdrop bg-white/75 flex justify-center flex-1 min-h-0">
+                <div class="p-2 card-darkdrop bg-white/75">
                   <.link
                     :if={@mosaic_title_item}
                     href={@mosaic_title_item.url}
                     aria-label={"View #{@mosaic_title_item.title |> hd}"}
-                    class="block h-full max-w-full"
                   >
                     <img
                       src={"#{@mosaic_title_item.primary_thumbnail_service_url}/full/!#{@mosaic_title_item.primary_thumbnail_width},#{@mosaic_title_item.primary_thumbnail_height}/0/default.jpg"}
                       width={@mosaic_title_item.primary_thumbnail_width}
                       height={@mosaic_title_item.primary_thumbnail_height}
-                      class="object-contain object-top h-full w-auto max-w-full"
+                      class="max-h-[50dvh] max-w-full w-auto h-auto"
                       alt={@mosaic_title_item.title |> hd}
                     />
                   </.link>
@@ -134,13 +133,13 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                 </div>
               </div>
 
-              <div class="grow flex-1 min-w-0 overflow-y-auto">
+              <div class="grow flex-1 min-w-0 w-full">
                 <div class="w-full relative z-30">
                   <div class="flex flex-wrap gap-4 p-5 relative z-50 bg-white/75">
                     <p class="text-lg text-dark-text pb-2">
                       {@collection.tagline}
                     </p>
-                    <div class="flex flex-wrap justify-center items-center text-dark-text gap-2">
+                    <div class="flex flex-wrap items-center text-dark-text gap-2">
                       <div class="text-sm bg-cloud rounded-full px-3 py-1">
                         {@collection.item_count} {gettext("Items")}
                       </div>
@@ -166,7 +165,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                 </div>
               </div>
 
-              <div class="grid-cols-1 col-span-2 static md:hidden">
+              <div class="grid-cols-1 col-span-2 static md:hidden w-full">
                 <.primary_button
                   href={~p"/search?#{%{filter: %{collection: [@collection.title |> hd]}}}"}
                   class="btn-primary w-full"

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -120,7 +120,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                       class={[
                         (@mosaic_title_item.primary_thumbnail_height >=
                            @mosaic_title_item.primary_thumbnail_width && "md:h-[50dvh] w-auto") ||
-                          "md:w-30dvw h-auto",
+                          "md:w-50dvw h-auto",
                         "object-contain"
                       ]}
                       alt={@mosaic_title_item.title |> hd}

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -101,6 +101,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
             </h1>
           </div>
           <div class="page-y-padding relative z-30">
+            <!-- Right Column: Featured Items Mosaic -->
             <div class="hero-container-collection flex flex-col md:flex-row-reverse w-full">
               <div
                 id="collection-mosaic"
@@ -137,7 +138,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                   </.primary_button>
                 </div>
               </div>
-
+              <!-- Left Column: Content -->
               <div class="grow flex-1 min-w-0 w-full">
                 <div class="w-full relative z-30">
                   <div class="flex flex-wrap gap-4 p-5 relative z-50 bg-white/75">

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -118,7 +118,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                       width={@mosaic_title_item.primary_thumbnail_width}
                       height={@mosaic_title_item.primary_thumbnail_height}
                       class={[
-                        (@mosaic_title_item.primary_thumbnail_height >
+                        (@mosaic_title_item.primary_thumbnail_height >=
                            @mosaic_title_item.primary_thumbnail_width && "md:h-[50dvh] w-auto") ||
                           "md:w-30dvw h-auto",
                         "object-contain"

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -120,7 +120,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                       class={[
                         (@mosaic_title_item.primary_thumbnail_height >=
                            @mosaic_title_item.primary_thumbnail_width && "md:h-[50dvh] w-auto") ||
-                          "md:w-50dvw h-auto",
+                          "md:w-[50dvw] h-auto",
                         "object-contain"
                       ]}
                       alt={@mosaic_title_item.title |> hd}

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -117,7 +117,12 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                       src={"#{@mosaic_title_item.primary_thumbnail_service_url}/full/!#{@mosaic_title_item.primary_thumbnail_width},#{@mosaic_title_item.primary_thumbnail_height}/0/default.jpg"}
                       width={@mosaic_title_item.primary_thumbnail_width}
                       height={@mosaic_title_item.primary_thumbnail_height}
-                      class="h-[50dvh] max-h-[50dvh] max-w-full w-auto"
+                      class={[
+                        (@mosaic_title_item.primary_thumbnail_height >
+                           @mosaic_title_item.primary_thumbnail_width && "h-[50dvh] w-auto") ||
+                          "w-30dvw h-auto",
+                        "object-contain"
+                      ]}
                       alt={@mosaic_title_item.title |> hd}
                     />
                   </.link>

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -120,7 +120,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                       class={[
                         (@mosaic_title_item.primary_thumbnail_height >=
                            @mosaic_title_item.primary_thumbnail_width && "md:h-[50dvh] w-auto") ||
-                          "md:w-[50dvw] h-auto",
+                          "md:w-[50dvw] max-h-[50dvh] h-auto",
                         "object-contain"
                       ]}
                       alt={@mosaic_title_item.title |> hd}

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -101,26 +101,25 @@ defmodule DpulCollectionsWeb.CollectionsLive do
             </h1>
           </div>
           <div class="page-y-padding relative z-30">
-            <div class="hero-container-collection flex md:flex-row-reverse flex-col gap-0">
+            <div class="hero-container-collection flex md:flex-row-reverse w-full gap-0">
               <!-- Right Column: Featured Items Mosaic -->
               <div
                 id="collection-mosaic"
-                class="flex flex-col gap-4 w-full grow"
+                class="flex flex-col gap-4 grow shrink-0"
                 phx-update="ignore"
               >
-                <div class="max-h-120 p-2 card-darkdrop bg-white min-h-0 min-w-0 flex">
-                  <div class="overflow-hidden w-full">
+                <div class="p-2 card-darkdrop bg-white/75 flex justify-center">
+                  <div>
                     <.link
                       :if={@mosaic_title_item}
                       href={@mosaic_title_item.url}
-                      class="overflow-hidden"
                       aria-label={"View #{@mosaic_title_item.title |> hd}"}
                     >
                       <img
                         src={"#{@mosaic_title_item.primary_thumbnail_service_url}/full/!#{@mosaic_title_item.primary_thumbnail_width},#{@mosaic_title_item.primary_thumbnail_height}/0/default.jpg"}
                         width={@mosaic_title_item.primary_thumbnail_width}
                         height={@mosaic_title_item.primary_thumbnail_height}
-                        class="object-cover object-top max-h-full max-w-full w-full"
+                        class="object-contain object-top max-h-[600px]"
                         alt={@mosaic_title_item.title |> hd}
                       />
                     </.link>
@@ -136,7 +135,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                 </div>
               </div>
               <!-- Left Column: Content -->
-              <div class="md:max-w-[40%]">
+              <div class="grow-0 shrink-5">
                 <div class="w-full relative z-30">
                   <div class="flex flex-wrap gap-4 p-5 relative z-50 bg-white/75">
                     <p class="text-lg text-dark-text pb-2">

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -119,8 +119,8 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                       height={@mosaic_title_item.primary_thumbnail_height}
                       class={[
                         (@mosaic_title_item.primary_thumbnail_height >
-                           @mosaic_title_item.primary_thumbnail_width && "h-[50dvh] w-auto") ||
-                          "w-30dvw h-auto",
+                           @mosaic_title_item.primary_thumbnail_width && "md:h-[50dvh] w-auto") ||
+                          "md:w-30dvw h-auto",
                         "object-contain"
                       ]}
                       alt={@mosaic_title_item.title |> hd}

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -120,7 +120,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                       class={[
                         (@mosaic_title_item.primary_thumbnail_height >=
                            @mosaic_title_item.primary_thumbnail_width && "md:h-[50dvh] w-auto") ||
-                          "md:w-[50dvw] max-h-[50dvh] h-auto",
+                          "md:w-[30dvw] max-h-[50dvh] h-auto",
                         "object-contain"
                       ]}
                       alt={@mosaic_title_item.title |> hd}


### PR DESCRIPTION
Closes #1160 

I'm not 100% on this - the extremes still end up with a bunch of dead space that feels really odd, but I do think it's better than cutting off a bunch of stuff.

It's -weirdly- hard to get an image to fill up as much space as possible, then fill in everything else beside it.

## Before

<img width="1521" height="1081" alt="Screenshot 2026-04-30 at 4 08 22 PM" src="https://github.com/user-attachments/assets/654c566a-d4c7-4bbd-bf93-857ebd2238ad" />


## After

<img width="1574" height="1065" alt="Screenshot 2026-04-30 at 4 08 17 PM" src="https://github.com/user-attachments/assets/83d3c484-d9b2-420a-a588-fff5b10d5624" />

## Before

<img width="1460" height="798" alt="Screenshot 2026-04-30 at 4 09 49 PM" src="https://github.com/user-attachments/assets/05dcdc8c-debc-4cea-bacf-f3f78b769818" />


## After

<img width="1478" height="1044" alt="Screenshot 2026-04-30 at 4 10 01 PM" src="https://github.com/user-attachments/assets/7fea023f-8f2e-4d14-97eb-3cdcd7fc5cc8" />


## Before

<img width="1445" height="1115" alt="Screenshot 2026-04-30 at 4 10 41 PM" src="https://github.com/user-attachments/assets/c94cd176-9308-448a-955b-a94f7d94bc93" />


## After
<img width="1522" height="1090" alt="Screenshot 2026-04-30 at 4 10 47 PM" src="https://github.com/user-attachments/assets/14c2c650-e5ae-4972-ba98-234c1d249522" />

