### PR TITLE
Ignore bandit logger errors

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -20,7 +20,7 @@ config :swoosh, local: false
 # Do not print debug messages in production
 config :logger, level: :info
 
-config :honeybadger, environment_name: {:system, "APP_ENV"}
+config :honeybadger, environment_name: {:system, "APP_ENV"}, ignored_domains: [:bandit]
 
 # Runtime production configuration, including reading
 # of environment variables, is done on config/runtime.exs.


### PR DESCRIPTION
Honeybadger for Elixir apparently has both a plug for catching errors
and can track any errors that use "Logger." Normally Honeybadger
prevents duplication by ignoring the logger domain "cowboy" which you
can see in the errors that don't have a controller and things. However,
Phoenix uses Bandit now - so replace it with "bandit" and hopefully our
duplicates go away.

Honeybadger docs here: https://github.com/honeybadger-io/honeybadger-elixir

Closes #1186
