### PR TITLE
Renovate: Require packages be older than 2 weeks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,7 @@
     "custom.regex",
     "mix"
   ],
+  "minimumReleaseAge": "14 days",
   "packageRules": [
     {
       "matchDatasources": [


### PR DESCRIPTION
This will probably cause some churn in the renovate config as it has in AbID and ImageCat, but we don't want to merge dependencies right away.

Closes #1190