### PR TITLE
Wrap raw strings with gettext

### DIFF
--- a/lib/dpul_collections_web/components/footer_component.ex
+++ b/lib/dpul_collections_web/components/footer_component.ex
@@ -29,7 +29,7 @@ defmodule DpulCollectionsWeb.FooterComponent do
         © 2025 {gettext("The Trustees of Princeton University")}
       </div>
       <div class="university-logo flex-none w-24 sm:w-48">
-        <img src={~p"/images/university-logo.svg"} alt={gettext("Princeton University Logo")} />
+        <img src={~p"/images/university-logo.svg"} alt={gettext("Princeton University")} />
       </div>
     </footer>
     """

--- a/lib/dpul_collections_web/components/footer_component.ex
+++ b/lib/dpul_collections_web/components/footer_component.ex
@@ -29,7 +29,7 @@ defmodule DpulCollectionsWeb.FooterComponent do
         © 2025 {gettext("The Trustees of Princeton University")}
       </div>
       <div class="university-logo flex-none w-24 sm:w-48">
-        <img src={~p"/images/university-logo.svg"} alt="Princeton University Logo" />
+        <img src={~p"/images/university-logo.svg"} alt={gettext("Princeton University Logo")} />
       </div>
     </footer>
     """

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -62,12 +62,12 @@ defmodule DpulCollectionsWeb.CollectionsLive do
           <% end %>
           <li class={"hidden group-[.expanded]:block less-button #{@button_class}"}>
             <button class="w-full h-full px-3 py-1.5 cursor-pointer text-xs">
-              Show less
+              {gettext("Show less")}
             </button>
           </li>
           <li class={"more-button invisible group-[.expanded]:invisible less-button px-3 py-1.5 #{@button_class}"}>
             <button class="w-full h-full cursor-pointer text-xs">
-              +<span class="more-count">{format_number(length(@items))}</span> more
+              +<span class="more-count">{format_number(length(@items))}</span> {gettext("more")}
             </button>
           </li>
         </ul>
@@ -274,7 +274,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
             id="contributors"
             class="content-area pb-6"
           >
-            <h2 class="heading text-2xl pb-4">Contributors</h2>
+            <h2 class="heading text-2xl pb-4">{gettext("Contributors")}</h2>
             <div class="flex flex-wrap gap-4 pb-6">
               <div
                 :for={contributor <- @collection.contributors}

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -570,12 +570,16 @@ defmodule DpulCollectionsWeb.ItemLive do
                 )
               )}
             </p>
-            <.input type="text" label="Name" field={@correction_form[:name]} />
-            <.input type="email" label="Email" field={@correction_form[:email]} />
-            <.input type="textarea" label="Message" field={@correction_form[:message]} />
+            <.input type="text" label={gettext("Name")} field={@correction_form[:name]} />
+            <.input type="email" label={gettext("Email")} field={@correction_form[:email]} />
             <.input
               type="textarea"
-              label="Feedback"
+              label={gettext("Message")}
+              field={@correction_form[:message]}
+            />
+            <.input
+              type="textarea"
+              label={gettext("Feedback")}
               class="form-helper"
               field={@correction_form[:feedback]}
             />
@@ -925,7 +929,7 @@ defmodule DpulCollectionsWeb.ItemLive do
           href={"https://catalog.princeton.edu/catalog/#{@item.mms_id |> hd}"}
           target="_blank"
         >
-          View in Library Catalog
+          {gettext("View in Library Catalog")}
         </.link>
       </div>
     </div>

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -286,7 +286,9 @@ defmodule DpulCollectionsWeb.SearchLive do
     >
       <div class="p-4 flex flex-col gap-4 grow">
         <p class="text-sm text-dark-text">
-          Filter your {format_number(@total_items)} results
+          {ngettext("Filter your %{count} result", "Filter your %{count} results", @total_items,
+            count: format_number(@total_items)
+          )}
         </p>
 
         <div class="flex flex-col gap-4">

--- a/lib/dpul_collections_web/live/user_live/confirmation.ex
+++ b/lib/dpul_collections_web/live/user_live/confirmation.ex
@@ -35,11 +35,11 @@ defmodule DpulCollectionsWeb.UserLive.Confirmation do
             <.primary_button
               name={@form[:remember_me].name}
               value="true"
-              phx-disable-with="Logging in..."
+              phx-disable-with={gettext("Logging in...")}
             >
               {gettext("Keep me logged in on this device")}
             </.primary_button>
-            <.primary_button phx-disable-with="Logging in...">
+            <.primary_button phx-disable-with={gettext("Logging in...")}>
               {gettext("Log me in only this time")}
             </.primary_button>
           </div>

--- a/lib/dpul_collections_web/live/user_live/login.ex
+++ b/lib/dpul_collections_web/live/user_live/login.ex
@@ -40,7 +40,7 @@ defmodule DpulCollectionsWeb.UserLive.Login do
           readonly={!!@current_scope}
           field={f[:email]}
           type="email"
-          label="Email"
+          label={gettext("Email")}
           autocomplete="username"
           required
           phx-mounted={JS.focus()}

--- a/lib/dpul_collections_web/live/user_live/settings.ex
+++ b/lib/dpul_collections_web/live/user_live/settings.ex
@@ -28,12 +28,12 @@ defmodule DpulCollectionsWeb.UserLive.Settings do
           <.input
             field={@email_form[:email]}
             type="email"
-            label="Email"
+            label={gettext("Email")}
             autocomplete="username"
             required
           />
           <div>
-            <.primary_button phx-disable-with="Changing...">
+            <.primary_button phx-disable-with={gettext("Changing...")}>
               {gettext("Change Email")}
             </.primary_button>
           </div>

--- a/lib/dpul_collections_web/live/user_sets/add_to_set_component.ex
+++ b/lib/dpul_collections_web/live/user_sets/add_to_set_component.ex
@@ -72,7 +72,7 @@ defmodule DpulCollectionsWeb.UserSets.AddToSetComponent do
         class="w-full text-left"
       >
         <span class="grow">
-          Create new set
+          {gettext("Create new set")}
         </span>
       </.primary_button>
       <ul class="flex flex-col gap-2">
@@ -84,7 +84,9 @@ defmodule DpulCollectionsWeb.UserSets.AddToSetComponent do
             phx-value-set-id={set.id}
           >
             <span class="grow">
-              {set.title} - {set.set_item_count} Items
+              {set.title} - {ngettext("%{count} Item", "%{count} Items", set.set_item_count,
+                count: format_number(set.set_item_count)
+              )}
             </span>
             <.icon :if={set.has_solr_id} name="hero-check-circle" />
           </.secondary_button>
@@ -105,18 +107,18 @@ defmodule DpulCollectionsWeb.UserSets.AddToSetComponent do
       phx-submit="create_set"
       phx-target={@myself}
     >
-      <.input type="text" required={true} label="Set name" field={@set_form[:title]} />
-      <.input type="textarea" label="Set description" field={@set_form[:description]} />
+      <.input type="text" required={true} label={gettext("Set name")} field={@set_form[:title]} />
+      <.input type="textarea" label={gettext("Set description")} field={@set_form[:description]} />
       <.inputs_for :let={si_form} field={@set_form[:set_items]}>
         <input type="hidden" name={si_form[:solr_id].name} value={si_form[:solr_id].value} />
       </.inputs_for>
       <div class="flex w-full">
         <.secondary_button phx-click="display_list_sets" phx-target={@myself}>
-          Cancel
+          {gettext("Cancel")}
         </.secondary_button>
         <div class="grow"></div>
         <.primary_button>
-          Create Set
+          {gettext("Create Set")}
         </.primary_button>
       </div>
     </.form>

--- a/lib/dpul_collections_web/live/user_sets_live/show.ex
+++ b/lib/dpul_collections_web/live/user_sets_live/show.ex
@@ -56,7 +56,7 @@ defmodule DpulCollectionsWeb.UserSetsLive.Show do
             class="text-md px-3 py-2 flex gap-2 h-10"
             phx-click={JS.exec("dcjs-open", to: "#share-modal")}
           >
-            <.icon name="hero-share" /> Share
+            <.icon name="hero-share" /> {gettext("Share")}
           </.secondary_button>
           <ItemLive.share_modal
             path={~p"/sets/#{@user_set.id}"}
@@ -65,7 +65,11 @@ defmodule DpulCollectionsWeb.UserSetsLive.Show do
           />
         </div>
         <hr />
-        <h2>{length(@user_set.set_items)} Items</h2>
+        <h2>
+          {ngettext("%{count} Item", "%{count} Items", length(@user_set.set_items),
+            count: format_number(length(@user_set.set_items))
+          )}
+        </h2>
         <ul id="set-items" class="grid grid-cols-[repeat(auto-fill,minmax(300px,_1fr))] gap-12 pt-5">
           <.browse_li
             :for={item <- @items}

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -21,10 +21,10 @@ msgstr ""
 msgid "Hang in there while we get back on track"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:36
-#: lib/dpul_collections_web/components/search_bar_component.ex:42
-#: lib/dpul_collections_web/components/search_bar_component.ex:117
-#: lib/dpul_collections_web/live/search_live.ex:445
+#: lib/dpul_collections_web/components/search_bar_component.ex:37
+#: lib/dpul_collections_web/components/search_bar_component.ex:43
+#: lib/dpul_collections_web/components/search_bar_component.ex:118
+#: lib/dpul_collections_web/live/search_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
@@ -56,18 +56,18 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:766
+#: lib/dpul_collections_web/live/search_live.ex:776
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:736
+#: lib/dpul_collections_web/live/search_live.ex:746
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:140
-#: lib/dpul_collections_web/live/search_live.ex:142
+#: lib/dpul_collections_web/live/search_live.ex:113
+#: lib/dpul_collections_web/live/search_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "sort by"
 msgstr ""
@@ -104,12 +104,12 @@ msgstr ""
 msgid "Page not found"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:96
+#: lib/dpul_collections_web/live/search_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "No items found"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:108
+#: lib/dpul_collections_web/live/search_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "of"
 msgstr ""
@@ -148,9 +148,9 @@ msgstr ""
 
 #: lib/dpul_collections_web/components/header_component.ex:40
 #: lib/dpul_collections_web/live/home_live.ex:36
-#: lib/dpul_collections_web/live/item_live.ex:1076
-#: lib/dpul_collections_web/live/item_live.ex:1077
-#: lib/dpul_collections_web/live/item_live.ex:1078
+#: lib/dpul_collections_web/live/item_live.ex:1080
+#: lib/dpul_collections_web/live/item_live.ex:1081
+#: lib/dpul_collections_web/live/item_live.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Digital Collections"
 msgstr ""
@@ -160,7 +160,7 @@ msgstr ""
 msgid "The Trustees of Princeton University"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:602
+#: lib/dpul_collections_web/live/search_live.ex:612
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -238,18 +238,18 @@ msgstr ""
 msgid "Subject"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:831
+#: lib/dpul_collections_web/live/item_live.ex:835
 #, elixir-autogen, elixir-format
 msgid "View all metadata for this item"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:779
+#: lib/dpul_collections_web/live/item_live.ex:783
 #, elixir-autogen, elixir-format
 msgid "No PDF Available"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:361
-#: lib/dpul_collections_web/live/item_live.ex:1077
+#: lib/dpul_collections_web/live/item_live.ex:1081
 #, elixir-autogen, elixir-format
 msgid "Viewer"
 msgstr ""
@@ -362,8 +362,8 @@ msgid "Keywords"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:313
-#: lib/dpul_collections_web/live/item_live.ex:817
-#: lib/dpul_collections_web/live/item_live.ex:1076
+#: lib/dpul_collections_web/live/item_live.ex:821
+#: lib/dpul_collections_web/live/item_live.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Metadata"
 msgstr ""
@@ -440,6 +440,7 @@ msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:366
 #: lib/dpul_collections_web/live/item_live.ex:442
+#: lib/dpul_collections_web/live/user_sets_live/show.ex:59
 #, elixir-autogen, elixir-format
 msgid "Share"
 msgstr ""
@@ -459,7 +460,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:771
+#: lib/dpul_collections_web/live/item_live.ex:775
 #, elixir-autogen, elixir-format
 msgid "Download PDF"
 msgstr ""
@@ -473,13 +474,13 @@ msgstr ""
 msgid "Recently Added"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:250
+#: lib/dpul_collections_web/live/collections_live.ex:251
 #: lib/dpul_collections_web/live/home_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Recently Added Items"
 msgstr ""
 
-#: lib/dpul_collections_web/components/browse_item.ex:228
+#: lib/dpul_collections_web/components/browse_item.ex:235
 #, elixir-autogen, elixir-format
 msgid "Updated"
 msgstr ""
@@ -509,17 +510,17 @@ msgstr ""
 msgid "Browse - Digital Collections"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:1046
+#: lib/dpul_collections_web/live/item_live.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:1045
+#: lib/dpul_collections_web/live/item_live.ex:1049
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:722
+#: lib/dpul_collections_web/live/item_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Letter Paper"
 msgstr ""
@@ -534,17 +535,17 @@ msgstr ""
 msgid "View Random Items"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:702
+#: lib/dpul_collections_web/live/item_live.ex:706
 #, elixir-autogen, elixir-format
 msgid "main image display"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:726
+#: lib/dpul_collections_web/live/search_live.ex:736
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr ""
 
-#: lib/dpul_collections_web/components/browse_item.ex:49
+#: lib/dpul_collections_web/components/browse_item.ex:51
 #, elixir-autogen, elixir-format
 msgid "more items"
 msgstr ""
@@ -589,7 +590,7 @@ msgstr ""
 msgid "Main Navigation"
 msgstr ""
 
-#: lib/dpul_collections_web/components/browse_item.ex:237
+#: lib/dpul_collections_web/components/browse_item.ex:244
 #: lib/dpul_collections_web/live/item_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Similar"
@@ -610,8 +611,8 @@ msgstr ""
 msgid "Categories"
 msgstr ""
 
-#: lib/dpul_collections_web/components/browse_item.ex:212
-#: lib/dpul_collections_web/live/search_live.ex:643
+#: lib/dpul_collections_web/components/browse_item.ex:219
+#: lib/dpul_collections_web/live/search_live.ex:653
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
@@ -630,15 +631,15 @@ msgstr ""
 msgid "Featured"
 msgstr ""
 
-#: lib/dpul_collections_web/components/browse_item.ex:163
+#: lib/dpul_collections_web/components/browse_item.ex:170
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:627
-#: lib/dpul_collections_web/live/search_live.ex:697
+#: lib/dpul_collections_web/live/search_live.ex:637
+#: lib/dpul_collections_web/live/search_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:220
+#: lib/dpul_collections_web/live/search_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
@@ -654,7 +655,7 @@ msgid "Leaflets"
 msgstr ""
 
 #: lib/dpul_collections_web/live/collections_live.ex:169
-#: lib/dpul_collections_web/live/collections_live.ex:208
+#: lib/dpul_collections_web/live/collections_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Learn More"
 msgstr ""
@@ -670,7 +671,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:733
+#: lib/dpul_collections_web/live/item_live.ex:737
 #, elixir-autogen, elixir-format
 msgid "Look closer"
 msgstr ""
@@ -691,7 +692,8 @@ msgstr ""
 msgid "My Sets"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:650
+#: lib/dpul_collections_web/components/browse_item.ex:226
+#: lib/dpul_collections_web/live/search_live.ex:660
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr ""
@@ -712,14 +714,14 @@ msgid "Posters"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:452
-#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:216
-#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:229
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:218
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:231
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:661
-#: lib/dpul_collections_web/live/search_live.ex:667
+#: lib/dpul_collections_web/live/search_live.ex:671
+#: lib/dpul_collections_web/live/search_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr ""
@@ -928,7 +930,7 @@ msgstr ""
 msgid "We sent an email to %{email}."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:317
+#: lib/dpul_collections_web/live/collections_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Copyright"
 msgstr ""
@@ -943,7 +945,7 @@ msgstr ""
 msgid "Digital Collection"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:260
+#: lib/dpul_collections_web/live/collections_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Explore the latest additions to our growing collection for"
 msgstr ""
@@ -956,7 +958,6 @@ msgstr ""
 #: lib/dpul_collections/item.ex:86
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
-#: lib/dpul_collections_web/components/browse_item.ex:219
 #: lib/dpul_collections_web/live/item_live.ex:2
 #: lib/dpul_collections_web/live/search_live.ex:7
 #: lib/dpul_collections_web/live/search_live/search_state.ex:2
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Format"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:227
+#: lib/dpul_collections_web/live/collections_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Formats"
 msgstr ""
@@ -979,7 +980,7 @@ msgstr ""
 msgid "Languages"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:343
+#: lib/dpul_collections_web/live/collections_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "Library of Congress Romanization tables"
 msgstr ""
@@ -989,7 +990,7 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:340
+#: lib/dpul_collections_web/live/collections_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Please refer to the %{romanization_link} when searching the collection."
 msgstr ""
@@ -999,17 +1000,17 @@ msgstr ""
 msgid "Please use this area to report errors, omissions, or %{description_link} that appear in the description of this collection. Corrections may include misspellings, incorrect or missing dates, misidentified individuals, places, or events, mislabeled folders, misfiled papers, etc."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:329
+#: lib/dpul_collections_web/live/collections_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "Preferred Citation"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:321
+#: lib/dpul_collections_web/live/collections_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "Princeton University Library claims no copyright governing this digital resource. It is provided for free, on a non-commercial, open-access basis, for fair-use academic and research purposes only. Anyone who claims copyright over any part of these resources and feels that they should not be presented in this manner is invited to %{contact_link}, who will in turn consider such concerns and make reasonable efforts to respond to such concerns."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:336
+#: lib/dpul_collections_web/live/collections_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Romanization"
 msgstr ""
@@ -1019,17 +1020,17 @@ msgstr ""
 msgid "Save to Set"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:584
+#: lib/dpul_collections_web/live/item_live.ex:588
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:595
+#: lib/dpul_collections_web/live/item_live.ex:599
 #, elixir-autogen, elixir-format
 msgid "Sorry, something went wrong. Either the message was blank or there was an error with the form submission. Please try again or email the library directly."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:217
+#: lib/dpul_collections_web/live/collections_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Subject Areas"
 msgstr ""
@@ -1039,19 +1040,19 @@ msgstr ""
 msgid "Suggest a correction"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:590
+#: lib/dpul_collections_web/live/item_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "Thank you for your suggestion. We will reach out to you if we have any questions. Our staff will review your suggestion and assess the practicality of its implementation, as well as its conformance to national and international description standards and current best practices in the field. You may not hear back from us, but, rest assured, we assess each suggestion we receive carefully before determining if and how to implement it."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:324
+#: lib/dpul_collections_web/live/collections_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "contact Princeton University Library"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:152
-#: lib/dpul_collections_web/live/search_live.ex:524
-#: lib/dpul_collections_web/live/search_live.ex:594
+#: lib/dpul_collections_web/live/search_live.ex:534
+#: lib/dpul_collections_web/live/search_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr ""
@@ -1061,7 +1062,7 @@ msgstr ""
 msgid "problematic language"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:244
+#: lib/dpul_collections_web/live/search_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Active Filters"
 msgstr ""
@@ -1092,7 +1093,7 @@ msgstr ""
 msgid "Call Number"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:249
+#: lib/dpul_collections_web/live/search_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr ""
@@ -1122,7 +1123,7 @@ msgstr ""
 msgid "Extent"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:238
+#: lib/dpul_collections_web/live/search_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Filter Results"
 msgstr ""
@@ -1158,7 +1159,7 @@ msgstr ""
 msgid "Related Name"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:324
+#: lib/dpul_collections_web/live/search_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "Results"
 msgstr ""
@@ -1173,7 +1174,7 @@ msgstr ""
 msgid "Scribe"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:451
+#: lib/dpul_collections_web/live/search_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "Search filters..."
 msgstr ""
@@ -1183,22 +1184,120 @@ msgstr ""
 msgid "Source Acquisition"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:324
+#: lib/dpul_collections_web/live/search_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:445
+#: lib/dpul_collections_web/live/search_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "filters"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:121
+#: lib/dpul_collections_web/components/search_bar_component.ex:122
 #, elixir-autogen, elixir-format
 msgid "Search all"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:59
+#: lib/dpul_collections_web/components/search_bar_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "In this Collection"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:87
+#: lib/dpul_collections_web/live/user_sets_live/show.ex:69
+#, elixir-autogen, elixir-format
+msgid "%{count} Item"
+msgid_plural "%{count} Items"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:117
+#, elixir-autogen, elixir-format
+msgid "Cancel"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_live/settings.ex:36
+#, elixir-autogen, elixir-format
+msgid "Changing..."
+msgstr ""
+
+#: lib/dpul_collections_web/live/collections_live.ex:277
+#, elixir-autogen, elixir-format
+msgid "Contributors"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:121
+#, elixir-autogen, elixir-format
+msgid "Create Set"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:75
+#, elixir-autogen, elixir-format
+msgid "Create new set"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:574
+#: lib/dpul_collections_web/live/user_live/login.ex:43
+#: lib/dpul_collections_web/live/user_live/settings.ex:31
+#, elixir-autogen, elixir-format
+msgid "Email"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:582
+#, elixir-autogen, elixir-format
+msgid "Feedback"
+msgstr ""
+
+#: lib/dpul_collections_web/live/search_live.ex:289
+#, elixir-autogen, elixir-format
+msgid "Filter your %{count} result"
+msgid_plural "Filter your %{count} results"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/dpul_collections_web/live/user_live/confirmation.ex:38
+#: lib/dpul_collections_web/live/user_live/confirmation.ex:42
+#, elixir-autogen, elixir-format
+msgid "Logging in..."
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:577
+#, elixir-autogen, elixir-format
+msgid "Message"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:573
+#, elixir-autogen, elixir-format
+msgid "Name"
+msgstr ""
+
+#: lib/dpul_collections_web/components/footer_component.ex:32
+#, elixir-autogen, elixir-format
+msgid "Princeton University Logo"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:111
+#, elixir-autogen, elixir-format
+msgid "Set description"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:110
+#, elixir-autogen, elixir-format
+msgid "Set name"
+msgstr ""
+
+#: lib/dpul_collections_web/live/collections_live.ex:65
+#, elixir-autogen, elixir-format
+msgid "Show less"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:932
+#, elixir-autogen, elixir-format
+msgid "View in Library Catalog"
+msgstr ""
+
+#: lib/dpul_collections_web/live/collections_live.ex:70
+#, elixir-autogen, elixir-format
+msgid "more"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -21,10 +21,10 @@ msgstr ""
 msgid "Hang in there while we get back on track"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:36
-#: lib/dpul_collections_web/components/search_bar_component.ex:42
-#: lib/dpul_collections_web/components/search_bar_component.ex:117
-#: lib/dpul_collections_web/live/search_live.ex:445
+#: lib/dpul_collections_web/components/search_bar_component.ex:37
+#: lib/dpul_collections_web/components/search_bar_component.ex:43
+#: lib/dpul_collections_web/components/search_bar_component.ex:118
+#: lib/dpul_collections_web/live/search_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
@@ -56,18 +56,18 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:766
+#: lib/dpul_collections_web/live/search_live.ex:776
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:736
+#: lib/dpul_collections_web/live/search_live.ex:746
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:140
-#: lib/dpul_collections_web/live/search_live.ex:142
+#: lib/dpul_collections_web/live/search_live.ex:113
+#: lib/dpul_collections_web/live/search_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "sort by"
 msgstr ""
@@ -104,12 +104,12 @@ msgstr ""
 msgid "Page not found"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:96
+#: lib/dpul_collections_web/live/search_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "No items found"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:108
+#: lib/dpul_collections_web/live/search_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "of"
 msgstr ""
@@ -148,9 +148,9 @@ msgstr ""
 
 #: lib/dpul_collections_web/components/header_component.ex:40
 #: lib/dpul_collections_web/live/home_live.ex:36
-#: lib/dpul_collections_web/live/item_live.ex:1076
-#: lib/dpul_collections_web/live/item_live.ex:1077
-#: lib/dpul_collections_web/live/item_live.ex:1078
+#: lib/dpul_collections_web/live/item_live.ex:1080
+#: lib/dpul_collections_web/live/item_live.ex:1081
+#: lib/dpul_collections_web/live/item_live.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Digital Collections"
 msgstr ""
@@ -160,7 +160,7 @@ msgstr ""
 msgid "The Trustees of Princeton University"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:602
+#: lib/dpul_collections_web/live/search_live.ex:612
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -238,18 +238,18 @@ msgstr ""
 msgid "Subject"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:831
+#: lib/dpul_collections_web/live/item_live.ex:835
 #, elixir-autogen, elixir-format
 msgid "View all metadata for this item"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:779
+#: lib/dpul_collections_web/live/item_live.ex:783
 #, elixir-autogen, elixir-format
 msgid "No PDF Available"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:361
-#: lib/dpul_collections_web/live/item_live.ex:1077
+#: lib/dpul_collections_web/live/item_live.ex:1081
 #, elixir-autogen, elixir-format
 msgid "Viewer"
 msgstr ""
@@ -362,8 +362,8 @@ msgid "Keywords"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:313
-#: lib/dpul_collections_web/live/item_live.ex:817
-#: lib/dpul_collections_web/live/item_live.ex:1076
+#: lib/dpul_collections_web/live/item_live.ex:821
+#: lib/dpul_collections_web/live/item_live.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Metadata"
 msgstr ""
@@ -440,6 +440,7 @@ msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:366
 #: lib/dpul_collections_web/live/item_live.ex:442
+#: lib/dpul_collections_web/live/user_sets_live/show.ex:59
 #, elixir-autogen, elixir-format
 msgid "Share"
 msgstr ""
@@ -459,7 +460,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:771
+#: lib/dpul_collections_web/live/item_live.ex:775
 #, elixir-autogen, elixir-format
 msgid "Download PDF"
 msgstr ""
@@ -473,13 +474,13 @@ msgstr ""
 msgid "Recently Added"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:250
+#: lib/dpul_collections_web/live/collections_live.ex:251
 #: lib/dpul_collections_web/live/home_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Recently Added Items"
 msgstr ""
 
-#: lib/dpul_collections_web/components/browse_item.ex:228
+#: lib/dpul_collections_web/components/browse_item.ex:235
 #, elixir-autogen, elixir-format
 msgid "Updated"
 msgstr ""
@@ -509,17 +510,17 @@ msgstr ""
 msgid "Browse - Digital Collections"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:1046
+#: lib/dpul_collections_web/live/item_live.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:1045
+#: lib/dpul_collections_web/live/item_live.ex:1049
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:722
+#: lib/dpul_collections_web/live/item_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Letter Paper"
 msgstr ""
@@ -534,17 +535,17 @@ msgstr ""
 msgid "View Random Items"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:702
+#: lib/dpul_collections_web/live/item_live.ex:706
 #, elixir-autogen, elixir-format
 msgid "main image display"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:726
+#: lib/dpul_collections_web/live/search_live.ex:736
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr ""
 
-#: lib/dpul_collections_web/components/browse_item.ex:49
+#: lib/dpul_collections_web/components/browse_item.ex:51
 #, elixir-autogen, elixir-format
 msgid "more items"
 msgstr ""
@@ -589,7 +590,7 @@ msgstr ""
 msgid "Main Navigation"
 msgstr ""
 
-#: lib/dpul_collections_web/components/browse_item.ex:237
+#: lib/dpul_collections_web/components/browse_item.ex:244
 #: lib/dpul_collections_web/live/item_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Similar"
@@ -610,8 +611,8 @@ msgstr ""
 msgid "Categories"
 msgstr ""
 
-#: lib/dpul_collections_web/components/browse_item.ex:212
-#: lib/dpul_collections_web/live/search_live.ex:643
+#: lib/dpul_collections_web/components/browse_item.ex:219
+#: lib/dpul_collections_web/live/search_live.ex:653
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
@@ -630,15 +631,15 @@ msgstr ""
 msgid "Featured"
 msgstr ""
 
-#: lib/dpul_collections_web/components/browse_item.ex:163
+#: lib/dpul_collections_web/components/browse_item.ex:170
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:627
-#: lib/dpul_collections_web/live/search_live.ex:697
+#: lib/dpul_collections_web/live/search_live.ex:637
+#: lib/dpul_collections_web/live/search_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:220
+#: lib/dpul_collections_web/live/search_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
@@ -654,7 +655,7 @@ msgid "Leaflets"
 msgstr ""
 
 #: lib/dpul_collections_web/live/collections_live.ex:169
-#: lib/dpul_collections_web/live/collections_live.ex:208
+#: lib/dpul_collections_web/live/collections_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Learn More"
 msgstr ""
@@ -670,7 +671,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:733
+#: lib/dpul_collections_web/live/item_live.ex:737
 #, elixir-autogen, elixir-format
 msgid "Look closer"
 msgstr ""
@@ -691,7 +692,8 @@ msgstr ""
 msgid "My Sets"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:650
+#: lib/dpul_collections_web/components/browse_item.ex:226
+#: lib/dpul_collections_web/live/search_live.ex:660
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr ""
@@ -712,14 +714,14 @@ msgid "Posters"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:452
-#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:216
-#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:229
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:218
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:231
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:661
-#: lib/dpul_collections_web/live/search_live.ex:667
+#: lib/dpul_collections_web/live/search_live.ex:671
+#: lib/dpul_collections_web/live/search_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr ""
@@ -928,7 +930,7 @@ msgstr ""
 msgid "We sent an email to %{email}."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:317
+#: lib/dpul_collections_web/live/collections_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Copyright"
 msgstr ""
@@ -943,7 +945,7 @@ msgstr ""
 msgid "Digital Collection"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:260
+#: lib/dpul_collections_web/live/collections_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Explore the latest additions to our growing collection for"
 msgstr ""
@@ -956,7 +958,6 @@ msgstr ""
 #: lib/dpul_collections/item.ex:86
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
-#: lib/dpul_collections_web/components/browse_item.ex:219
 #: lib/dpul_collections_web/live/item_live.ex:2
 #: lib/dpul_collections_web/live/search_live.ex:7
 #: lib/dpul_collections_web/live/search_live/search_state.ex:2
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Format"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:227
+#: lib/dpul_collections_web/live/collections_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Formats"
 msgstr ""
@@ -979,7 +980,7 @@ msgstr ""
 msgid "Languages"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:343
+#: lib/dpul_collections_web/live/collections_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "Library of Congress Romanization tables"
 msgstr ""
@@ -989,7 +990,7 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:340
+#: lib/dpul_collections_web/live/collections_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Please refer to the %{romanization_link} when searching the collection."
 msgstr ""
@@ -999,17 +1000,17 @@ msgstr ""
 msgid "Please use this area to report errors, omissions, or %{description_link} that appear in the description of this collection. Corrections may include misspellings, incorrect or missing dates, misidentified individuals, places, or events, mislabeled folders, misfiled papers, etc."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:329
+#: lib/dpul_collections_web/live/collections_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "Preferred Citation"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:321
+#: lib/dpul_collections_web/live/collections_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "Princeton University Library claims no copyright governing this digital resource. It is provided for free, on a non-commercial, open-access basis, for fair-use academic and research purposes only. Anyone who claims copyright over any part of these resources and feels that they should not be presented in this manner is invited to %{contact_link}, who will in turn consider such concerns and make reasonable efforts to respond to such concerns."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:336
+#: lib/dpul_collections_web/live/collections_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Romanization"
 msgstr ""
@@ -1019,17 +1020,17 @@ msgstr ""
 msgid "Save to Set"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:584
+#: lib/dpul_collections_web/live/item_live.ex:588
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:595
+#: lib/dpul_collections_web/live/item_live.ex:599
 #, elixir-autogen, elixir-format
 msgid "Sorry, something went wrong. Either the message was blank or there was an error with the form submission. Please try again or email the library directly."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:217
+#: lib/dpul_collections_web/live/collections_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Subject Areas"
 msgstr ""
@@ -1039,19 +1040,19 @@ msgstr ""
 msgid "Suggest a correction"
 msgstr ""
 
-#: lib/dpul_collections_web/live/item_live.ex:590
+#: lib/dpul_collections_web/live/item_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "Thank you for your suggestion. We will reach out to you if we have any questions. Our staff will review your suggestion and assess the practicality of its implementation, as well as its conformance to national and international description standards and current best practices in the field. You may not hear back from us, but, rest assured, we assess each suggestion we receive carefully before determining if and how to implement it."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:324
+#: lib/dpul_collections_web/live/collections_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "contact Princeton University Library"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:152
-#: lib/dpul_collections_web/live/search_live.ex:524
-#: lib/dpul_collections_web/live/search_live.ex:594
+#: lib/dpul_collections_web/live/search_live.ex:534
+#: lib/dpul_collections_web/live/search_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr ""
@@ -1061,7 +1062,7 @@ msgstr ""
 msgid "problematic language"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:244
+#: lib/dpul_collections_web/live/search_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Active Filters"
 msgstr ""
@@ -1092,7 +1093,7 @@ msgstr ""
 msgid "Call Number"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:249
+#: lib/dpul_collections_web/live/search_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr ""
@@ -1122,7 +1123,7 @@ msgstr ""
 msgid "Extent"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:238
+#: lib/dpul_collections_web/live/search_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Filter Results"
 msgstr ""
@@ -1158,7 +1159,7 @@ msgstr ""
 msgid "Related Name"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:324
+#: lib/dpul_collections_web/live/search_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "Results"
 msgstr ""
@@ -1173,7 +1174,7 @@ msgstr ""
 msgid "Scribe"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:451
+#: lib/dpul_collections_web/live/search_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "Search filters..."
 msgstr ""
@@ -1183,22 +1184,120 @@ msgstr ""
 msgid "Source Acquisition"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:324
+#: lib/dpul_collections_web/live/search_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:445
+#: lib/dpul_collections_web/live/search_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "filters"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:121
+#: lib/dpul_collections_web/components/search_bar_component.ex:122
 #, elixir-autogen, elixir-format
 msgid "Search all"
 msgstr ""
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:59
+#: lib/dpul_collections_web/components/search_bar_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "In this Collection"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:87
+#: lib/dpul_collections_web/live/user_sets_live/show.ex:69
+#, elixir-autogen, elixir-format
+msgid "%{count} Item"
+msgid_plural "%{count} Items"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:117
+#, elixir-autogen, elixir-format
+msgid "Cancel"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_live/settings.ex:36
+#, elixir-autogen, elixir-format
+msgid "Changing..."
+msgstr ""
+
+#: lib/dpul_collections_web/live/collections_live.ex:277
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Contributors"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:121
+#, elixir-autogen, elixir-format
+msgid "Create Set"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:75
+#, elixir-autogen, elixir-format
+msgid "Create new set"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:574
+#: lib/dpul_collections_web/live/user_live/login.ex:43
+#: lib/dpul_collections_web/live/user_live/settings.ex:31
+#, elixir-autogen, elixir-format
+msgid "Email"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:582
+#, elixir-autogen, elixir-format
+msgid "Feedback"
+msgstr ""
+
+#: lib/dpul_collections_web/live/search_live.ex:289
+#, elixir-autogen, elixir-format
+msgid "Filter your %{count} result"
+msgid_plural "Filter your %{count} results"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/dpul_collections_web/live/user_live/confirmation.ex:38
+#: lib/dpul_collections_web/live/user_live/confirmation.ex:42
+#, elixir-autogen, elixir-format
+msgid "Logging in..."
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:577
+#, elixir-autogen, elixir-format
+msgid "Message"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:573
+#, elixir-autogen, elixir-format
+msgid "Name"
+msgstr ""
+
+#: lib/dpul_collections_web/components/footer_component.ex:32
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Princeton University Logo"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:111
+#, elixir-autogen, elixir-format
+msgid "Set description"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:110
+#, elixir-autogen, elixir-format
+msgid "Set name"
+msgstr ""
+
+#: lib/dpul_collections_web/live/collections_live.ex:65
+#, elixir-autogen, elixir-format
+msgid "Show less"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:932
+#, elixir-autogen, elixir-format
+msgid "View in Library Catalog"
+msgstr ""
+
+#: lib/dpul_collections_web/live/collections_live.ex:70
+#, elixir-autogen, elixir-format
+msgid "more"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -21,10 +21,10 @@ msgstr "¡Error!"
 msgid "Hang in there while we get back on track"
 msgstr "Aguanta mientras volvemos al buen camino"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:36
-#: lib/dpul_collections_web/components/search_bar_component.ex:42
-#: lib/dpul_collections_web/components/search_bar_component.ex:117
-#: lib/dpul_collections_web/live/search_live.ex:445
+#: lib/dpul_collections_web/components/search_bar_component.ex:37
+#: lib/dpul_collections_web/components/search_bar_component.ex:43
+#: lib/dpul_collections_web/components/search_bar_component.ex:118
+#: lib/dpul_collections_web/live/search_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Buscar"
@@ -56,18 +56,18 @@ msgstr "cerrar"
 msgid "Language"
 msgstr "Idioma"
 
-#: lib/dpul_collections_web/live/search_live.ex:766
+#: lib/dpul_collections_web/live/search_live.ex:776
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Proxima"
 
-#: lib/dpul_collections_web/live/search_live.ex:736
+#: lib/dpul_collections_web/live/search_live.ex:746
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Anterior"
 
-#: lib/dpul_collections_web/live/search_live.ex:140
-#: lib/dpul_collections_web/live/search_live.ex:142
+#: lib/dpul_collections_web/live/search_live.ex:113
+#: lib/dpul_collections_web/live/search_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "sort by"
 msgstr "Ordenar por"
@@ -104,12 +104,12 @@ msgstr "Aviso de privacidad"
 msgid "Page not found"
 msgstr "Página no encontrada"
 
-#: lib/dpul_collections_web/live/search_live.ex:96
+#: lib/dpul_collections_web/live/search_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "No items found"
 msgstr "No artículos encontrada"
 
-#: lib/dpul_collections_web/live/search_live.ex:108
+#: lib/dpul_collections_web/live/search_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "of"
 msgstr "de"
@@ -148,9 +148,9 @@ msgstr "navegar"
 
 #: lib/dpul_collections_web/components/header_component.ex:40
 #: lib/dpul_collections_web/live/home_live.ex:36
-#: lib/dpul_collections_web/live/item_live.ex:1076
-#: lib/dpul_collections_web/live/item_live.ex:1077
-#: lib/dpul_collections_web/live/item_live.ex:1078
+#: lib/dpul_collections_web/live/item_live.ex:1080
+#: lib/dpul_collections_web/live/item_live.ex:1081
+#: lib/dpul_collections_web/live/item_live.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Digital Collections"
 msgstr "Colecciones Digitales"
@@ -160,7 +160,7 @@ msgstr "Colecciones Digitales"
 msgid "The Trustees of Princeton University"
 msgstr "Los fideicomisarios de la Universidad de Princeton"
 
-#: lib/dpul_collections_web/live/search_live.ex:602
+#: lib/dpul_collections_web/live/search_live.ex:612
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Añadido"
@@ -238,18 +238,18 @@ msgstr "Editor"
 msgid "Subject"
 msgstr "Tema"
 
-#: lib/dpul_collections_web/live/item_live.ex:831
+#: lib/dpul_collections_web/live/item_live.ex:835
 #, elixir-autogen, elixir-format
 msgid "View all metadata for this item"
 msgstr "Ver todos los metadatos de este ítem"
 
-#: lib/dpul_collections_web/live/item_live.ex:779
+#: lib/dpul_collections_web/live/item_live.ex:783
 #, elixir-autogen, elixir-format
 msgid "No PDF Available"
 msgstr "PDF no disponible"
 
 #: lib/dpul_collections_web/live/item_live.ex:361
-#: lib/dpul_collections_web/live/item_live.ex:1077
+#: lib/dpul_collections_web/live/item_live.ex:1081
 #, elixir-autogen, elixir-format
 msgid "Viewer"
 msgstr "Abrir"
@@ -362,8 +362,8 @@ msgid "Keywords"
 msgstr "Palabras clave"
 
 #: lib/dpul_collections_web/live/item_live.ex:313
-#: lib/dpul_collections_web/live/item_live.ex:817
-#: lib/dpul_collections_web/live/item_live.ex:1076
+#: lib/dpul_collections_web/live/item_live.ex:821
+#: lib/dpul_collections_web/live/item_live.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Metadata"
 msgstr "Metadatos"
@@ -440,6 +440,7 @@ msgstr "Artículos similares fuera de esta colección"
 
 #: lib/dpul_collections_web/live/item_live.ex:366
 #: lib/dpul_collections_web/live/item_live.ex:442
+#: lib/dpul_collections_web/live/user_sets_live/show.ex:59
 #, elixir-autogen, elixir-format
 msgid "Share"
 msgstr "Comparte"
@@ -459,7 +460,7 @@ msgstr "Comparte este artículo"
 msgid "Size"
 msgstr "Tamaño"
 
-#: lib/dpul_collections_web/live/item_live.ex:771
+#: lib/dpul_collections_web/live/item_live.ex:775
 #, elixir-autogen, elixir-format
 msgid "Download PDF"
 msgstr "Descargar PDF"
@@ -473,13 +474,13 @@ msgstr "Descargar PDF"
 msgid "Recently Added"
 msgstr "Actualizado recientemente"
 
-#: lib/dpul_collections_web/live/collections_live.ex:250
+#: lib/dpul_collections_web/live/collections_live.ex:251
 #: lib/dpul_collections_web/live/home_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Recently Added Items"
 msgstr "Materiales Recientes"
 
-#: lib/dpul_collections_web/components/browse_item.ex:228
+#: lib/dpul_collections_web/components/browse_item.ex:235
 #, elixir-autogen, elixir-format
 msgid "Updated"
 msgstr "Actualizado"
@@ -509,17 +510,17 @@ msgstr "Explorar"
 msgid "Browse - Digital Collections"
 msgstr "Explorar - Colecciones digitales"
 
-#: lib/dpul_collections_web/live/item_live.ex:1046
+#: lib/dpul_collections_web/live/item_live.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Copiado"
 
-#: lib/dpul_collections_web/live/item_live.ex:1045
+#: lib/dpul_collections_web/live/item_live.ex:1049
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Copiar"
 
-#: lib/dpul_collections_web/live/item_live.ex:722
+#: lib/dpul_collections_web/live/item_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Letter Paper"
 msgstr "Papel de carta"
@@ -534,17 +535,17 @@ msgstr "Saltar al contenido"
 msgid "View Random Items"
 msgstr "Ver elementos aleatorios"
 
-#: lib/dpul_collections_web/live/item_live.ex:702
+#: lib/dpul_collections_web/live/item_live.ex:706
 #, elixir-autogen, elixir-format
 msgid "main image display"
 msgstr "visualización de la imagen principal"
 
-#: lib/dpul_collections_web/live/search_live.ex:726
+#: lib/dpul_collections_web/live/search_live.ex:736
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr "Resultados de la búsqueda por"
 
-#: lib/dpul_collections_web/components/browse_item.ex:49
+#: lib/dpul_collections_web/components/browse_item.ex:51
 #, elixir-autogen, elixir-format
 msgid "more items"
 msgstr "más artículos"
@@ -589,7 +590,7 @@ msgstr "¿Por qué las imágenes están borrosas?"
 msgid "Main Navigation"
 msgstr "Navegación principal"
 
-#: lib/dpul_collections_web/components/browse_item.ex:237
+#: lib/dpul_collections_web/components/browse_item.ex:244
 #: lib/dpul_collections_web/live/item_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Similar"
@@ -610,8 +611,8 @@ msgstr "Explorar Colecciones"
 msgid "Categories"
 msgstr "Categorías"
 
-#: lib/dpul_collections_web/components/browse_item.ex:212
-#: lib/dpul_collections_web/live/search_live.ex:643
+#: lib/dpul_collections_web/components/browse_item.ex:219
+#: lib/dpul_collections_web/live/search_live.ex:653
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Fecha"
@@ -630,15 +631,15 @@ msgstr "Descubre, descarga y comparte artículos contemporáneos e históricos d
 msgid "Featured"
 msgstr "Destacado"
 
-#: lib/dpul_collections_web/components/browse_item.ex:163
+#: lib/dpul_collections_web/components/browse_item.ex:170
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:627
-#: lib/dpul_collections_web/live/search_live.ex:697
+#: lib/dpul_collections_web/live/search_live.ex:637
+#: lib/dpul_collections_web/live/search_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr "Archivos"
 
-#: lib/dpul_collections_web/live/search_live.ex:220
+#: lib/dpul_collections_web/live/search_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filtros"
@@ -654,7 +655,7 @@ msgid "Leaflets"
 msgstr "Folletos"
 
 #: lib/dpul_collections_web/live/collections_live.ex:169
-#: lib/dpul_collections_web/live/collections_live.ex:208
+#: lib/dpul_collections_web/live/collections_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Learn More"
 msgstr "Más información"
@@ -670,7 +671,7 @@ msgstr "Iniciar sesión"
 msgid "Log out"
 msgstr "Cierre la sesión"
 
-#: lib/dpul_collections_web/live/item_live.ex:733
+#: lib/dpul_collections_web/live/item_live.ex:737
 #, elixir-autogen, elixir-format
 msgid "Look closer"
 msgstr "Mira más de cerca"
@@ -691,7 +692,8 @@ msgstr "Mi Cuenta"
 msgid "My Sets"
 msgstr "Mis Conjuntos"
 
-#: lib/dpul_collections_web/live/search_live.ex:650
+#: lib/dpul_collections_web/components/browse_item.ex:226
+#: lib/dpul_collections_web/live/search_live.ex:660
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr "Origen"
@@ -712,14 +714,14 @@ msgid "Posters"
 msgstr "Pósteres"
 
 #: lib/dpul_collections_web/live/item_live.ex:452
-#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:216
-#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:229
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:218
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:231
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Guardar"
 
-#: lib/dpul_collections_web/live/search_live.ex:661
-#: lib/dpul_collections_web/live/search_live.ex:667
+#: lib/dpul_collections_web/live/search_live.ex:671
+#: lib/dpul_collections_web/live/search_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr "Resultados de la búsqueda"
@@ -928,7 +930,7 @@ msgstr "Le enviamos un código por correo electrónico"
 msgid "We sent an email to %{email}."
 msgstr "Enviamos un correo electrónico a %{email}."
 
-#: lib/dpul_collections_web/live/collections_live.ex:317
+#: lib/dpul_collections_web/live/collections_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Copyright"
 msgstr "Política de derechos de autor"
@@ -943,7 +945,7 @@ msgstr "Corregir"
 msgid "Digital Collection"
 msgstr "Colecciones Digitales"
 
-#: lib/dpul_collections_web/live/collections_live.ex:260
+#: lib/dpul_collections_web/live/collections_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Explore the latest additions to our growing collection for"
 msgstr "Explore las últimas incorporaciones a nuestra creciente colección de"
@@ -956,7 +958,6 @@ msgstr "Destacado"
 #: lib/dpul_collections/item.ex:86
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
-#: lib/dpul_collections_web/components/browse_item.ex:219
 #: lib/dpul_collections_web/live/item_live.ex:2
 #: lib/dpul_collections_web/live/search_live.ex:7
 #: lib/dpul_collections_web/live/search_live/search_state.ex:2
@@ -964,7 +965,7 @@ msgstr "Destacado"
 msgid "Format"
 msgstr "Formato"
 
-#: lib/dpul_collections_web/live/collections_live.ex:227
+#: lib/dpul_collections_web/live/collections_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Formats"
 msgstr "Formatos"
@@ -979,7 +980,7 @@ msgstr "Artículos"
 msgid "Languages"
 msgstr "Idioma"
 
-#: lib/dpul_collections_web/live/collections_live.ex:343
+#: lib/dpul_collections_web/live/collections_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "Library of Congress Romanization tables"
 msgstr "tablas de romanización de la Biblioteca del Congreso"
@@ -989,7 +990,7 @@ msgstr "tablas de romanización de la Biblioteca del Congreso"
 msgid "Locations"
 msgstr "Ubicaciones"
 
-#: lib/dpul_collections_web/live/collections_live.ex:340
+#: lib/dpul_collections_web/live/collections_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Please refer to the %{romanization_link} when searching the collection."
 msgstr "Por favor consulte las %{romanization_link} al buscar en la colección."
@@ -999,17 +1000,17 @@ msgstr "Por favor consulte las %{romanization_link} al buscar en la colección."
 msgid "Please use this area to report errors, omissions, or %{description_link} that appear in the description of this collection. Corrections may include misspellings, incorrect or missing dates, misidentified individuals, places, or events, mislabeled folders, misfiled papers, etc."
 msgstr "Utilice esta área para informar errores, omisiones o %{description_link} que aparezcan en la descripción de esta colección. Las correcciones pueden incluir errores ortográficos, fechas incorrectas o faltantes, personas, lugares o eventos mal identificados, carpetas mal etiquetadas, documentos mal archivados, etc."
 
-#: lib/dpul_collections_web/live/collections_live.ex:329
+#: lib/dpul_collections_web/live/collections_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "Preferred Citation"
 msgstr "Cita preferida"
 
-#: lib/dpul_collections_web/live/collections_live.ex:321
+#: lib/dpul_collections_web/live/collections_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "Princeton University Library claims no copyright governing this digital resource. It is provided for free, on a non-commercial, open-access basis, for fair-use academic and research purposes only. Anyone who claims copyright over any part of these resources and feels that they should not be presented in this manner is invited to %{contact_link}, who will in turn consider such concerns and make reasonable efforts to respond to such concerns."
 msgstr "La Biblioteca de la Universidad de Princeton no reclama derechos de autor sobre este recurso digital. Se proporciona de forma gratuita, sin fines comerciales y de acceso abierto, únicamente para fines académicos y de investigación de uso justo. Cualquier persona que reclame derechos de autor sobre cualquier parte de estos recursos y considere que no deberían presentarse de esta manera está invitada a %{contact_link}, quienes a su vez considerarán dichas inquietudes y harán esfuerzos razonables para responder a las mismas."
 
-#: lib/dpul_collections_web/live/collections_live.ex:336
+#: lib/dpul_collections_web/live/collections_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Romanization"
 msgstr "Romanización"
@@ -1019,17 +1020,17 @@ msgstr "Romanización"
 msgid "Save to Set"
 msgstr "Guardar en conjunto"
 
-#: lib/dpul_collections_web/live/item_live.ex:584
+#: lib/dpul_collections_web/live/item_live.ex:588
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr "Enviar"
 
-#: lib/dpul_collections_web/live/item_live.ex:595
+#: lib/dpul_collections_web/live/item_live.ex:599
 #, elixir-autogen, elixir-format
 msgid "Sorry, something went wrong. Either the message was blank or there was an error with the form submission. Please try again or email the library directly."
 msgstr "Lo sentimos, algo salió mal. El mensaje estaba en blanco o hubo un error con el envío del formulario. Por favor, inténtelo de nuevo o envíe un correo electrónico directamente a la biblioteca."
 
-#: lib/dpul_collections_web/live/collections_live.ex:217
+#: lib/dpul_collections_web/live/collections_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Subject Areas"
 msgstr "Tema"
@@ -1039,19 +1040,19 @@ msgstr "Tema"
 msgid "Suggest a correction"
 msgstr "Sugerir una corrección"
 
-#: lib/dpul_collections_web/live/item_live.ex:590
+#: lib/dpul_collections_web/live/item_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "Thank you for your suggestion. We will reach out to you if we have any questions. Our staff will review your suggestion and assess the practicality of its implementation, as well as its conformance to national and international description standards and current best practices in the field. You may not hear back from us, but, rest assured, we assess each suggestion we receive carefully before determining if and how to implement it."
 msgstr "Gracias por su sugerencia. Nos comunicaremos con usted si tenemos alguna pregunta. Nuestro personal revisará su sugerencia y evaluará la viabilidad de su implementación, así como su conformidad con los estándares de descripción nacionales e internacionales y las mejores prácticas actuales en el campo. Es posible que no reciba respuesta de nuestra parte, pero tenga la seguridad de que evaluamos cuidadosamente cada sugerencia que recibimos antes de determinar si implementarla y cómo hacerlo."
 
-#: lib/dpul_collections_web/live/collections_live.ex:324
+#: lib/dpul_collections_web/live/collections_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "contact Princeton University Library"
 msgstr "contactar a la Biblioteca de la Universidad de Princeton"
 
 #: lib/dpul_collections_web/live/item_live.ex:152
-#: lib/dpul_collections_web/live/search_live.ex:524
-#: lib/dpul_collections_web/live/search_live.ex:594
+#: lib/dpul_collections_web/live/search_live.ex:534
+#: lib/dpul_collections_web/live/search_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr "formato"
@@ -1061,7 +1062,7 @@ msgstr "formato"
 msgid "problematic language"
 msgstr "lenguaje problemático"
 
-#: lib/dpul_collections_web/live/search_live.ex:244
+#: lib/dpul_collections_web/live/search_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Active Filters"
 msgstr "Filtros Activos"
@@ -1092,7 +1093,7 @@ msgstr "Nota Vinculante"
 msgid "Call Number"
 msgstr "Número de Llamada"
 
-#: lib/dpul_collections_web/live/search_live.ex:249
+#: lib/dpul_collections_web/live/search_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr "Borrar todo"
@@ -1122,7 +1123,7 @@ msgstr "Donante"
 msgid "Extent"
 msgstr "Medida"
 
-#: lib/dpul_collections_web/live/search_live.ex:238
+#: lib/dpul_collections_web/live/search_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Filter Results"
 msgstr "Filtros"
@@ -1158,7 +1159,7 @@ msgstr "Referencias"
 msgid "Related Name"
 msgstr "Nombre Relacionado"
 
-#: lib/dpul_collections_web/live/search_live.ex:324
+#: lib/dpul_collections_web/live/search_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "Results"
 msgstr "Resultados"
@@ -1173,7 +1174,7 @@ msgstr "Resultados"
 msgid "Scribe"
 msgstr "Escriba"
 
-#: lib/dpul_collections_web/live/search_live.ex:451
+#: lib/dpul_collections_web/live/search_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "Search filters..."
 msgstr "Filtros de búsqueda..."
@@ -1183,22 +1184,120 @@ msgstr "Filtros de búsqueda..."
 msgid "Source Acquisition"
 msgstr "Adquisición de Fuente"
 
-#: lib/dpul_collections_web/live/search_live.ex:324
+#: lib/dpul_collections_web/live/search_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Abrir"
 
-#: lib/dpul_collections_web/live/search_live.ex:445
+#: lib/dpul_collections_web/live/search_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "filters"
 msgstr "Filtros"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:121
+#: lib/dpul_collections_web/components/search_bar_component.ex:122
 #, elixir-autogen, elixir-format
 msgid "Search all"
 msgstr "Buscar todo"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:59
+#: lib/dpul_collections_web/components/search_bar_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "In this Collection"
 msgstr "En esta colección"
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:87
+#: lib/dpul_collections_web/live/user_sets_live/show.ex:69
+#, elixir-autogen, elixir-format
+msgid "%{count} Item"
+msgid_plural "%{count} Items"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:117
+#, elixir-autogen, elixir-format
+msgid "Cancel"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_live/settings.ex:36
+#, elixir-autogen, elixir-format
+msgid "Changing..."
+msgstr ""
+
+#: lib/dpul_collections_web/live/collections_live.ex:277
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Contributors"
+msgstr "Colaborador"
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:121
+#, elixir-autogen, elixir-format
+msgid "Create Set"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:75
+#, elixir-autogen, elixir-format
+msgid "Create new set"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:574
+#: lib/dpul_collections_web/live/user_live/login.ex:43
+#: lib/dpul_collections_web/live/user_live/settings.ex:31
+#, elixir-autogen, elixir-format
+msgid "Email"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:582
+#, elixir-autogen, elixir-format
+msgid "Feedback"
+msgstr ""
+
+#: lib/dpul_collections_web/live/search_live.ex:289
+#, elixir-autogen, elixir-format
+msgid "Filter your %{count} result"
+msgid_plural "Filter your %{count} results"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/dpul_collections_web/live/user_live/confirmation.ex:38
+#: lib/dpul_collections_web/live/user_live/confirmation.ex:42
+#, elixir-autogen, elixir-format
+msgid "Logging in..."
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:577
+#, elixir-autogen, elixir-format
+msgid "Message"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:573
+#, elixir-autogen, elixir-format
+msgid "Name"
+msgstr ""
+
+#: lib/dpul_collections_web/components/footer_component.ex:32
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Princeton University Logo"
+msgstr "Biblioteca de la Universidad de Princeton"
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:111
+#, elixir-autogen, elixir-format
+msgid "Set description"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:110
+#, elixir-autogen, elixir-format
+msgid "Set name"
+msgstr ""
+
+#: lib/dpul_collections_web/live/collections_live.ex:65
+#, elixir-autogen, elixir-format
+msgid "Show less"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:932
+#, elixir-autogen, elixir-format
+msgid "View in Library Catalog"
+msgstr ""
+
+#: lib/dpul_collections_web/live/collections_live.ex:70
+#, elixir-autogen, elixir-format
+msgid "more"
+msgstr ""

--- a/priv/gettext/pt/LC_MESSAGES/default.po
+++ b/priv/gettext/pt/LC_MESSAGES/default.po
@@ -21,10 +21,10 @@ msgstr "Erro!"
 msgid "Hang in there while we get back on track"
 msgstr "Aguarde enquanto voltamos ao normal"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:36
-#: lib/dpul_collections_web/components/search_bar_component.ex:42
-#: lib/dpul_collections_web/components/search_bar_component.ex:117
-#: lib/dpul_collections_web/live/search_live.ex:445
+#: lib/dpul_collections_web/components/search_bar_component.ex:37
+#: lib/dpul_collections_web/components/search_bar_component.ex:43
+#: lib/dpul_collections_web/components/search_bar_component.ex:118
+#: lib/dpul_collections_web/live/search_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Pesquisar"
@@ -56,18 +56,18 @@ msgstr "fechar"
 msgid "Language"
 msgstr "Idioma"
 
-#: lib/dpul_collections_web/live/search_live.ex:766
+#: lib/dpul_collections_web/live/search_live.ex:776
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Próxima"
 
-#: lib/dpul_collections_web/live/search_live.ex:736
+#: lib/dpul_collections_web/live/search_live.ex:746
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Anterior"
 
-#: lib/dpul_collections_web/live/search_live.ex:140
-#: lib/dpul_collections_web/live/search_live.ex:142
+#: lib/dpul_collections_web/live/search_live.ex:113
+#: lib/dpul_collections_web/live/search_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "sort by"
 msgstr "ordenar por"
@@ -104,12 +104,12 @@ msgstr "Aviso de Privacidade"
 msgid "Page not found"
 msgstr "Página não encontrada"
 
-#: lib/dpul_collections_web/live/search_live.ex:96
+#: lib/dpul_collections_web/live/search_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "No items found"
 msgstr "Nenhum item encontrado"
 
-#: lib/dpul_collections_web/live/search_live.ex:108
+#: lib/dpul_collections_web/live/search_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "of"
 msgstr "de"
@@ -148,9 +148,9 @@ msgstr "Navegar"
 
 #: lib/dpul_collections_web/components/header_component.ex:40
 #: lib/dpul_collections_web/live/home_live.ex:36
-#: lib/dpul_collections_web/live/item_live.ex:1076
-#: lib/dpul_collections_web/live/item_live.ex:1077
-#: lib/dpul_collections_web/live/item_live.ex:1078
+#: lib/dpul_collections_web/live/item_live.ex:1080
+#: lib/dpul_collections_web/live/item_live.ex:1081
+#: lib/dpul_collections_web/live/item_live.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Digital Collections"
 msgstr "Coleções Digitais"
@@ -160,7 +160,7 @@ msgstr "Coleções Digitais"
 msgid "The Trustees of Princeton University"
 msgstr "Os Curadores da Universidade de Princeton"
 
-#: lib/dpul_collections_web/live/search_live.ex:602
+#: lib/dpul_collections_web/live/search_live.ex:612
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Adicionado"
@@ -238,18 +238,18 @@ msgstr "Editora"
 msgid "Subject"
 msgstr "Assunto"
 
-#: lib/dpul_collections_web/live/item_live.ex:831
+#: lib/dpul_collections_web/live/item_live.ex:835
 #, elixir-autogen, elixir-format
 msgid "View all metadata for this item"
 msgstr "Ver todos os metadados deste item"
 
-#: lib/dpul_collections_web/live/item_live.ex:779
+#: lib/dpul_collections_web/live/item_live.ex:783
 #, elixir-autogen, elixir-format
 msgid "No PDF Available"
 msgstr "Nenhum PDF disponível"
 
 #: lib/dpul_collections_web/live/item_live.ex:361
-#: lib/dpul_collections_web/live/item_live.ex:1077
+#: lib/dpul_collections_web/live/item_live.ex:1081
 #, elixir-autogen, elixir-format
 msgid "Viewer"
 msgstr "Visualizador"
@@ -362,8 +362,8 @@ msgid "Keywords"
 msgstr "Palavras-chave"
 
 #: lib/dpul_collections_web/live/item_live.ex:313
-#: lib/dpul_collections_web/live/item_live.ex:817
-#: lib/dpul_collections_web/live/item_live.ex:1076
+#: lib/dpul_collections_web/live/item_live.ex:821
+#: lib/dpul_collections_web/live/item_live.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Metadata"
 msgstr "Metadados"
@@ -440,6 +440,7 @@ msgstr "Itens Semelhantes fora desta Coleção"
 
 #: lib/dpul_collections_web/live/item_live.ex:366
 #: lib/dpul_collections_web/live/item_live.ex:442
+#: lib/dpul_collections_web/live/user_sets_live/show.ex:59
 #, elixir-autogen, elixir-format
 msgid "Share"
 msgstr "Compartilhar"
@@ -459,7 +460,7 @@ msgstr "Compartilhar este item"
 msgid "Size"
 msgstr "Tamanho"
 
-#: lib/dpul_collections_web/live/item_live.ex:771
+#: lib/dpul_collections_web/live/item_live.ex:775
 #, elixir-autogen, elixir-format
 msgid "Download PDF"
 msgstr "Baixar PDF"
@@ -473,13 +474,13 @@ msgstr "Baixar PDF"
 msgid "Recently Added"
 msgstr "Adicionado Recentemente"
 
-#: lib/dpul_collections_web/live/collections_live.ex:250
+#: lib/dpul_collections_web/live/collections_live.ex:251
 #: lib/dpul_collections_web/live/home_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Recently Added Items"
 msgstr "Itens Adicionados Recentemente"
 
-#: lib/dpul_collections_web/components/browse_item.ex:228
+#: lib/dpul_collections_web/components/browse_item.ex:235
 #, elixir-autogen, elixir-format
 msgid "Updated"
 msgstr "Atualizado"
@@ -509,17 +510,17 @@ msgstr "Explorar"
 msgid "Browse - Digital Collections"
 msgstr "Navegar - Coleções Digitais"
 
-#: lib/dpul_collections_web/live/item_live.ex:1046
+#: lib/dpul_collections_web/live/item_live.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Copiado"
 
-#: lib/dpul_collections_web/live/item_live.ex:1045
+#: lib/dpul_collections_web/live/item_live.ex:1049
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Copiar"
 
-#: lib/dpul_collections_web/live/item_live.ex:722
+#: lib/dpul_collections_web/live/item_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Letter Paper"
 msgstr "Papel Carta"
@@ -534,17 +535,17 @@ msgstr "Ir para o Conteúdo"
 msgid "View Random Items"
 msgstr "Ver Itens Aleatórios"
 
-#: lib/dpul_collections_web/live/item_live.ex:702
+#: lib/dpul_collections_web/live/item_live.ex:706
 #, elixir-autogen, elixir-format
 msgid "main image display"
 msgstr "exibição da imagem principal"
 
-#: lib/dpul_collections_web/live/search_live.ex:726
+#: lib/dpul_collections_web/live/search_live.ex:736
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr "Navegação da Página de Resultados da Pesquisa"
 
-#: lib/dpul_collections_web/components/browse_item.ex:49
+#: lib/dpul_collections_web/components/browse_item.ex:51
 #, elixir-autogen, elixir-format
 msgid "more items"
 msgstr "mais itens"
@@ -589,7 +590,7 @@ msgstr "Por que as imagens estão borradas?"
 msgid "Main Navigation"
 msgstr "Navegação Principal"
 
-#: lib/dpul_collections_web/components/browse_item.ex:237
+#: lib/dpul_collections_web/components/browse_item.ex:244
 #: lib/dpul_collections_web/live/item_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Similar"
@@ -610,8 +611,8 @@ msgstr "Navegar na Coleção"
 msgid "Categories"
 msgstr "Categorias"
 
-#: lib/dpul_collections_web/components/browse_item.ex:212
-#: lib/dpul_collections_web/live/search_live.ex:643
+#: lib/dpul_collections_web/components/browse_item.ex:219
+#: lib/dpul_collections_web/live/search_live.ex:653
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Data"
@@ -630,15 +631,15 @@ msgstr "Descubra, baixe e compartilhe itens contemporâneos e históricos de tod
 msgid "Featured"
 msgstr "Destaques"
 
-#: lib/dpul_collections_web/components/browse_item.ex:163
+#: lib/dpul_collections_web/components/browse_item.ex:170
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:627
-#: lib/dpul_collections_web/live/search_live.ex:697
+#: lib/dpul_collections_web/live/search_live.ex:637
+#: lib/dpul_collections_web/live/search_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr "Arquivos"
 
-#: lib/dpul_collections_web/live/search_live.ex:220
+#: lib/dpul_collections_web/live/search_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filtros"
@@ -654,7 +655,7 @@ msgid "Leaflets"
 msgstr "Panfletos"
 
 #: lib/dpul_collections_web/live/collections_live.ex:169
-#: lib/dpul_collections_web/live/collections_live.ex:208
+#: lib/dpul_collections_web/live/collections_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Learn More"
 msgstr "Saiba Mais"
@@ -670,7 +671,7 @@ msgstr "Entrar"
 msgid "Log out"
 msgstr "Sair"
 
-#: lib/dpul_collections_web/live/item_live.ex:733
+#: lib/dpul_collections_web/live/item_live.ex:737
 #, elixir-autogen, elixir-format
 msgid "Look closer"
 msgstr "Ver em detalhes"
@@ -691,7 +692,8 @@ msgstr "Minha Conta"
 msgid "My Sets"
 msgstr "Meus Conjuntos"
 
-#: lib/dpul_collections_web/live/search_live.ex:650
+#: lib/dpul_collections_web/components/browse_item.ex:226
+#: lib/dpul_collections_web/live/search_live.ex:660
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr "Origem"
@@ -712,14 +714,14 @@ msgid "Posters"
 msgstr "Pôsteres"
 
 #: lib/dpul_collections_web/live/item_live.ex:452
-#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:216
-#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:229
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:218
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:231
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Salvar"
 
-#: lib/dpul_collections_web/live/search_live.ex:661
-#: lib/dpul_collections_web/live/search_live.ex:667
+#: lib/dpul_collections_web/live/search_live.ex:671
+#: lib/dpul_collections_web/live/search_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr "Resultados da Pesquisa"
@@ -928,7 +930,7 @@ msgstr "Enviamos um código por e-mail"
 msgid "We sent an email to %{email}."
 msgstr "Enviamos um e-mail para %{email}."
 
-#: lib/dpul_collections_web/live/collections_live.ex:317
+#: lib/dpul_collections_web/live/collections_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Copyright"
 msgstr "Política de Direitos Autorais"
@@ -943,7 +945,7 @@ msgstr "Corrigir"
 msgid "Digital Collection"
 msgstr "Coleções Digitais"
 
-#: lib/dpul_collections_web/live/collections_live.ex:260
+#: lib/dpul_collections_web/live/collections_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Explore the latest additions to our growing collection for"
 msgstr "Explore as últimas adições à nossa crescente coleção de"
@@ -956,7 +958,6 @@ msgstr "Destaques"
 #: lib/dpul_collections/item.ex:86
 #: lib/dpul_collections/search_result.ex:2
 #: lib/dpul_collections/solr.ex:3
-#: lib/dpul_collections_web/components/browse_item.ex:219
 #: lib/dpul_collections_web/live/item_live.ex:2
 #: lib/dpul_collections_web/live/search_live.ex:7
 #: lib/dpul_collections_web/live/search_live/search_state.ex:2
@@ -964,7 +965,7 @@ msgstr "Destaques"
 msgid "Format"
 msgstr "Formato"
 
-#: lib/dpul_collections_web/live/collections_live.ex:227
+#: lib/dpul_collections_web/live/collections_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Formats"
 msgstr "Formatos"
@@ -979,7 +980,7 @@ msgstr "Itens"
 msgid "Languages"
 msgstr "Idioma"
 
-#: lib/dpul_collections_web/live/collections_live.ex:343
+#: lib/dpul_collections_web/live/collections_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "Library of Congress Romanization tables"
 msgstr "tabelas de romanização da Biblioteca do Congresso"
@@ -989,7 +990,7 @@ msgstr "tabelas de romanização da Biblioteca do Congresso"
 msgid "Locations"
 msgstr "Localizações"
 
-#: lib/dpul_collections_web/live/collections_live.ex:340
+#: lib/dpul_collections_web/live/collections_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Please refer to the %{romanization_link} when searching the collection."
 msgstr "Por favor consulte as %{romanization_link} ao pesquisar na coleção."
@@ -999,17 +1000,17 @@ msgstr "Por favor consulte as %{romanization_link} ao pesquisar na coleção."
 msgid "Please use this area to report errors, omissions, or %{description_link} that appear in the description of this collection. Corrections may include misspellings, incorrect or missing dates, misidentified individuals, places, or events, mislabeled folders, misfiled papers, etc."
 msgstr "Utilize esta área para relatar erros, omissões ou %{description_link} que aparecem na descrição desta coleção. As correções podem incluir erros ortográficos, datas incorretas ou ausentes, indivíduos, lugares ou eventos mal identificados, pastas mal rotuladas, documentos arquivados incorretamente, etc."
 
-#: lib/dpul_collections_web/live/collections_live.ex:329
+#: lib/dpul_collections_web/live/collections_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "Preferred Citation"
 msgstr "Citação preferida"
 
-#: lib/dpul_collections_web/live/collections_live.ex:321
+#: lib/dpul_collections_web/live/collections_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "Princeton University Library claims no copyright governing this digital resource. It is provided for free, on a non-commercial, open-access basis, for fair-use academic and research purposes only. Anyone who claims copyright over any part of these resources and feels that they should not be presented in this manner is invited to %{contact_link}, who will in turn consider such concerns and make reasonable efforts to respond to such concerns."
 msgstr "A Biblioteca da Universidade de Princeton não reivindica direitos autorais sobre este recurso digital. Ele é fornecido gratuitamente, em uma base não comercial e de acesso aberto, apenas para fins acadêmicos e de pesquisa de uso justo. Qualquer pessoa que reivindique direitos autorais sobre qualquer parte destes recursos e considere que não deveriam ser apresentados desta maneira está convidada a %{contact_link}, que por sua vez considerarão tais preocupações e farão esforços razoáveis para responder a essas preocupações."
 
-#: lib/dpul_collections_web/live/collections_live.ex:336
+#: lib/dpul_collections_web/live/collections_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Romanization"
 msgstr "Romanização"
@@ -1019,17 +1020,17 @@ msgstr "Romanização"
 msgid "Save to Set"
 msgstr "Salvar no conjunto"
 
-#: lib/dpul_collections_web/live/item_live.ex:584
+#: lib/dpul_collections_web/live/item_live.ex:588
 #, elixir-autogen, elixir-format
 msgid "Send"
 msgstr "Enviar"
 
-#: lib/dpul_collections_web/live/item_live.ex:595
+#: lib/dpul_collections_web/live/item_live.ex:599
 #, elixir-autogen, elixir-format
 msgid "Sorry, something went wrong. Either the message was blank or there was an error with the form submission. Please try again or email the library directly."
 msgstr "Desculpe, algo deu errado. A mensagem estava em branco ou houve um erro com o envio do formulário. Por favor, tente novamente ou envie um e-mail diretamente para a biblioteca."
 
-#: lib/dpul_collections_web/live/collections_live.ex:217
+#: lib/dpul_collections_web/live/collections_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Subject Areas"
 msgstr "Assunto"
@@ -1039,19 +1040,19 @@ msgstr "Assunto"
 msgid "Suggest a correction"
 msgstr "Sugerir uma correção"
 
-#: lib/dpul_collections_web/live/item_live.ex:590
+#: lib/dpul_collections_web/live/item_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "Thank you for your suggestion. We will reach out to you if we have any questions. Our staff will review your suggestion and assess the practicality of its implementation, as well as its conformance to national and international description standards and current best practices in the field. You may not hear back from us, but, rest assured, we assess each suggestion we receive carefully before determining if and how to implement it."
 msgstr "Obrigado pela sua sugestão. Entraremos em contato se tivermos alguma dúvida. Nossa equipe analisará sua sugestão e avaliará a viabilidade de sua implementação, bem como sua conformidade com os padrões de descrição nacionais e internacionais e as melhores práticas atuais na área. Você pode não receber uma resposta nossa, mas fique tranquilo, avaliamos cuidadosamente cada sugestão que recebemos antes de determinar se e como implementá-la."
 
-#: lib/dpul_collections_web/live/collections_live.ex:324
+#: lib/dpul_collections_web/live/collections_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "contact Princeton University Library"
 msgstr "entrar em contato com a Biblioteca da Universidade de Princeton"
 
 #: lib/dpul_collections_web/live/item_live.ex:152
-#: lib/dpul_collections_web/live/search_live.ex:524
-#: lib/dpul_collections_web/live/search_live.ex:594
+#: lib/dpul_collections_web/live/search_live.ex:534
+#: lib/dpul_collections_web/live/search_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr "formato"
@@ -1061,7 +1062,7 @@ msgstr "formato"
 msgid "problematic language"
 msgstr "linguagem problemática"
 
-#: lib/dpul_collections_web/live/search_live.ex:244
+#: lib/dpul_collections_web/live/search_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Active Filters"
 msgstr "Filtros Ativos"
@@ -1092,7 +1093,7 @@ msgstr "Nota Vinculativa"
 msgid "Call Number"
 msgstr "Número de Chamada"
 
-#: lib/dpul_collections_web/live/search_live.ex:249
+#: lib/dpul_collections_web/live/search_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr "Limpar Tudo"
@@ -1122,7 +1123,7 @@ msgstr "Doador"
 msgid "Extent"
 msgstr "Extensão"
 
-#: lib/dpul_collections_web/live/search_live.ex:238
+#: lib/dpul_collections_web/live/search_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Filter Results"
 msgstr "Filtros"
@@ -1158,7 +1159,7 @@ msgstr "Referências"
 msgid "Related Name"
 msgstr "Nome Relacionado"
 
-#: lib/dpul_collections_web/live/search_live.ex:324
+#: lib/dpul_collections_web/live/search_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "Results"
 msgstr "Resultados"
@@ -1173,7 +1174,7 @@ msgstr "Resultados"
 msgid "Scribe"
 msgstr "Escriba"
 
-#: lib/dpul_collections_web/live/search_live.ex:451
+#: lib/dpul_collections_web/live/search_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "Search filters..."
 msgstr "Filtros de pesquisa..."
@@ -1183,22 +1184,120 @@ msgstr "Filtros de pesquisa..."
 msgid "Source Acquisition"
 msgstr "Aquisição de Fonte"
 
-#: lib/dpul_collections_web/live/search_live.ex:324
+#: lib/dpul_collections_web/live/search_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Visualizador"
 
-#: lib/dpul_collections_web/live/search_live.ex:445
+#: lib/dpul_collections_web/live/search_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "filters"
 msgstr "Filtros"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:121
+#: lib/dpul_collections_web/components/search_bar_component.ex:122
 #, elixir-autogen, elixir-format
 msgid "Search all"
 msgstr "Pesquisar tudo"
 
-#: lib/dpul_collections_web/components/search_bar_component.ex:59
+#: lib/dpul_collections_web/components/search_bar_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "In this Collection"
 msgstr "Nesta coleção"
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:87
+#: lib/dpul_collections_web/live/user_sets_live/show.ex:69
+#, elixir-autogen, elixir-format
+msgid "%{count} Item"
+msgid_plural "%{count} Items"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:117
+#, elixir-autogen, elixir-format
+msgid "Cancel"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_live/settings.ex:36
+#, elixir-autogen, elixir-format
+msgid "Changing..."
+msgstr ""
+
+#: lib/dpul_collections_web/live/collections_live.ex:277
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Contributors"
+msgstr "Contribuinte"
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:121
+#, elixir-autogen, elixir-format
+msgid "Create Set"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:75
+#, elixir-autogen, elixir-format
+msgid "Create new set"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:574
+#: lib/dpul_collections_web/live/user_live/login.ex:43
+#: lib/dpul_collections_web/live/user_live/settings.ex:31
+#, elixir-autogen, elixir-format
+msgid "Email"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:582
+#, elixir-autogen, elixir-format
+msgid "Feedback"
+msgstr ""
+
+#: lib/dpul_collections_web/live/search_live.ex:289
+#, elixir-autogen, elixir-format
+msgid "Filter your %{count} result"
+msgid_plural "Filter your %{count} results"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/dpul_collections_web/live/user_live/confirmation.ex:38
+#: lib/dpul_collections_web/live/user_live/confirmation.ex:42
+#, elixir-autogen, elixir-format
+msgid "Logging in..."
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:577
+#, elixir-autogen, elixir-format
+msgid "Message"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:573
+#, elixir-autogen, elixir-format
+msgid "Name"
+msgstr ""
+
+#: lib/dpul_collections_web/components/footer_component.ex:32
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Princeton University Logo"
+msgstr "Biblioteca da Universidade de Princeton"
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:111
+#, elixir-autogen, elixir-format
+msgid "Set description"
+msgstr ""
+
+#: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:110
+#, elixir-autogen, elixir-format
+msgid "Set name"
+msgstr ""
+
+#: lib/dpul_collections_web/live/collections_live.ex:65
+#, elixir-autogen, elixir-format
+msgid "Show less"
+msgstr ""
+
+#: lib/dpul_collections_web/live/item_live.ex:932
+#, elixir-autogen, elixir-format
+msgid "View in Library Catalog"
+msgstr ""
+
+#: lib/dpul_collections_web/live/collections_live.ex:70
+#, elixir-autogen, elixir-format
+msgid "more"
+msgstr ""


### PR DESCRIPTION
Closes #1195 

Identifies raw strings in the website and wraps them in `gettext` for future translation.