### PR TITLE
Update missing CSS changes for LiveView 1.1

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -98,7 +98,7 @@
  * Make LiveView wrapper divs transparent for layout.
  * This makes it possible to use LiveViews as flex children for example.
  */
-[data-phx-root-id] { display: contents }
+[data-phx-session], [data-phx-teleported-src] { display: contents }
 
 /***
  * page layout utilities


### PR DESCRIPTION
This got updated here: https://github.com/phoenixframework/phoenix/pull/6268

But wasn't part of the update instructions, so we never got it: https://hexdocs.pm/phoenix_live_view/changelog.html

This parameter changed in https://github.com/phoenixframework/phoenix_live_view/pull/4184 to show up early, which I -think- means it triggers this bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1791648