### PR TITLE
Improve "Skip To Content"

### DIFF
--- a/lib/dpul_collections_web/components/layouts/root.html.heex
+++ b/lib/dpul_collections_web/components/layouts/root.html.heex
@@ -15,15 +15,16 @@
   </head>
   <body class="bg-white antialiased text-dark-text">
     <.google_tag_manager_noscript />
-    <nav id="skip-link" role="navigation" aria-label={gettext("Skip links")}>
-      <a
-        class="transition left-0 bg-primary bg-gray-200 text-primary-content absolute p-3 m-3 -translate-y-16 focus:translate-y-0"
-        href="#main-content"
-      >
-        {gettext("Skip To Content")}
-      </a>
-    </nav>
     <div class="flex flex-col min-h-screen" id="app">
+      <nav id="skip-link" role="navigation" aria-label={gettext("Skip links")}>
+        <button
+          type="button"
+          phx-click={JS.focus(to: "#main-content")}
+          class="transition left-0 bg-primary bg-gray-200 text-primary-content absolute p-3 m-3 -translate-y-16 focus:translate-y-0"
+        >
+          {gettext("Skip To Content")}
+        </button>
+      </nav>
       {@inner_content}
     </div>
   </body>


### PR DESCRIPTION
1. Nests the "Skip To Content" in #app so tab order is correct
1. Converts "Skip To Content" to a button that focuses "#main-content. Button is more semantic.