### PR TITLE
Try a simpler matting strategy for digital collections header.

### DIFF
--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -52,7 +52,8 @@ defmodule DpulCollections.Solr do
     "updated_at_dt",
     "content_warning_s",
     "geographic_origin_txt_sort",
-    "tagline_txtm"
+    "tagline_txtm",
+    "primary_thumbnail_h_w_ratio_f"
   ]
 
   def raw_query(search_state, index \\ Index.read_index()) do

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -108,7 +108,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                 class="flex flex-col gap-4 w-full grow"
                 phx-update="ignore"
               >
-                <div class="max-h-120 p-2 card-darkdrop bg-white min-h-0 min-w-0 flex">
+                <div class="max-h-120 p-2 card-darkdrop bg-white/75 min-h-0 min-w-0 flex">
                   <div class="overflow-hidden w-full">
                     <.link
                       :if={@mosaic_title_item}
@@ -120,7 +120,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                         src={"#{@mosaic_title_item.primary_thumbnail_service_url}/full/!#{@mosaic_title_item.primary_thumbnail_width},#{@mosaic_title_item.primary_thumbnail_height}/0/default.jpg"}
                         width={@mosaic_title_item.primary_thumbnail_width}
                         height={@mosaic_title_item.primary_thumbnail_height}
-                        class="object-cover object-top max-h-full max-w-full w-full"
+                        class="object-contain object-top max-h-full max-w-full w-full"
                         alt={@mosaic_title_item.title |> hd}
                       />
                     </.link>


### PR DESCRIPTION
Work towards #1160

This design prefers empty space for un-cropped photos to prevent the text from taking over the screen.

<img width="1361" height="797" alt="Screenshot 2026-05-04 at 12 09 14 PM" src="https://github.com/user-attachments/assets/a334363a-3e58-46df-a422-4f7523153cd9" />
<img width="1317" height="753" alt="Screenshot 2026-05-04 at 12 09 22 PM" src="https://github.com/user-attachments/assets/51b2ece1-e8ab-4468-b903-a34d47789782" />
<img width="1326" height="788" alt="Screenshot 2026-05-04 at 12 09 30 PM" src="https://github.com/user-attachments/assets/d10a0dc3-4e82-422a-90a4-9d0323f8d0d7" />
<img width="1349" height="754" alt="Screenshot 2026-05-04 at 12 09 47 PM" src="https://github.com/user-attachments/assets/4b0a0432-d1d8-4dde-90d5-0746acaa76b1" />
<img width="1372" height="748" alt="Screenshot 2026-05-04 at 12 10 03 PM" src="https://github.com/user-attachments/assets/101c6344-6273-4bbf-b787-2851e1b91542" />
<img width="1328" height="735" alt="Screenshot 2026-05-04 at 12 10 13 PM" src="https://github.com/user-attachments/assets/bacc1235-cc73-4a7e-a922-bd9d97c5159a" />
