### PR TITLE
Add filter hotkey

### DIFF
--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -181,7 +181,31 @@ defmodule DpulCollectionsWeb.SearchLive do
         }
       }
     </script>
-    <section id="filters">
+    <script :type={Phoenix.LiveView.ColocatedHook} name=".FilterHotkey">
+      export default {
+        mounted() {
+          this.handler = (e) => {
+            // Return unless the `f` key is pressed
+            if (e.key !== 'f') return;
+            // Return if any modifier key is pressed
+            if (e.metaKey || e.ctrlKey || e.altKey) return;
+            const target = e.target;
+            // Return if we are inputting text so we can use the `f` character
+            if (target.tagName === 'INPUT' && target.type === 'text') return;
+
+            e.preventDefault();
+            const modal = document.getElementById('filter-modal');
+            const event = modal.open ? 'dpulc:closeDialog' : 'dpulc:showDialog';
+            modal.dispatchEvent(new Event(event));
+          };
+          window.addEventListener('keydown', this.handler);
+        },
+        destroyed() {
+          window.removeEventListener('keydown', this.handler);
+        }
+      }
+    </script>
+    <section id="filters" phx-hook=".FilterHotkey">
       <div id="search-filters" class="content-area py-4 w-full">
         <div class="flex items-center gap-4 flex-wrap">
           <.primary_button

--- a/test/dpul_collections_web/features/search_test.exs
+++ b/test/dpul_collections_web/features/search_test.exs
@@ -2,6 +2,7 @@ defmodule DpulCollectionsWeb.Features.SearchTest do
   use DpulCollections.DataCase
   use PhoenixTest.Playwright.Case
   alias DpulCollections.Solr
+  alias PhoenixTest.Playwright
 
   test "filters are searchable", %{conn: conn} do
     Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
@@ -40,6 +41,48 @@ defmodule DpulCollectionsWeb.Features.SearchTest do
     |> assert_has("button.format.filter")
 
     :timer.sleep(1000)
+  end
+
+  describe "the 'f' filter hotkey" do
+    test "toggles the filter modal open and closed", %{conn: conn} do
+      Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
+      Solr.soft_commit(active_collection())
+
+      conn
+      |> visit("/search?q=")
+      |> assert_has(".phx-connected")
+      |> refute_has("#filter-modal")
+      |> Playwright.press("body", "f")
+      |> assert_has("#filter-modal h2", text: "Filter Results")
+      |> Playwright.press("body", "f")
+      |> refute_has("#filter-modal")
+    end
+
+    test "is ignored when typing in the search input", %{conn: conn} do
+      Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
+      Solr.soft_commit(active_collection())
+
+      conn
+      |> visit("/search?q=")
+      |> assert_has(".phx-connected")
+      |> Playwright.press("#q", "f")
+      |> refute_has("#filter-modal")
+    end
+
+    test "still toggles after a filter checkbox has been clicked", %{conn: conn} do
+      Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
+      Solr.soft_commit(active_collection())
+
+      # Open the modal, then press 'f'
+      conn
+      |> visit("/search?q=")
+      |> assert_has(".phx-connected")
+      |> click_button("Filters")
+      |> click_button("Format")
+      |> check("Pamphlets", exact: false)
+      |> Playwright.press("body", "f")
+      |> refute_has("#filter-modal")
+    end
   end
 
   test "search page is accessible", %{conn: conn} do


### PR DESCRIPTION
Closes #1172 

Use the `f` key to open and close the filter modal.