### PR TITLE
Try matting strategy without the white background, so it's similar to LAE.*

### DIFF
--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -52,7 +52,8 @@ defmodule DpulCollections.Solr do
     "updated_at_dt",
     "content_warning_s",
     "geographic_origin_txt_sort",
-    "tagline_txtm"
+    "tagline_txtm",
+    "primary_thumbnail_h_w_ratio_f"
   ]
 
   def raw_query(search_state, index \\ Index.read_index()) do

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -108,7 +108,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                 class="flex flex-col gap-4 w-full grow"
                 phx-update="ignore"
               >
-                <div class="max-h-120 p-2 card-darkdrop bg-white/75 min-h-0 min-w-0 flex">
+                <div class="max-h-120 p-2 card-darkdrop min-h-0 min-w-0 flex">
                   <div class="overflow-hidden w-full">
                     <.link
                       :if={@mosaic_title_item}

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -108,7 +108,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                 class="flex flex-col gap-4 w-full grow"
                 phx-update="ignore"
               >
-                <div class="max-h-120 p-2 card-darkdrop bg-white min-h-0 min-w-0 flex">
+                <div class="max-h-120 p-2 card-darkdrop bg-white/75 min-h-0 min-w-0 flex">
                   <div class="overflow-hidden w-full">
                     <.link
                       :if={@mosaic_title_item}
@@ -120,7 +120,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                         src={"#{@mosaic_title_item.primary_thumbnail_service_url}/full/!#{@mosaic_title_item.primary_thumbnail_width},#{@mosaic_title_item.primary_thumbnail_height}/0/default.jpg"}
                         width={@mosaic_title_item.primary_thumbnail_width}
                         height={@mosaic_title_item.primary_thumbnail_height}
-                        class="object-cover object-top max-h-full max-w-full w-full"
+                        class="object-contain object-top max-h-full max-w-full w-full"
                         alt={@mosaic_title_item.title |> hd}
                       />
                     </.link>


### PR DESCRIPTION
There's some button adjusting and aligning of the left/right vertically that'd have to happen here, and I think the ones that end up with a little even matting around the picture look better, but we should be able to get an idea from these screenshots:

<img width="1371" height="731" alt="Screenshot 2026-05-06 at 9 41 12 AM" src="https://github.com/user-attachments/assets/4092fbcf-d382-42af-9897-375cb7a520fb" />
<img width="1434" height="809" alt="Screenshot 2026-05-06 at 9 40 54 AM" src="https://github.com/user-attachments/assets/fed87d1d-392c-4a68-ace4-394e143ba4e5" />
<img width="1433" height="739" alt="Screenshot 2026-05-06 at 9 40 49 AM" src="https://github.com/user-attachments/assets/04d5912d-c300-4dcf-8b5a-1028f242141c" />
<img width="1380" height="846" alt="Screenshot 2026-05-06 at 9 40 45 AM" src="https://github.com/user-attachments/assets/871b1b5a-b0d4-450c-b236-fd05ddc0444e" />
<img width="1378" height="800" alt="Screenshot 2026-05-06 at 9 40 40 AM" src="https://github.com/user-attachments/assets/5b6a9f8c-b128-4d51-a205-101aa1eb3075" />
<img width="1389" height="784" alt="Screenshot 2026-05-06 at 9 40 37 AM" src="https://github.com/user-attachments/assets/f8846a34-a9c5-47e8-8745-f86511b8ef98" />
<img width="1349" height="780" alt="Screenshot 2026-05-06 at 9 40 34 AM" src="https://github.com/user-attachments/assets/ab1b7b2d-3bcc-4460-98dd-1e28f3f3bde1" />
<img width="1296" height="821" alt="Screenshot 2026-05-06 at 9 40 31 AM" src="https://github.com/user-attachments/assets/975cb2fc-db35-469d-974d-8bafb0b3aaed" />
<img width="1344" height="845" alt="Screenshot 2026-05-06 at 9 40 28 AM" src="https://github.com/user-attachments/assets/7583e67f-b8cd-4eee-ab34-aa4917786e36" />
<img width="1457" height="815" alt="Screenshot 2026-05-06 at 9 40 25 AM" src="https://github.com/user-attachments/assets/291d5a87-e079-4311-8312-157ec32b59cf" />
<img width="1393" height="847" alt="Screenshot 2026-05-06 at 9 40 22 AM" src="https://github.com/user-attachments/assets/a3becd83-c3e4-4e0c-ac11-097edc2eb476" />
<img width="1372" height="881" alt="Screenshot 2026-05-06 at 9 40 15 AM" src="https://github.com/user-attachments/assets/65d34226-cd17-4c59-8c37-e7f49a1b4c5a" />
<img width="1425" height="892" alt="Screenshot 2026-05-06 at 9 40 09 AM" src="https://github.com/user-attachments/assets/6f62a9f8-1894-453e-a62b-19a3dc294f60" />
