### PR TITLE
Format numbers based on locale

### DIFF
--- a/lib/dpul_collections_web/cldr.ex
+++ b/lib/dpul_collections_web/cldr.ex
@@ -3,6 +3,6 @@ defmodule DpulCollectionsWeb.Cldr do
   """
   use Cldr,
     locales: ["en", "es", "pt"],
-    gettext: MyPhoenixApp.Gettext,
+    gettext: DpulCollectionsWeb.Gettext,
     providers: [Cldr.Number, Cldr.Calendar, Cldr.DateTime, Cldr.LocaleDisplay]
 end

--- a/lib/dpul_collections_web/components/browse_item.ex
+++ b/lib/dpul_collections_web/components/browse_item.ex
@@ -167,7 +167,7 @@ defmodule DpulCollectionsWeb.BrowseItem do
               :if={@thumb_source.file_count > 4}
               class="absolute bg-background right-2 top-0 z-10 pr-2 pb-1 diagonal-drop"
             >
-              {@thumb_source.file_count} {gettext("Files")}
+              {format_number(@thumb_source.file_count)} {gettext("Files")}
             </div>
           </div>
           <div class="flex-grow flex w-full flex-col justify-end">

--- a/lib/dpul_collections_web/components/core_components.ex
+++ b/lib/dpul_collections_web/components/core_components.ex
@@ -899,4 +899,13 @@ defmodule DpulCollectionsWeb.CoreComponents do
   def translate_errors(errors, field) when is_list(errors) do
     for {^field, {msg, opts}} <- errors, do: translate_error({msg, opts})
   end
+
+  @doc """
+  Formats a number using language-specific delimiters
+  """
+  def format_number(number) when is_integer(number) do
+    DpulCollectionsWeb.Cldr.Number.to_string!(number)
+  end
+
+  def format_number(_), do: nil
 end

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -56,7 +56,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                 collection_filter={@collection_title}
                 class={@pill_class}
               >
-                {value} ({count})
+                {value} ({format_number(count)})
               </.filter_link_button>
             </li>
           <% end %>
@@ -67,7 +67,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
           </li>
           <li class={"more-button invisible group-[.expanded]:invisible less-button px-3 py-1.5 #{@button_class}"}>
             <button class="w-full h-full cursor-pointer text-xs">
-              +<span class="more-count">{length(@items)}</span> more
+              +<span class="more-count">{format_number(length(@items))}</span> more
             </button>
           </li>
         </ul>
@@ -144,19 +144,19 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                     </p>
                     <div class="flex flex-wrap justify-center items-center text-dark-text gap-2">
                       <div class="text-sm bg-cloud rounded-full px-3 py-1">
-                        {@collection.item_count} {gettext("Items")}
+                        {format_number(@collection.item_count)} {gettext("Items")}
                       </div>
                       <div
                         :if={length(@collection.languages) > 0}
                         class="text-sm bg-cloud rounded-full px-3 py-1"
                       >
-                        {length(@collection.languages)} {gettext("Languages")}
+                        {format_number(length(@collection.languages))} {gettext("Languages")}
                       </div>
                       <div
                         :if={length(@collection.geographic_origins) > 0}
                         class="text-sm bg-cloud rounded-full px-3 py-1"
                       >
-                        {length(@collection.geographic_origins)} {gettext("Locations")}
+                        {format_number(length(@collection.geographic_origins))} {gettext("Locations")}
                       </div>
                     </div>
                   </div>

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -200,8 +200,8 @@ defmodule DpulCollectionsWeb.ItemLive do
             <div class="grid grid-cols-2 py-1 pr-2">
               <div class="text-left text-l text-gray-600 font-semibold">
                 {gettext("%{file_min} of %{file_max} images",
-                  file_min: min(@item.file_count, image_thumb_grid_count()),
-                  file_max: @item.file_count
+                  file_min: format_number(min(@item.file_count, image_thumb_grid_count())),
+                  file_max: format_number(@item.file_count)
                 )}
               </div>
               <div class="text-right text-accent uppercase">

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -78,7 +78,7 @@ defmodule DpulCollectionsWeb.SearchLive do
         true -> first_item + per_page - 1
       end
 
-    "#{first_item} - #{last_item} #{gettext("of")} #{total_items}"
+    "#{format_number(first_item)} - #{format_number(last_item)} #{gettext("of")} #{format_number(total_items)}"
   end
 
   attr :current_scope, :map, required: false, default: nil
@@ -286,7 +286,7 @@ defmodule DpulCollectionsWeb.SearchLive do
     >
       <div class="p-4 flex flex-col gap-4 grow">
         <p class="text-sm text-dark-text">
-          Filter your {@total_items} results
+          Filter your {format_number(@total_items)} results
         </p>
 
         <div class="flex flex-col gap-4">
@@ -318,7 +318,7 @@ defmodule DpulCollectionsWeb.SearchLive do
           phx-click={JS.exec("dcjs-close", to: "#filter-modal")}
           class="cursor-pointer w-full py-3 font-bold rounded-md"
         >
-          {gettext("View")} {@total_items} {gettext("Results")}
+          {gettext("View")} {format_number(@total_items)} {gettext("Results")}
         </.primary_button>
       </div>
     </.form>
@@ -471,7 +471,7 @@ defmodule DpulCollectionsWeb.SearchLive do
         class="max-h-100 overflow-y-auto grid grid-cols-1 sm:grid-cols-1 space-y-1"
         options={
           @filter.data
-          |> Enum.map(fn {value, count} -> {{value, count}, value} end)
+          |> Enum.map(fn {value, count} -> {{value, format_number(count)}, value} end)
         }
       />
     </div>
@@ -539,15 +539,15 @@ defmodule DpulCollectionsWeb.SearchLive do
           <div :if={@item.tagline} class="text-base">{@item.tagline}</div>
           <div class="brief-metadata flex flex-auto flex-row gap-4">
             <div class="flex flex-col pe-4 gap-0 py-0 h-min">
-              <div class="text-lg">{@item.item_count}</div>
+              <div class="text-lg">{format_number(@item.item_count)}</div>
               <div class="text-base">Items</div>
             </div>
             <div class="flex flex-col pe-4 gap-0 py-0 h-min">
-              <div class="text-lg">{length(@item.languages)}</div>
+              <div class="text-lg">{format_number(length(@item.languages))}</div>
               <div class="text-base">Languages</div>
             </div>
             <div class="flex flex-col pe-4 gap-0 py-0 h-min">
-              <div class="text-lg">{length(@item.geographic_origins)}</div>
+              <div class="text-lg">{format_number(length(@item.geographic_origins))}</div>
               <div class="text-base">Locations</div>
             </div>
           </div>
@@ -632,7 +632,7 @@ defmodule DpulCollectionsWeb.SearchLive do
               id={"filecount-#{@item.id}"}
               class="hidden absolute diagonal-rise -right-px -bottom-px bg-sage-100 pr-4 py-2 text-sm"
             >
-              {@item.file_count} {gettext("Files")}
+              {format_number(@item.file_count)} {gettext("Files")}
             </div>
           </div>
         </div>
@@ -702,7 +702,7 @@ defmodule DpulCollectionsWeb.SearchLive do
         :if={@item.file_count > 1}
         class="absolute sm:hidden diagonal-rise right-0 bottom-0 bg-sage-100 pr-4 py-2"
       >
-        {@item.file_count} {gettext("Files")}
+        {format_number(@item.file_count)} {gettext("Files")}
       </div>
     </div>
     """
@@ -792,7 +792,7 @@ defmodule DpulCollectionsWeb.SearchLive do
     """
   end
 
-  attr :text, :string, doc: "the page number, or ellipsis"
+  attr :text, :any, doc: "the page number, or ellipsis"
   attr :current_page, :boolean, default: false, doc: "whether this is the current page"
   attr :class, :string
 
@@ -812,7 +812,7 @@ defmodule DpulCollectionsWeb.SearchLive do
       phx-click="paginate"
       phx-value-page={@text}
     >
-      {@text}
+      {format_number(@text)}
     </a>
     """
   end
@@ -820,7 +820,7 @@ defmodule DpulCollectionsWeb.SearchLive do
   def page_link_or_span(assigns = %{current_page: true}) do
     ~H"""
     <span class={[@class, "active bg-accent font-semibold"]}>
-      {@text}
+      {format_number(@text)}
     </span>
     """
   end

--- a/lib/dpul_collections_web/set_locale_hook.ex
+++ b/lib/dpul_collections_web/set_locale_hook.ex
@@ -7,6 +7,7 @@ defmodule DpulCollectionsWeb.SetLocaleHook do
 
   def on_mount(:default, _params, %{"locale" => locale}, socket) do
     Gettext.put_locale(DpulCollectionsWeb.Gettext, locale)
+    Cldr.put_locale(DpulCollectionsWeb.Cldr, locale)
     {:cont, Phoenix.Component.assign(socket, :locale, locale)}
   end
 
@@ -14,6 +15,7 @@ defmodule DpulCollectionsWeb.SetLocaleHook do
     # Fallback when "locale" is not in session
     default_locale = "en"
     Gettext.put_locale(DpulCollectionsWeb.Gettext, default_locale)
+    Cldr.put_locale(DpulCollectionsWeb.Cldr, default_locale)
     {:cont, Phoenix.Component.assign(socket, :locale, default_locale)}
   end
 end

--- a/lib/plug/locale_plug.ex
+++ b/lib/plug/locale_plug.ex
@@ -22,6 +22,7 @@ defmodule DpulCollectionsWeb.LocalePlug do
 
       locale ->
         Gettext.put_locale(backend, locale)
+        Cldr.put_locale(DpulCollectionsWeb.Cldr, locale)
 
         conn
         |> put_resp_header("content-language", locale_to_language(locale))

--- a/test/dpul_collections_web/core_components_test.exs
+++ b/test/dpul_collections_web/core_components_test.exs
@@ -243,4 +243,36 @@ defmodule DpulCollectionsWeb.CoreComponents.ButtonTest do
       assert list == ["not found"]
     end
   end
+
+  describe "format_number" do
+    setup do
+      # reset locale to original value on exit
+      original = Cldr.get_locale(DpulCollectionsWeb.Cldr)
+      on_exit(fn -> Cldr.put_locale(DpulCollectionsWeb.Cldr, original) end)
+      :ok
+    end
+
+    test "uses commas as delimiters if language is English" do
+      Cldr.put_locale(DpulCollectionsWeb.Cldr, "en")
+      assert format_number(1234) == "1,234"
+      assert format_number(1_234_567) == "1,234,567"
+    end
+
+    test "uses periods as delimiters if language is Spanish" do
+      Cldr.put_locale(DpulCollectionsWeb.Cldr, "es")
+      assert format_number(1234) == "1234"
+      assert format_number(10000) == "10.000"
+      assert format_number(1_234_567) == "1.234.567"
+    end
+
+    test "uses periods as delimiters if language is Portuguese" do
+      Cldr.put_locale(DpulCollectionsWeb.Cldr, "pt")
+      assert format_number(1234) == "1.234"
+      assert format_number(1_234_567) == "1.234.567"
+    end
+
+    test "does not error with nil value" do
+      assert format_number(nil) == nil
+    end
+  end
 end

--- a/test/dpul_collections_web/set_locale_hook_test.exs
+++ b/test/dpul_collections_web/set_locale_hook_test.exs
@@ -8,6 +8,7 @@ defmodule DpulCollectionsWeb.SetLocaleHookTest do
   setup do
     # Reset locale before each test to avoid interference
     Gettext.put_locale(DpulCollectionsWeb.Gettext, @default_locale)
+    Cldr.put_locale(DpulCollectionsWeb.Cldr, @default_locale)
     :ok
   end
 
@@ -23,6 +24,7 @@ defmodule DpulCollectionsWeb.SetLocaleHookTest do
     # Assert
     assert updated_socket.assigns.locale == "es"
     assert Gettext.get_locale(DpulCollectionsWeb.Gettext) == "es"
+    assert Cldr.get_locale(DpulCollectionsWeb.Cldr).cldr_locale_name == :es
   end
 
   test "assigns default locale when locale is not in session" do
@@ -38,6 +40,7 @@ defmodule DpulCollectionsWeb.SetLocaleHookTest do
     # Assert
     assert updated_socket.assigns.locale == @default_locale
     assert Gettext.get_locale(DpulCollectionsWeb.Gettext) == @default_locale
+    assert Cldr.get_locale(DpulCollectionsWeb.Cldr).cldr_locale_name == :en
   end
 
   test "handles unexpected session structure gracefully" do

--- a/test/plug/locale_plug_test.exs
+++ b/test/plug/locale_plug_test.exs
@@ -8,6 +8,7 @@ defmodule DpulCollectionsWeb.LocalePlugTest do
   setup do
     # Reset locale before each test to avoid interference
     Gettext.put_locale(DpulCollectionsWeb.Gettext, @default_locale)
+    Cldr.put_locale(DpulCollectionsWeb.Cldr, @default_locale)
     :ok
   end
 
@@ -15,6 +16,7 @@ defmodule DpulCollectionsWeb.LocalePlugTest do
     conn = get(conn, "/?locale=es")
 
     assert Gettext.get_locale(DpulCollectionsWeb.Gettext) == "es"
+    assert Cldr.get_locale(DpulCollectionsWeb.Cldr).cldr_locale_name == :es
     assert conn.resp_cookies["locale"][:value] == "es"
     assert get_resp_header(conn, "content-language") == ["es"]
   end


### PR DESCRIPTION
Closes #1133 

EN:
<img width="1086" height="623" alt="Screenshot 2026-05-05 at 4 16 30 PM" src="https://github.com/user-attachments/assets/32305fb2-b63a-4124-9c1d-6fb3e8ed67a8" />

ES:
<img width="1090" height="627" alt="Screenshot 2026-05-05 at 4 16 17 PM" src="https://github.com/user-attachments/assets/e8a6639a-5a4b-4802-8651-1d11a4f17f20" />

PT:
<img width="1086" height="624" alt="Screenshot 2026-05-05 at 4 15 49 PM" src="https://github.com/user-attachments/assets/c227ba49-4ede-41ce-a486-773ab2cbe484" />
