### PR TITLE
Make collection filter pills clickable

### DIFF
--- a/lib/dpul_collections/collection.ex
+++ b/lib/dpul_collections/collection.ex
@@ -27,6 +27,13 @@ defmodule DpulCollections.Collection do
     |> from_solr()
   end
 
+  def authoritative_slug_from_title(title) do
+    case Solr.find_by_collection_title(title) do
+      %{"authoritative_slug_s" => slug} when is_binary(slug) -> slug
+      _ -> nil
+    end
+  end
+
   def get_featured_items(label) do
     params =
       SearchState.from_params(%{

--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -327,6 +327,22 @@ defmodule DpulCollections.Solr do
     end
   end
 
+  def find_by_collection_title(title, index \\ Index.read_index()) do
+    {:ok, response} =
+      Client.query(
+        index,
+        params: [
+          q: ~s(resource_type_s:collection AND title_txtm:"#{escape_query(title)}"),
+          rows: 1
+        ]
+      )
+
+    case response.body["response"]["docs"] do
+      [] -> nil
+      [doc | _] -> doc
+    end
+  end
+
   @spec add(list(map()) | String.t(), %Index{}) ::
           {:ok, Req.Response.t()} | {:error, Exception.t()}
   def add(docs, index \\ Index.read_index())

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -388,25 +388,53 @@ defmodule DpulCollectionsWeb.SearchLive do
 
   def filter_pill(assigns = %{filter_value: filter_value}) when is_binary(filter_value) do
     ~H"""
-    <.primary_button
+    <div
       :if={@filter_value}
-      role="button"
-      phx-value-filter-value={@filter_value}
-      phx-value-filter={@field}
-      phx-click="remove_filter"
       class={[
         @field,
-        "filter flex max-w-full gap-1 py-2 px-4 btn-primary no-underline font-semibold *:font-semibold text-sm h-full"
+        "filter inline-flex max-w-full overflow-hidden bg-primary text-dark-text font-semibold *:font-semibold text-sm h-full"
       ]}
     >
       {# These labels are defined explicitly in Solr.Constants, but have to be called here because Constants is defined at compile time.}
-      {Gettext.gettext(DpulCollectionsWeb.Gettext, @label)}
-      <span><.icon name="hero-chevron-right" class="p-1 h-4 w-4 icon" /></span>
-      <span class="filter-text truncate">
-        {@filter_value}
+      <button
+        :if={@field == "collection"}
+        type="button"
+        phx-click="navigate_to_collection"
+        phx-value-title={@filter_value}
+        class="filter-body flex items-center gap-1 py-2 pl-4 pr-2 no-underline hover:underline hover:bg-hover-accent focus-visible:underline focus-visible:bg-hover-accent cursor-pointer text-left"
+      >
+        {Gettext.gettext(DpulCollectionsWeb.Gettext, @label)}
+        <span><.icon name="hero-chevron-right" class="p-1 h-4 w-4 icon" /></span>
+        <span class="filter-text truncate">
+          {@filter_value}
+        </span>
+      </button>
+      <span
+        :if={@field != "collection"}
+        class="filter-body flex items-center gap-1 py-2 pl-4 pr-2"
+      >
+        {Gettext.gettext(DpulCollectionsWeb.Gettext, @label)}
+        <span><.icon name="hero-chevron-right" class="p-1 h-4 w-4 icon" /></span>
+        <span class="filter-text truncate">
+          {@filter_value}
+        </span>
       </span>
-      <span><.icon name="hero-x-circle" class="ml-2 h-6 w-6 icon" /></span>
-    </.primary_button>
+      <button
+        type="button"
+        class="filter-dismiss flex items-center justify-center px-3 py-2 hover:bg-hover-accent focus-visible:bg-hover-accent cursor-pointer"
+        phx-click="remove_filter"
+        phx-value-filter={@field}
+        phx-value-filter-value={@filter_value}
+        aria-label={
+          gettext("Remove %{label}: %{value} filter",
+            label: Gettext.gettext(DpulCollectionsWeb.Gettext, @label),
+            value: @filter_value
+          )
+        }
+      >
+        <.icon name="hero-x-circle" class="h-6 w-6 icon" />
+      </button>
+    </div>
     """
   end
 
@@ -825,6 +853,16 @@ defmodule DpulCollectionsWeb.SearchLive do
       {format_number(@text)}
     </span>
     """
+  end
+
+  def handle_event("navigate_to_collection", %{"title" => title}, socket) do
+    case Collection.authoritative_slug_from_title(title) do
+      slug when is_binary(slug) ->
+        {:noreply, push_navigate(socket, to: ~p"/collections/#{slug}")}
+
+      _ ->
+        {:noreply, put_flash(socket, :error, gettext("Collection not found"))}
+    end
   end
 
   def handle_event(

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -401,11 +401,11 @@ defmodule DpulCollectionsWeb.SearchLive do
         type="button"
         phx-click="navigate_to_collection"
         phx-value-title={@filter_value}
-        class="filter-body flex items-center gap-1 py-2 pl-4 pr-2 no-underline hover:underline hover:bg-hover-accent focus-visible:underline focus-visible:bg-hover-accent cursor-pointer text-left"
+        class="filter-body group flex items-center gap-1 py-2 pl-4 pr-2 no-underline hover:bg-hover-accent focus-visible:bg-hover-accent cursor-pointer text-left"
       >
         {Gettext.gettext(DpulCollectionsWeb.Gettext, @label)}
         <span><.icon name="hero-chevron-right" class="p-1 h-4 w-4 icon" /></span>
-        <span class="filter-text truncate">
+        <span class="filter-text truncate group-hover:underline group-focus-visible:underline">
           {@filter_value}
         </span>
       </button>

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -395,30 +395,11 @@ defmodule DpulCollectionsWeb.SearchLive do
         "filter inline-flex max-w-full overflow-hidden bg-primary text-dark-text font-semibold *:font-semibold text-sm h-full"
       ]}
     >
-      {# These labels are defined explicitly in Solr.Constants, but have to be called here because Constants is defined at compile time.}
-      <button
-        :if={@field == "collection"}
-        type="button"
-        phx-click="navigate_to_collection"
-        phx-value-title={@filter_value}
-        class="filter-body group flex items-center gap-1 py-2 pl-4 pr-2 no-underline hover:bg-hover-accent focus-visible:bg-hover-accent cursor-pointer text-left"
-      >
-        {Gettext.gettext(DpulCollectionsWeb.Gettext, @label)}
-        <span><.icon name="hero-chevron-right" class="p-1 h-4 w-4 icon" /></span>
-        <span class="filter-text truncate group-hover:underline group-focus-visible:underline">
-          {@filter_value}
-        </span>
-      </button>
-      <span
-        :if={@field != "collection"}
-        class="filter-body flex items-center gap-1 py-2 pl-4 pr-2"
-      >
-        {Gettext.gettext(DpulCollectionsWeb.Gettext, @label)}
-        <span><.icon name="hero-chevron-right" class="p-1 h-4 w-4 icon" /></span>
-        <span class="filter-text truncate">
-          {@filter_value}
-        </span>
-      </span>
+      <.filter_pill_body
+        filter_value={@filter_value}
+        field={@field}
+        label={@label}
+      />
       <button
         type="button"
         class="filter-dismiss flex items-center justify-center px-3 py-2 hover:bg-hover-accent focus-visible:bg-hover-accent cursor-pointer"
@@ -440,6 +421,35 @@ defmodule DpulCollectionsWeb.SearchLive do
 
   def filter_pill(assigns) do
     ~H"""
+    """
+  end
+
+  def filter_pill_body(assigns = %{field: field}) when field == "collection" do
+    ~H"""
+    <button
+      type="button"
+      phx-click="navigate_to_collection"
+      phx-value-title={@filter_value}
+      class="filter-body group flex items-center gap-1 py-2 pl-4 pr-2 no-underline hover:bg-hover-accent focus-visible:bg-hover-accent cursor-pointer text-left"
+    >
+      {Gettext.gettext(DpulCollectionsWeb.Gettext, @label)}
+      <span><.icon name="hero-chevron-right" class="p-1 h-4 w-4 icon" /></span>
+      <span class="filter-text truncate group-hover:underline group-focus-visible:underline">
+        {@filter_value}
+      </span>
+    </button>
+    """
+  end
+
+  def filter_pill_body(assigns) do
+    ~H"""
+    <span class="filter-body flex items-center gap-1 py-2 pl-4 pr-2">
+      {Gettext.gettext(DpulCollectionsWeb.Gettext, @label)}
+      <span><.icon name="hero-chevron-right" class="p-1 h-4 w-4 icon" /></span>
+      <span class="filter-text truncate">
+        {@filter_value}
+      </span>
+    </span>
     """
   end
 

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -24,7 +24,7 @@ msgstr ""
 #: lib/dpul_collections_web/components/search_bar_component.ex:37
 #: lib/dpul_collections_web/components/search_bar_component.ex:43
 #: lib/dpul_collections_web/components/search_bar_component.ex:118
-#: lib/dpul_collections_web/live/search_live.ex:455
+#: lib/dpul_collections_web/live/search_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
@@ -56,12 +56,12 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:776
+#: lib/dpul_collections_web/live/search_live.ex:804
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:746
+#: lib/dpul_collections_web/live/search_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
@@ -72,14 +72,14 @@ msgstr ""
 msgid "sort by"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:423
-#: lib/dpul_collections_web/live/search_live.ex:424
+#: lib/dpul_collections_web/live/search_live.ex:451
+#: lib/dpul_collections_web/live/search_live.ex:452
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:428
-#: lib/dpul_collections_web/live/search_live.ex:429
+#: lib/dpul_collections_web/live/search_live.ex:456
+#: lib/dpul_collections_web/live/search_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr ""
@@ -160,7 +160,7 @@ msgstr ""
 msgid "The Trustees of Princeton University"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:612
+#: lib/dpul_collections_web/live/search_live.ex:640
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -540,7 +540,7 @@ msgstr ""
 msgid "main image display"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:736
+#: lib/dpul_collections_web/live/search_live.ex:764
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr ""
@@ -612,7 +612,7 @@ msgid "Categories"
 msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:219
-#: lib/dpul_collections_web/live/search_live.ex:653
+#: lib/dpul_collections_web/live/search_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
@@ -633,8 +633,8 @@ msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:170
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:637
-#: lib/dpul_collections_web/live/search_live.ex:707
+#: lib/dpul_collections_web/live/search_live.ex:665
+#: lib/dpul_collections_web/live/search_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr ""
@@ -693,7 +693,7 @@ msgid "My Sets"
 msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:226
-#: lib/dpul_collections_web/live/search_live.ex:660
+#: lib/dpul_collections_web/live/search_live.ex:688
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr ""
@@ -720,8 +720,8 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:671
-#: lib/dpul_collections_web/live/search_live.ex:677
+#: lib/dpul_collections_web/live/search_live.ex:699
+#: lib/dpul_collections_web/live/search_live.ex:705
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr ""
@@ -1051,8 +1051,8 @@ msgid "contact Princeton University Library"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:152
-#: lib/dpul_collections_web/live/search_live.ex:534
-#: lib/dpul_collections_web/live/search_live.ex:604
+#: lib/dpul_collections_web/live/search_live.ex:562
+#: lib/dpul_collections_web/live/search_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr ""
@@ -1067,7 +1067,7 @@ msgstr ""
 msgid "Active Filters"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:434
+#: lib/dpul_collections_web/live/search_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Apply Year Range"
 msgstr ""
@@ -1174,7 +1174,7 @@ msgstr ""
 msgid "Scribe"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:461
+#: lib/dpul_collections_web/live/search_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Search filters..."
 msgstr ""
@@ -1189,7 +1189,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:455
+#: lib/dpul_collections_web/live/search_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "filters"
 msgstr ""
@@ -1272,11 +1272,6 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/dpul_collections_web/components/footer_component.ex:32
-#, elixir-autogen, elixir-format
-msgid "Princeton University Logo"
-msgstr ""
-
 #: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:111
 #, elixir-autogen, elixir-format
 msgid "Set description"
@@ -1300,4 +1295,19 @@ msgstr ""
 #: lib/dpul_collections_web/live/collections_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "more"
+msgstr ""
+
+#: lib/dpul_collections_web/live/search_live.ex:864
+#, elixir-autogen, elixir-format
+msgid "Collection not found"
+msgstr ""
+
+#: lib/dpul_collections_web/components/footer_component.ex:32
+#, elixir-autogen, elixir-format
+msgid "Princeton University"
+msgstr ""
+
+#: lib/dpul_collections_web/live/search_live.ex:429
+#, elixir-autogen, elixir-format
+msgid "Remove %{label}: %{value} filter"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr ""
 #: lib/dpul_collections_web/components/search_bar_component.ex:37
 #: lib/dpul_collections_web/components/search_bar_component.ex:43
 #: lib/dpul_collections_web/components/search_bar_component.ex:118
-#: lib/dpul_collections_web/live/search_live.ex:455
+#: lib/dpul_collections_web/live/search_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
@@ -56,12 +56,12 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:776
+#: lib/dpul_collections_web/live/search_live.ex:804
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:746
+#: lib/dpul_collections_web/live/search_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
@@ -72,14 +72,14 @@ msgstr ""
 msgid "sort by"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:423
-#: lib/dpul_collections_web/live/search_live.ex:424
+#: lib/dpul_collections_web/live/search_live.ex:451
+#: lib/dpul_collections_web/live/search_live.ex:452
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:428
-#: lib/dpul_collections_web/live/search_live.ex:429
+#: lib/dpul_collections_web/live/search_live.ex:456
+#: lib/dpul_collections_web/live/search_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr ""
@@ -160,7 +160,7 @@ msgstr ""
 msgid "The Trustees of Princeton University"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:612
+#: lib/dpul_collections_web/live/search_live.ex:640
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -540,7 +540,7 @@ msgstr ""
 msgid "main image display"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:736
+#: lib/dpul_collections_web/live/search_live.ex:764
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr ""
@@ -612,7 +612,7 @@ msgid "Categories"
 msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:219
-#: lib/dpul_collections_web/live/search_live.ex:653
+#: lib/dpul_collections_web/live/search_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
@@ -633,8 +633,8 @@ msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:170
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:637
-#: lib/dpul_collections_web/live/search_live.ex:707
+#: lib/dpul_collections_web/live/search_live.ex:665
+#: lib/dpul_collections_web/live/search_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr ""
@@ -693,7 +693,7 @@ msgid "My Sets"
 msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:226
-#: lib/dpul_collections_web/live/search_live.ex:660
+#: lib/dpul_collections_web/live/search_live.ex:688
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr ""
@@ -720,8 +720,8 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:671
-#: lib/dpul_collections_web/live/search_live.ex:677
+#: lib/dpul_collections_web/live/search_live.ex:699
+#: lib/dpul_collections_web/live/search_live.ex:705
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr ""
@@ -1051,8 +1051,8 @@ msgid "contact Princeton University Library"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:152
-#: lib/dpul_collections_web/live/search_live.ex:534
-#: lib/dpul_collections_web/live/search_live.ex:604
+#: lib/dpul_collections_web/live/search_live.ex:562
+#: lib/dpul_collections_web/live/search_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr ""
@@ -1067,7 +1067,7 @@ msgstr ""
 msgid "Active Filters"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:434
+#: lib/dpul_collections_web/live/search_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Apply Year Range"
 msgstr ""
@@ -1174,7 +1174,7 @@ msgstr ""
 msgid "Scribe"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:461
+#: lib/dpul_collections_web/live/search_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Search filters..."
 msgstr ""
@@ -1189,7 +1189,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:455
+#: lib/dpul_collections_web/live/search_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "filters"
 msgstr ""
@@ -1272,11 +1272,6 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/dpul_collections_web/components/footer_component.ex:32
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Princeton University Logo"
-msgstr ""
-
 #: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:111
 #, elixir-autogen, elixir-format
 msgid "Set description"
@@ -1300,4 +1295,19 @@ msgstr ""
 #: lib/dpul_collections_web/live/collections_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "more"
+msgstr ""
+
+#: lib/dpul_collections_web/live/search_live.ex:864
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Collection not found"
+msgstr ""
+
+#: lib/dpul_collections_web/components/footer_component.ex:32
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Princeton University"
+msgstr ""
+
+#: lib/dpul_collections_web/live/search_live.ex:429
+#, elixir-autogen, elixir-format
+msgid "Remove %{label}: %{value} filter"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr "Aguanta mientras volvemos al buen camino"
 #: lib/dpul_collections_web/components/search_bar_component.ex:37
 #: lib/dpul_collections_web/components/search_bar_component.ex:43
 #: lib/dpul_collections_web/components/search_bar_component.ex:118
-#: lib/dpul_collections_web/live/search_live.ex:455
+#: lib/dpul_collections_web/live/search_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Buscar"
@@ -56,12 +56,12 @@ msgstr "cerrar"
 msgid "Language"
 msgstr "Idioma"
 
-#: lib/dpul_collections_web/live/search_live.ex:776
+#: lib/dpul_collections_web/live/search_live.ex:804
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Proxima"
 
-#: lib/dpul_collections_web/live/search_live.ex:746
+#: lib/dpul_collections_web/live/search_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Anterior"
@@ -72,14 +72,14 @@ msgstr "Anterior"
 msgid "sort by"
 msgstr "Ordenar por"
 
-#: lib/dpul_collections_web/live/search_live.ex:423
-#: lib/dpul_collections_web/live/search_live.ex:424
+#: lib/dpul_collections_web/live/search_live.ex:451
+#: lib/dpul_collections_web/live/search_live.ex:452
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr "De"
 
-#: lib/dpul_collections_web/live/search_live.ex:428
-#: lib/dpul_collections_web/live/search_live.ex:429
+#: lib/dpul_collections_web/live/search_live.ex:456
+#: lib/dpul_collections_web/live/search_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr "A"
@@ -160,7 +160,7 @@ msgstr "Colecciones Digitales"
 msgid "The Trustees of Princeton University"
 msgstr "Los fideicomisarios de la Universidad de Princeton"
 
-#: lib/dpul_collections_web/live/search_live.ex:612
+#: lib/dpul_collections_web/live/search_live.ex:640
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Añadido"
@@ -540,7 +540,7 @@ msgstr "Ver elementos aleatorios"
 msgid "main image display"
 msgstr "visualización de la imagen principal"
 
-#: lib/dpul_collections_web/live/search_live.ex:736
+#: lib/dpul_collections_web/live/search_live.ex:764
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr "Resultados de la búsqueda por"
@@ -612,7 +612,7 @@ msgid "Categories"
 msgstr "Categorías"
 
 #: lib/dpul_collections_web/components/browse_item.ex:219
-#: lib/dpul_collections_web/live/search_live.ex:653
+#: lib/dpul_collections_web/live/search_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Fecha"
@@ -633,8 +633,8 @@ msgstr "Destacado"
 
 #: lib/dpul_collections_web/components/browse_item.ex:170
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:637
-#: lib/dpul_collections_web/live/search_live.ex:707
+#: lib/dpul_collections_web/live/search_live.ex:665
+#: lib/dpul_collections_web/live/search_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr "Archivos"
@@ -693,7 +693,7 @@ msgid "My Sets"
 msgstr "Mis Conjuntos"
 
 #: lib/dpul_collections_web/components/browse_item.ex:226
-#: lib/dpul_collections_web/live/search_live.ex:660
+#: lib/dpul_collections_web/live/search_live.ex:688
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr "Origen"
@@ -720,8 +720,8 @@ msgstr "Pósteres"
 msgid "Save"
 msgstr "Guardar"
 
-#: lib/dpul_collections_web/live/search_live.ex:671
-#: lib/dpul_collections_web/live/search_live.ex:677
+#: lib/dpul_collections_web/live/search_live.ex:699
+#: lib/dpul_collections_web/live/search_live.ex:705
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr "Resultados de la búsqueda"
@@ -1051,8 +1051,8 @@ msgid "contact Princeton University Library"
 msgstr "contactar a la Biblioteca de la Universidad de Princeton"
 
 #: lib/dpul_collections_web/live/item_live.ex:152
-#: lib/dpul_collections_web/live/search_live.ex:534
-#: lib/dpul_collections_web/live/search_live.ex:604
+#: lib/dpul_collections_web/live/search_live.ex:562
+#: lib/dpul_collections_web/live/search_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr "formato"
@@ -1067,7 +1067,7 @@ msgstr "lenguaje problemático"
 msgid "Active Filters"
 msgstr "Filtros Activos"
 
-#: lib/dpul_collections_web/live/search_live.ex:434
+#: lib/dpul_collections_web/live/search_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Apply Year Range"
 msgstr "Aplicar Rango de Años"
@@ -1174,7 +1174,7 @@ msgstr "Resultados"
 msgid "Scribe"
 msgstr "Escriba"
 
-#: lib/dpul_collections_web/live/search_live.ex:461
+#: lib/dpul_collections_web/live/search_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Search filters..."
 msgstr "Filtros de búsqueda..."
@@ -1189,7 +1189,7 @@ msgstr "Adquisición de Fuente"
 msgid "View"
 msgstr "Abrir"
 
-#: lib/dpul_collections_web/live/search_live.ex:455
+#: lib/dpul_collections_web/live/search_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "filters"
 msgstr "Filtros"
@@ -1272,11 +1272,6 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/dpul_collections_web/components/footer_component.ex:32
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Princeton University Logo"
-msgstr "Biblioteca de la Universidad de Princeton"
-
 #: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:111
 #, elixir-autogen, elixir-format
 msgid "Set description"
@@ -1300,4 +1295,19 @@ msgstr ""
 #: lib/dpul_collections_web/live/collections_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "more"
+msgstr ""
+
+#: lib/dpul_collections_web/live/search_live.ex:864
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Collection not found"
+msgstr "Coleccion"
+
+#: lib/dpul_collections_web/components/footer_component.ex:32
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Princeton University"
+msgstr "Biblioteca de la Universidad de Princeton"
+
+#: lib/dpul_collections_web/live/search_live.ex:429
+#, elixir-autogen, elixir-format
+msgid "Remove %{label}: %{value} filter"
 msgstr ""

--- a/priv/gettext/pt/LC_MESSAGES/default.po
+++ b/priv/gettext/pt/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr "Aguarde enquanto voltamos ao normal"
 #: lib/dpul_collections_web/components/search_bar_component.ex:37
 #: lib/dpul_collections_web/components/search_bar_component.ex:43
 #: lib/dpul_collections_web/components/search_bar_component.ex:118
-#: lib/dpul_collections_web/live/search_live.ex:455
+#: lib/dpul_collections_web/live/search_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Pesquisar"
@@ -56,12 +56,12 @@ msgstr "fechar"
 msgid "Language"
 msgstr "Idioma"
 
-#: lib/dpul_collections_web/live/search_live.ex:776
+#: lib/dpul_collections_web/live/search_live.ex:804
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Próxima"
 
-#: lib/dpul_collections_web/live/search_live.ex:746
+#: lib/dpul_collections_web/live/search_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Anterior"
@@ -72,14 +72,14 @@ msgstr "Anterior"
 msgid "sort by"
 msgstr "ordenar por"
 
-#: lib/dpul_collections_web/live/search_live.ex:423
-#: lib/dpul_collections_web/live/search_live.ex:424
+#: lib/dpul_collections_web/live/search_live.ex:451
+#: lib/dpul_collections_web/live/search_live.ex:452
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr "De"
 
-#: lib/dpul_collections_web/live/search_live.ex:428
-#: lib/dpul_collections_web/live/search_live.ex:429
+#: lib/dpul_collections_web/live/search_live.ex:456
+#: lib/dpul_collections_web/live/search_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr "Até"
@@ -160,7 +160,7 @@ msgstr "Coleções Digitais"
 msgid "The Trustees of Princeton University"
 msgstr "Os Curadores da Universidade de Princeton"
 
-#: lib/dpul_collections_web/live/search_live.ex:612
+#: lib/dpul_collections_web/live/search_live.ex:640
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Adicionado"
@@ -540,7 +540,7 @@ msgstr "Ver Itens Aleatórios"
 msgid "main image display"
 msgstr "exibição da imagem principal"
 
-#: lib/dpul_collections_web/live/search_live.ex:736
+#: lib/dpul_collections_web/live/search_live.ex:764
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr "Navegação da Página de Resultados da Pesquisa"
@@ -612,7 +612,7 @@ msgid "Categories"
 msgstr "Categorias"
 
 #: lib/dpul_collections_web/components/browse_item.ex:219
-#: lib/dpul_collections_web/live/search_live.ex:653
+#: lib/dpul_collections_web/live/search_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Data"
@@ -633,8 +633,8 @@ msgstr "Destaques"
 
 #: lib/dpul_collections_web/components/browse_item.ex:170
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:637
-#: lib/dpul_collections_web/live/search_live.ex:707
+#: lib/dpul_collections_web/live/search_live.ex:665
+#: lib/dpul_collections_web/live/search_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr "Arquivos"
@@ -693,7 +693,7 @@ msgid "My Sets"
 msgstr "Meus Conjuntos"
 
 #: lib/dpul_collections_web/components/browse_item.ex:226
-#: lib/dpul_collections_web/live/search_live.ex:660
+#: lib/dpul_collections_web/live/search_live.ex:688
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr "Origem"
@@ -720,8 +720,8 @@ msgstr "Pôsteres"
 msgid "Save"
 msgstr "Salvar"
 
-#: lib/dpul_collections_web/live/search_live.ex:671
-#: lib/dpul_collections_web/live/search_live.ex:677
+#: lib/dpul_collections_web/live/search_live.ex:699
+#: lib/dpul_collections_web/live/search_live.ex:705
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr "Resultados da Pesquisa"
@@ -1051,8 +1051,8 @@ msgid "contact Princeton University Library"
 msgstr "entrar em contato com a Biblioteca da Universidade de Princeton"
 
 #: lib/dpul_collections_web/live/item_live.ex:152
-#: lib/dpul_collections_web/live/search_live.ex:534
-#: lib/dpul_collections_web/live/search_live.ex:604
+#: lib/dpul_collections_web/live/search_live.ex:562
+#: lib/dpul_collections_web/live/search_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr "formato"
@@ -1067,7 +1067,7 @@ msgstr "linguagem problemática"
 msgid "Active Filters"
 msgstr "Filtros Ativos"
 
-#: lib/dpul_collections_web/live/search_live.ex:434
+#: lib/dpul_collections_web/live/search_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Apply Year Range"
 msgstr "Aplicar Faixa Anual"
@@ -1174,7 +1174,7 @@ msgstr "Resultados"
 msgid "Scribe"
 msgstr "Escriba"
 
-#: lib/dpul_collections_web/live/search_live.ex:461
+#: lib/dpul_collections_web/live/search_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Search filters..."
 msgstr "Filtros de pesquisa..."
@@ -1189,7 +1189,7 @@ msgstr "Aquisição de Fonte"
 msgid "View"
 msgstr "Visualizador"
 
-#: lib/dpul_collections_web/live/search_live.ex:455
+#: lib/dpul_collections_web/live/search_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "filters"
 msgstr "Filtros"
@@ -1272,11 +1272,6 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/dpul_collections_web/components/footer_component.ex:32
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Princeton University Logo"
-msgstr "Biblioteca da Universidade de Princeton"
-
 #: lib/dpul_collections_web/live/user_sets/add_to_set_component.ex:111
 #, elixir-autogen, elixir-format
 msgid "Set description"
@@ -1300,4 +1295,19 @@ msgstr ""
 #: lib/dpul_collections_web/live/collections_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "more"
+msgstr ""
+
+#: lib/dpul_collections_web/live/search_live.ex:864
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Collection not found"
+msgstr "Coleção"
+
+#: lib/dpul_collections_web/components/footer_component.ex:32
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Princeton University"
+msgstr "Biblioteca da Universidade de Princeton"
+
+#: lib/dpul_collections_web/live/search_live.ex:429
+#, elixir-autogen, elixir-format
+msgid "Remove %{label}: %{value} filter"
 msgstr ""

--- a/test/dpul_collections/collection_test.exs
+++ b/test/dpul_collections/collection_test.exs
@@ -38,6 +38,30 @@ defmodule DpulCollections.CollectionTest do
     end
   end
 
+  describe ".authoritative_slug_from_title/1" do
+    test "returns the authoritative slug when a collection with the given title is indexed" do
+      Solr.add(
+        [
+          %{
+            id: "d7c889ba-9992-494e-8fe4-2c4a9b3c3d7d",
+            title_txtm: ["Latin American Ephemera"],
+            resource_type_s: "collection",
+            authoritative_slug_s: "lae"
+          }
+        ],
+        SolrTestSupport.active_collection()
+      )
+
+      Solr.soft_commit()
+
+      assert Collection.authoritative_slug_from_title("Latin American Ephemera") == "lae"
+    end
+
+    test "returns nil when no collection matches the title" do
+      assert Collection.authoritative_slug_from_title("Unindexed Collection") == nil
+    end
+  end
+
   describe ".get_contributors/1" do
     test "returns 3 contributors for lae" do
       assert length(Collection.get_contributors("lae")) == 3

--- a/test/dpul_collections_web/features/collection_test.exs
+++ b/test/dpul_collections_web/features/collection_test.exs
@@ -97,8 +97,8 @@ defmodule DpulCollectionsWeb.Features.CollectionViewTest do
       |> assert_has(".phx-connected")
       |> click_link("Politics and government")
       |> assert_has("h1", text: "Search Results")
-      |> assert_has("button.category", text: "Politics and government")
-      |> assert_has("button.collection", text: "South Asian Ephemera")
+      |> assert_has(".filter.category", text: "Politics and government")
+      |> assert_has(".filter.collection", text: "South Asian Ephemera")
     end
 
     test "a collection without contributors still displays copyright policy", %{conn: conn} do

--- a/test/dpul_collections_web/features/search_test.exs
+++ b/test/dpul_collections_web/features/search_test.exs
@@ -38,7 +38,7 @@ defmodule DpulCollectionsWeb.Features.SearchTest do
     |> refute_has("#filter-modal")
     |> click_button("Filters")
     |> click_button("View 5 results")
-    |> assert_has("button.format.filter")
+    |> assert_has(".filter.format")
 
     :timer.sleep(1000)
   end
@@ -147,6 +147,65 @@ defmodule DpulCollectionsWeb.Features.SearchTest do
     |> assert_has("#item-1", text: "Document-1")
     # when visible images equals filecount don't show image total
     |> assert_has("#filecount-1", text: "8 Files")
+  end
+
+  describe "filter pill" do
+    test "clicking the dismiss section removes the filter; clicking the body does not",
+         %{conn: conn} do
+      Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
+      Solr.soft_commit(active_collection())
+
+      conn
+      |> visit("/search?filter[format][]=Pamphlets")
+      |> assert_has(".phx-connected")
+      |> assert_has(".filter.format", text: "Pamphlets")
+      # Click the body
+      |> Playwright.click("#search-filters .filter.format .filter-body")
+      |> assert_has(".filter.format", text: "Pamphlets")
+      # Click the dismiss section
+      |> Playwright.click("#search-filters .filter.format .filter-dismiss")
+      |> refute_has(".filter.format")
+    end
+
+    test "clicking a collection filter pill body navigates to the collection page",
+         %{conn: conn} do
+      items =
+        SolrTestSupport.mock_solr_documents(2)
+        |> Enum.map(&Map.put(&1, :collection_titles_ss, ["Amazing Project"]))
+
+      Solr.add(
+        [
+          %{
+            id: "d7c889ba-9992-494e-8fe4-2c4a9b3c3d7d",
+            title_txtm: ["Latin American Ephemera"],
+            resource_type_s: "collection",
+            authoritative_slug_s: "lae"
+          }
+          | items
+        ],
+        active_collection()
+      )
+
+      Solr.soft_commit(active_collection())
+
+      conn
+      |> visit("/search?filter[collection][]=Latin+American+Ephemera")
+      |> assert_has(".phx-connected")
+      |> Playwright.click("#search-filters .collection.filter .filter-body")
+      |> assert_path("/collections/lae")
+    end
+
+    test "clicking a collection filter pill when the collection doesn't exist flashes an error",
+         %{conn: conn} do
+      Solr.add(SolrTestSupport.mock_solr_documents(2), active_collection())
+      Solr.soft_commit(active_collection())
+
+      conn
+      |> visit("/search?filter[collection][]=Unindexed+Collection")
+      |> assert_has(".phx-connected")
+      |> Playwright.click("#search-filters .collection.filter .filter-body")
+      |> assert_has("#flash-error", text: "Collection not found")
+    end
   end
 
   test "filters are retained when adding a keyword", %{conn: conn} do

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -249,7 +249,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
 
     # Removing one pill doesn't remove the other
     view
-    |> element("#search-filters .filter", "Pamphlets")
+    |> element("#search-filters .filter-dismiss[phx-value-filter-value='Pamphlets']")
     |> render_click()
 
     assert view
@@ -413,7 +413,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
     |> render_click()
 
     view
-    |> element("#search-filters .filter", "Folders")
+    |> element("#search-filters .filter-dismiss[phx-value-filter-value='Folders']")
     |> render_click()
 
     assert view
@@ -608,7 +608,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
 
     # The filter can be removed.
     view
-    |> element("#search-filters .filter", "Similar")
+    |> element("#search-filters .similar.filter .filter-dismiss")
     |> render_click()
 
     refute has_element?(view, ".filter.similar")


### PR DESCRIPTION
Closes #1158
Closes #1057

- **Make collection filter pills clickable**
- **Only underline the filter pill collection name**

<img width="659" height="209" alt="image" src="https://github.com/user-attachments/assets/3c5213e5-4841-4e21-89f6-6bc4621629a8" />

