### PR TITLE
[WIP] Filter preview

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -278,6 +278,27 @@
   @apply text-accent hover:bg-primary-bright w-6 h-6 p-1 bg-background;
 }
 
+@utility force-mobile-items {
+  & .item > div {
+    grid-template-rows: auto !important;
+    grid-template-columns: none !important;
+  }
+
+  & .metadata {
+    grid-column: unset !important;
+    grid-column-start: unset !important;
+  }
+
+  & .small-thumbnails {
+    display: none !important;
+  }
+
+  & .search-thumbnail img {
+    height: 200px !important;
+    width: 200px !important;
+  }
+}
+
 @utility card {
   @apply drop-shadow-[0.25rem_0.25rem_0.25rem_var(--color-sage-300)];
   @apply hover:drop-shadow-[0_0_0.7rem_var(--color-sage-600)];
@@ -419,6 +440,7 @@
 #collection-page .recent-container {
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
 }
+
 
 /* Every odd section has a dark background, so change the card backdrop to
  * prevent them from glowing. */

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -108,8 +108,8 @@ Hooks.ShowPageCount = {
     let elID = this.el.getAttribute("data-id")
     // subtract large thumbnail from total file count; it has separate layout
     let elFilecount = this.el.getAttribute("data-filecount") - 1
-    let fileCountLabelEl = window.document.getElementById('filecount-'+elID)
-    let containerEl = window.document.getElementById('item-metadata-'+elID)
+    let fileCountLabelEl = window.document.querySelector('[data-filecount-id="filecount-'+elID+'"]')
+    let containerEl = this.el.querySelector(".metadata")
 
     // Handle Resize
     this.handleResize = () => {

--- a/lib/dpul_collections_web/components/core_components.ex
+++ b/lib/dpul_collections_web/components/core_components.ex
@@ -510,27 +510,12 @@ defmodule DpulCollectionsWeb.CoreComponents do
       dcjs-close={JS.dispatch("dpulc:closeDialog") |> JS.exec("dcjs-after-close")}
       dcjs-after-close={@afterClose}
       phx-remove={JS.exec("dcjs-close")}
-      aria-labelledby={"#{@id}-label"}
       closedBy="any"
       class="drawer pointer-events-none backdrop:bg-black/50 fixed inset-0 m-0 max-h-full max-w-full h-full w-full bg-transparent open:flex open:justify-end"
     >
-      <div class="pointer-events-auto w-full sm:max-w-2xl h-full bg-background shadow-xl flex flex-col">
-        <div class="flex items-center justify-between px-4 py-4 border-b border-rust/20 bg-sage-100">
-          <h2 id={"#{@id}-label"} class="text-lg font-bold">
-            {@label}
-          </h2>
-          <button
-            type="button"
-            class="p-2 hover:bg-primary-bright rounded-md transition-colors cursor-pointer"
-            phx-click={JS.exec("dcjs-close", to: {:closest, "dialog"})}
-          >
-            <.icon name="hero-x-mark" class="h-5 w-5" />
-            <span class="sr-only">{gettext("Close")}</span>
-          </button>
-        </div>
-        <div class="flex flex-col overflow-y-auto grow">
-          {render_slot(@inner_block)}
-        </div>
+
+      <div class="pointer-events-auto w-full sm:max-w-6xl h-full bg-background shadow-xl flex flex-col">
+        {render_slot(@inner_block)}
       </div>
     </dialog>
     """

--- a/lib/dpul_collections_web/components/core_components.ex
+++ b/lib/dpul_collections_web/components/core_components.ex
@@ -510,7 +510,7 @@ defmodule DpulCollectionsWeb.CoreComponents do
       dcjs-after-close={@afterClose}
       phx-remove={JS.exec("dcjs-close")}
       closedBy="any"
-      class="drawer pointer-events-none backdrop:bg-black/50 fixed inset-0 m-0 max-h-full max-w-full h-full w-full bg-transparent open:flex open:justify-end"
+      class="drawer pointer-events-none backdrop:bg-black/90 fixed inset-0 m-0 max-h-full max-w-full h-full w-full bg-transparent open:flex open:justify-end"
     >
       <div class="pointer-events-auto w-full sm:max-w-6xl h-full bg-background shadow-xl flex flex-col">
         {render_slot(@inner_block)}

--- a/lib/dpul_collections_web/components/core_components.ex
+++ b/lib/dpul_collections_web/components/core_components.ex
@@ -469,14 +469,13 @@ defmodule DpulCollectionsWeb.CoreComponents do
       dcjs-close={JS.dispatch("dpulc:closeDialog") |> JS.exec("dcjs-after-close")}
       dcjs-after-close={@afterClose}
       phx-remove={JS.exec("dcjs-close")}
-      aria-labelledby={"#{@id}-label"}
       closedBy="any"
       class="modal max-w-2xl backdrop:bg-black/50 open:fixed open:top-[50%] open:left-[50%] open:-translate-x-[50%] open:-translate-y-[50%] fixed bg-white rounded-lg shadow-sm text-dark-text"
     >
       <div class="w-full max-w-2xl bg-white shadow-lg rounded-lg p-8 relative">
         <!-- Modal header -->
         <div class="flex items-center justify-between border-b border-gray-300 pb-3">
-          <h2 id={"#{@id}-label"} class="text-xl font-semibold">
+          <h2 class="text-xl font-semibold">
             {@label}
           </h2>
           <button

--- a/lib/dpul_collections_web/components/core_components.ex
+++ b/lib/dpul_collections_web/components/core_components.ex
@@ -513,7 +513,6 @@ defmodule DpulCollectionsWeb.CoreComponents do
       closedBy="any"
       class="drawer pointer-events-none backdrop:bg-black/50 fixed inset-0 m-0 max-h-full max-w-full h-full w-full bg-transparent open:flex open:justify-end"
     >
-
       <div class="pointer-events-auto w-full sm:max-w-6xl h-full bg-background shadow-xl flex flex-col">
         {render_slot(@inner_block)}
       </div>
@@ -764,6 +763,24 @@ defmodule DpulCollectionsWeb.CoreComponents do
 
   def input(%{type: "hidden", multiple: true} = assigns) do
     ~H"""
+    """
+  end
+
+  def input(%{type: "hidden"} = assigns) do
+    ~H"""
+    <input
+      type={@type}
+      name={@name}
+      id={@id}
+      value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+      class={[
+        "block w-full text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
+        "phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400",
+        @errors == [] && "border-zinc-300 focus:border-zinc-400",
+        @errors != [] && "border-rose-400 focus:border-rose-400"
+      ]}
+      {@rest}
+    />
     """
   end
 

--- a/lib/dpul_collections_web/content_warnings.ex
+++ b/lib/dpul_collections_web/content_warnings.ex
@@ -44,7 +44,8 @@ defmodule DpulCollectionsWeb.ContentWarnings do
       dcjs-open={JS.exec("dcjs-open", to: {:inner, "dialog"})}
     >
       <.link
-        class="flex gap-2 align-center text-rust"
+        id={"open-show-image-banner-#{@item_id}"}
+        class="show-image-banner-link flex gap-2 align-center text-rust"
         phx-click={JS.exec("dcjs-open", to: {:closest, "div"})}
       >
         <span class="flex-none">

--- a/lib/dpul_collections_web/content_warnings.ex
+++ b/lib/dpul_collections_web/content_warnings.ex
@@ -40,13 +40,12 @@ defmodule DpulCollectionsWeb.ContentWarnings do
   def show_images_banner(assigns) do
     ~H"""
     <div
-      id={"show-image-banner-#{@item_id}"}
       class="show-image-banner absolute top-0 left-0 w-full p-3 bg-white z-2 flex gap-2 align-center"
+      dcjs-open={JS.exec("dcjs-open", to: {:inner, "dialog"})}
     >
       <.link
-        id={"open-show-image-banner-#{@item_id}"}
         class="flex gap-2 align-center text-rust"
-        phx-click={JS.exec("dcjs-open", to: "#show-image-banner-#{@item_id}-dialog")}
+        phx-click={JS.exec("dcjs-open", to: {:closest, "div"})}
       >
         <span class="flex-none">
           <.icon name="hero-eye-slash" class="h-5 w-5 icon mb-[2px]" />
@@ -55,11 +54,11 @@ defmodule DpulCollectionsWeb.ContentWarnings do
           {gettext("Why are the images blurred?")}
         </span>
       </.link>
+      <.content_modal
+        item_id={@item_id}
+        content_warning={@content_warning}
+      />
     </div>
-    <.content_modal
-      item_id={@item_id}
-      content_warning={@content_warning}
-    />
     """
   end
 

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -289,12 +289,12 @@ defmodule DpulCollectionsWeb.SearchLive do
       for={@filter_form}
       class="grow flex flex-col min-h-0"
     >
-      <div class="flex flex-col gap-4 overflow-y-auto grow min-h-0">
+      <div class="flex flex-col gap-4 overflow-y-auto grow pt-4 min-h-0">
         <div class={[
-          "py-3 px-4 bg-primary-light border-b border-rust/20",
+          "-mt-4 py-3 px-4 bg-primary-light border-b border-rust/20",
           map_size(@search_state.filter) == 0 && "hidden"
         ]}>
-          <div class="flex items-center justify-between">
+          <div class="flex items-center justify-between mb-2">
             <span class="text-sm font-semibold">{gettext("Active Filters")}</span>
             <.link
               patch="/search"
@@ -417,6 +417,7 @@ defmodule DpulCollectionsWeb.SearchLive do
     ~H"""
     <.primary_button
       :if={@filter_value}
+      type="button"
       role="button"
       phx-value-filter-value={@filter_value}
       phx-value-filter={@field}

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -96,6 +96,10 @@ defmodule DpulCollectionsWeb.SearchLive do
         year_form={@year_form}
         filter_data={@filter_data}
         expanded_filter={@expanded_filter}
+        items={@items}
+        show_images={@show_images}
+        current_scope={@current_scope}
+        current_path={@current_path}
       />
       <section class="content-area">
         <div class="py-4 flex flex-row justify-between gap-4">
@@ -254,8 +258,19 @@ defmodule DpulCollectionsWeb.SearchLive do
               </button>
             </div>
           </div>
-          <div class="p-4">
-            Preview items here..
+          <div class="p-4 overflow-y-auto">
+            <ul class="force-mobile-items grid grid-flow-row auto-rows-max gap-8">
+              <.search_item
+                :for={item <- @items}
+                search_state={@search_state}
+                item={item}
+                sort_by={@search_state.sort_by}
+                show_images={@show_images}
+                current_scope={@current_scope}
+                current_path={@current_path}
+                id_prefix="filter-"
+              />
+            </ul>
           </div>
           <.filter_form_component
             search_state={@search_state}
@@ -513,10 +528,12 @@ defmodule DpulCollectionsWeb.SearchLive do
     |> Enum.map(fn {k, v} -> {v[:label], k} end)
   end
 
+  attr :id_prefix, :string, required: false, default: nil
+
   def search_item(assigns = %{item: %Collection{}}) do
     ~H"""
     <li
-      id={"item-#{@item.id}"}
+      id={"#{@id_prefix}item-#{@item.id}"}
       class="item card"
       data-id={@item.id}
       aria-label={@item.title |> hd}
@@ -539,10 +556,7 @@ defmodule DpulCollectionsWeb.SearchLive do
             />
           </div>
         </div>
-        <div
-          class="metadata sm:col-span-3 flex flex-col gap-2 sm:gap-4 p-4"
-          id={"item-metadata-#{@item.id}"}
-        >
+        <div class="metadata sm:col-span-3 flex flex-col gap-2 sm:gap-4 p-4">
           <div class="flex flex-wrap flex-row sm:flex-row justify-between">
             <h2 dir="auto" class="w-full flex-grow sm:w-fit">
               <.link
@@ -584,7 +598,7 @@ defmodule DpulCollectionsWeb.SearchLive do
   def search_item(assigns = %{item: %Item{}}) do
     ~H"""
     <li
-      id={"item-#{@item.id}"}
+      id={"#{@id_prefix}item-#{@item.id}"}
       class="item card text-start"
       aria-label={@item.title |> hd}
       phx-hook="ShowPageCount"
@@ -608,16 +622,12 @@ defmodule DpulCollectionsWeb.SearchLive do
           item={@item}
           show_images={@show_images}
         />
-        <div
-          class="metadata sm:col-span-3 sm:col-start-2 flex flex-col gap-2 sm:gap-4 p-4"
-          id={"item-metadata-#{@item.id}"}
-        >
+        <div class="metadata sm:col-span-3 sm:col-start-2 flex flex-col gap-2 sm:gap-4 p-4">
           <div class="flex flex-wrap flex-row sm:flex-row justify-between">
             <h2 dir="auto" class="w-full flex-grow sm:w-fit pr-3">
               <.link
                 navigate={@item.url}
                 class="card-link"
-                id={"item-title-#{@item.id}"}
               >
                 {@item.title}
               </.link>
@@ -653,7 +663,7 @@ defmodule DpulCollectionsWeb.SearchLive do
               show_images={@show_images}
             />
             <div
-              id={"filecount-#{@item.id}"}
+              data-filecount-id={"filecount-#{@item.id}"}
               class="hidden absolute diagonal-rise -right-px -bottom-px bg-sage-100 pr-4 py-2 text-sm"
             >
               {format_number(@item.file_count)} {gettext("Files")}

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -233,7 +233,7 @@ defmodule DpulCollectionsWeb.SearchLive do
       </div>
 
       <.drawer id="filter-modal" label={gettext("Filter Results")}>
-        <div class="grid grid-cols-[1fr_minmax(0,36rem)] grid-rows-[auto_1fr] h-full gap-0">
+        <div class="grid grid-cols-[1fr_minmax(0,36rem)] grid-rows-[auto_1fr] h-full">
           <div class="grid grid-cols-subgrid items-baseline col-span-2 px-4 py-4 border-1 border-rust/20 bg-sage-100">
             <div class="flex">
               <h2 class="text-lg font-bold">
@@ -254,21 +254,17 @@ defmodule DpulCollectionsWeb.SearchLive do
               </button>
             </div>
           </div>
-          <div class="grid col-span-2 grid-cols-subgrid min-h-0">
-            <div class="flex py-4 px-4 min-h-0">
-              Preview items here..
-            </div>
-            <div class="flex flex-col border-l border-rust/20 min-h-0">
-              <.filter_form_component
-                search_state={@search_state}
-                total_items={@total_items}
-                filter_form={@filter_form}
-                year_form={@year_form}
-                filter_data={@filter_data}
-                expanded_filter={@expanded_filter}
-              />
-            </div>
+          <div class="p-4">
+            Preview items here..
           </div>
+          <.filter_form_component
+            search_state={@search_state}
+            total_items={@total_items}
+            filter_form={@filter_form}
+            year_form={@year_form}
+            filter_data={@filter_data}
+            expanded_filter={@expanded_filter}
+          />
         </div>
       </.drawer>
     </section>
@@ -287,58 +283,56 @@ defmodule DpulCollectionsWeb.SearchLive do
       phx-change="checked_filter"
       phx-submit="apply_filters"
       for={@filter_form}
-      class="grow flex flex-col min-h-0"
+      class="grow flex flex-col min-h-0 border-l border-rust/20"
     >
-      <div class="flex flex-col gap-4 overflow-y-auto grow pt-4 min-h-0">
-        <div class={[
-          "-mt-4 py-3 px-4 bg-primary-light border-b border-rust/20",
-          map_size(@search_state.filter) == 0 && "hidden"
-        ]}>
-          <div class="flex items-center justify-between mb-2">
-            <span class="text-sm font-semibold">{gettext("Active Filters")}</span>
-            <.link
-              patch="/search"
-              class="text-xs text-accent hover:underline"
-            >
-              {gettext("Clear all")}
-            </.link>
-          </div>
-          <div class="flex flex-wrap gap-2">
-            <.filter_pill
-              :for={{filter_field, filter_settings} <- filter_configuration()}
-              search_state={@search_state}
-              field={filter_field}
-              label={filter_settings.label}
-              filter_value={filter_settings.value_function.(@search_state.filter[filter_field])}
-            />
-          </div>
+      <div class={[
+        "py-3 px-4 bg-primary-light border-b border-rust/20",
+        map_size(@search_state.filter) == 0 && "hidden"
+      ]}>
+        <div class="flex items-center justify-between mb-2">
+          <span class="text-sm font-semibold">{gettext("Active Filters")}</span>
+          <.link
+            patch="/search"
+            class="text-xs text-accent hover:underline"
+          >
+            {gettext("Clear all")}
+          </.link>
         </div>
+        <div class="flex flex-wrap gap-2">
+          <.filter_pill
+            :for={{filter_field, filter_settings} <- filter_configuration()}
+            search_state={@search_state}
+            field={filter_field}
+            label={filter_settings.label}
+            filter_value={filter_settings.value_function.(@search_state.filter[filter_field])}
+          />
+        </div>
+      </div>
 
-        <p class="text-sm text-dark-text shrink-0 px-4">
+      <div class="flex flex-col gap-4 p-4 overflow-y-auto grow min-h-0">
+        <p class="text-sm text-dark-text">
           Filter your {format_number(@total_items)} results
         </p>
 
-        <div class="flex flex-col gap-4 px-4 pb-4">
-          <.filter_section
-            :for={{field, filter} <- @filter_data}
-            field={field}
-            filter={filter}
-            expanded={field == @expanded_filter}
-            filter_form={@filter_form}
-            year_form={@year_form}
-          />
+        <.filter_section
+          :for={{field, filter} <- @filter_data}
+          field={field}
+          filter={filter}
+          expanded={field == @expanded_filter}
+          filter_form={@filter_form}
+          year_form={@year_form}
+        />
 
-          <.input
-            :for={hidden_filter <- hidden_filters()}
-            type="hidden"
-            field={@filter_form[hidden_filter]}
-          />
-          <input
-            name="q"
-            type="hidden"
-            value={@search_state[:q]}
-          />
-        </div>
+        <.input
+          :for={hidden_filter <- hidden_filters()}
+          type="hidden"
+          field={@filter_form[hidden_filter]}
+        />
+        <input
+          name="q"
+          type="hidden"
+          value={@search_state[:q]}
+        />
       </div>
 
       <%!-- Footer with view results button --%>

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -237,9 +237,9 @@ defmodule DpulCollectionsWeb.SearchLive do
       </div>
 
       <.drawer id="filter-modal" label={gettext("Filter Results")}>
-        <div class="grid grid-cols-[1fr_minmax(0,36rem)] grid-rows-[auto_1fr] h-full">
+        <div class="grid grid-cols-1 md:grid-cols-[1fr_minmax(0,32rem)] grid-rows-[auto_1fr] h-full">
           <div class="grid grid-cols-subgrid items-baseline col-span-2 px-4 py-4 border-1 border-rust/20 bg-sage-100">
-            <div class="flex">
+            <div class="hidden sm:flex">
               <h2 class="text-lg font-bold">
                 {gettext("Preview")}
               </h2>
@@ -258,7 +258,7 @@ defmodule DpulCollectionsWeb.SearchLive do
               </button>
             </div>
           </div>
-          <div class="p-4 overflow-y-auto">
+          <div class="sm:block hidden p-4 overflow-y-auto">
             <ul class="force-mobile-items grid grid-flow-row auto-rows-max gap-8">
               <.search_item
                 :for={item <- @items}

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -238,14 +238,14 @@ defmodule DpulCollectionsWeb.SearchLive do
 
       <.drawer id="filter-modal" label={gettext("Filter Results")}>
         <div class="grid grid-cols-1 md:grid-cols-[1fr_minmax(0,32rem)] grid-rows-[auto_1fr] h-full">
-          <div class="grid grid-cols-subgrid items-baseline col-span-2 px-4 py-4 border-1 border-rust/20 bg-sage-100">
-            <div class="hidden sm:flex">
+          <div class="grid grid-cols-subgrid items-baseline col-span-2 border-1 border-rust/20 bg-sage-100">
+            <div class="hidden sm:flex px-4 py-4">
               <h2 class="text-lg font-bold">
                 {gettext("Preview")}
               </h2>
             </div>
-            <div class="flex items-center justify-between px-4">
-              <h2 class="text-lg font-bold">
+            <div class="flex items-center justify-between border-l border-rust/20 h-full">
+              <h2 class="text-lg font-bold px-4">
                 {gettext("Filter Results")}
               </h2>
               <button

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -233,11 +233,68 @@ defmodule DpulCollectionsWeb.SearchLive do
       </div>
 
       <.drawer id="filter-modal" label={gettext("Filter Results")}>
+        <div class="grid grid-cols-[1fr_minmax(0,36rem)] grid-rows-[auto_1fr] h-full gap-0">
+          <div class="grid grid-cols-subgrid items-baseline col-span-2 px-4 py-4 border-1 border-rust/20 bg-sage-100">
+            <div class="flex">
+              <h2 class="text-lg font-bold">
+                {gettext("Preview")}
+              </h2>
+            </div>
+            <div class="flex items-center justify-between px-4">
+              <h2 class="text-lg font-bold">
+                {gettext("Filter Results")}
+              </h2>
+              <button
+                type="button"
+                class="p-2 hover:bg-primary-bright rounded-md transition-colors cursor-pointer"
+                phx-click={JS.exec("dcjs-close", to: {:closest, "dialog"})}
+              >
+                <.icon name="hero-x-mark" class="h-5 w-5" />
+                <span class="sr-only">{gettext("Close")}</span>
+              </button>
+            </div>
+          </div>
+          <div class="grid col-span-2 grid-cols-subgrid min-h-0">
+            <div class="flex py-4 px-4 min-h-0">
+              Preview items here..
+            </div>
+            <div class="flex flex-col border-l border-rust/20 min-h-0">
+              <.filter_form_component
+                search_state={@search_state}
+                total_items={@total_items}
+                filter_form={@filter_form}
+                year_form={@year_form}
+                filter_data={@filter_data}
+                expanded_filter={@expanded_filter}
+              />
+            </div>
+          </div>
+        </div>
+      </.drawer>
+    </section>
+    """
+  end
+
+  def hidden_filters() do
+    @filter_keys -- @filter_fields
+  end
+
+  def filter_form_component(assigns) do
+    ~H"""
+    <.form
+      :if={@total_items > 0}
+      id="filter-form"
+      phx-change="checked_filter"
+      phx-submit="apply_filters"
+      for={@filter_form}
+      class="grow flex flex-col min-h-0"
+    >
+      <div class="flex flex-col gap-4 overflow-y-auto grow min-h-0">
         <div class={[
-          "px-4 py-3 bg-primary-light border-b border-rust/20",
+          "py-3 px-4 bg-primary-light border-b border-rust/20",
           map_size(@search_state.filter) == 0 && "hidden"
         ]}>
-          <div class="flex items-center justify-between mb-2">
+          <div class="flex items-center justify-between">
             <span class="text-sm font-semibold">{gettext("Active Filters")}</span>
             <.link
               patch="/search"
@@ -257,39 +314,11 @@ defmodule DpulCollectionsWeb.SearchLive do
           </div>
         </div>
 
-        <.filter_form_component
-          search_state={@search_state}
-          total_items={@total_items}
-          filter_form={@filter_form}
-          year_form={@year_form}
-          filter_data={@filter_data}
-          expanded_filter={@expanded_filter}
-        />
-      </.drawer>
-    </section>
-    """
-  end
-
-  def hidden_filters() do
-    @filter_keys -- @filter_fields
-  end
-
-  def filter_form_component(assigns) do
-    ~H"""
-    <.form
-      :if={@total_items > 0}
-      id="filter-form"
-      phx-change="checked_filter"
-      phx-submit="apply_filters"
-      for={@filter_form}
-      class="grow flex flex-col"
-    >
-      <div class="p-4 flex flex-col gap-4 grow">
-        <p class="text-sm text-dark-text">
+        <p class="text-sm text-dark-text shrink-0 px-4">
           Filter your {format_number(@total_items)} results
         </p>
 
-        <div class="flex flex-col gap-4">
+        <div class="flex flex-col gap-4 px-4 pb-4">
           <.filter_section
             :for={{field, filter} <- @filter_data}
             field={field}
@@ -313,7 +342,7 @@ defmodule DpulCollectionsWeb.SearchLive do
       </div>
 
       <%!-- Footer with view results button --%>
-      <div class="sticky bottom-0 px-4 py-4 bg-sage-100 border-t border-rust/20">
+      <div class="shrink-0 px-4 py-4 bg-sage-100 border-t border-rust/20">
         <.primary_button
           phx-click={JS.exec("dcjs-close", to: "#filter-modal")}
           class="cursor-pointer w-full py-3 font-bold rounded-md"
@@ -328,7 +357,7 @@ defmodule DpulCollectionsWeb.SearchLive do
   defp filter_section(assigns) do
     ~H"""
     <div class={[
-      "border border-rust/20 rounded-lg overflow-hidden bg-white",
+      "shrink-0 border border-rust/20 rounded-lg overflow-hidden bg-white",
       length(@filter.data) == 0 && "hidden"
     ]}>
       <button

--- a/test/dpul_collections_web/features/search_test.exs
+++ b/test/dpul_collections_web/features/search_test.exs
@@ -136,7 +136,7 @@ defmodule DpulCollectionsWeb.Features.SearchTest do
     # when filecount exceeds visible images show image total
     |> assert_has("#item-1", text: "Document-1")
     # when visible images equals filecount don't show image total
-    |> assert_has("#filecount-1", text: "8 Files")
+    |> assert_has("[data-filecount-id='filecount-1']", text: "8 Files")
   end
 
   test "filters are retained when adding a keyword", %{conn: conn} do

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -197,6 +197,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
 
     assert html =~ "Filter your 100 results"
     refute html =~ "Applied Filters"
+    assert html =~ "Preview"
 
     # Clicking the button shows the filters.
     view

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -20,7 +20,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
 
       # Open dialog
       view
-      |> element("li:first-child button", "Save")
+      |> element("#search-results li:first-child button", "Save")
       |> render_click()
 
       # Create new set
@@ -813,7 +813,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
 
       # There should be a title
       assert document
-             |> Floki.find("#item-title-27fd4d29-1170-47a5-891b-f2743873bcef")
+             |> Floki.find("#item-27fd4d29-1170-47a5-891b-f2743873bcef h2")
              |> Enum.count() == 1
     end
 


### PR DESCRIPTION
Work towards #1185

<img width="1888" height="810" alt="Screenshot 2026-05-06 at 8 43 21 AM" src="https://github.com/user-attachments/assets/7dc546a3-638c-426b-a663-000a6e660f98" />

Some notes on the implementation:

APPARENTLY `sm:` is screen based, not container based. Tailwind has "container queries", but I couldn't get them to work: https://tailwindcss.com/blog/tailwindcss-v4#container-queries

I had to switch the filter to grid to get the headers to have a consistent height. I think. There may have been a flex way, but it took a fair bit of fiddling.

@sdellis was right, a lot of duplicate ID problems. Not all solved yet.