### PR TITLE
Add languages to collection description

### DIFF
--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -238,6 +238,16 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                 button_class="bg-cloud/80 hover:bg-cloud/60"
                 collection_title={@collection.title |> hd}
               />
+
+              <.pill_section
+                title={gettext("Languages")}
+                unit="language"
+                items={@collection.languages}
+                container_id="languages-container"
+                pill_class="btn-primary-bright-colors"
+                button_class="bg-primary-bright/80 hover:bg-primary-bright/60"
+                collection_title={@collection.title |> hd}
+              />
             </div>
           </div>
         </div>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -24,7 +24,7 @@ msgstr ""
 #: lib/dpul_collections_web/components/search_bar_component.ex:37
 #: lib/dpul_collections_web/components/search_bar_component.ex:43
 #: lib/dpul_collections_web/components/search_bar_component.ex:118
-#: lib/dpul_collections_web/live/search_live.ex:483
+#: lib/dpul_collections_web/live/search_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
@@ -56,12 +56,12 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:804
+#: lib/dpul_collections_web/live/search_live.ex:824
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:774
+#: lib/dpul_collections_web/live/search_live.ex:794
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
@@ -72,14 +72,14 @@ msgstr ""
 msgid "sort by"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:451
-#: lib/dpul_collections_web/live/search_live.ex:452
+#: lib/dpul_collections_web/live/search_live.ex:461
+#: lib/dpul_collections_web/live/search_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:456
-#: lib/dpul_collections_web/live/search_live.ex:457
+#: lib/dpul_collections_web/live/search_live.ex:466
+#: lib/dpul_collections_web/live/search_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr ""
@@ -160,7 +160,7 @@ msgstr ""
 msgid "The Trustees of Princeton University"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:640
+#: lib/dpul_collections_web/live/search_live.ex:660
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "Recently Added"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:251
+#: lib/dpul_collections_web/live/collections_live.ex:261
 #: lib/dpul_collections_web/live/home_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Recently Added Items"
@@ -540,7 +540,7 @@ msgstr ""
 msgid "main image display"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:764
+#: lib/dpul_collections_web/live/search_live.ex:784
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr ""
@@ -612,7 +612,7 @@ msgid "Categories"
 msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:219
-#: lib/dpul_collections_web/live/search_live.ex:681
+#: lib/dpul_collections_web/live/search_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
@@ -633,8 +633,8 @@ msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:170
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:665
-#: lib/dpul_collections_web/live/search_live.ex:735
+#: lib/dpul_collections_web/live/search_live.ex:685
+#: lib/dpul_collections_web/live/search_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr ""
@@ -693,7 +693,7 @@ msgid "My Sets"
 msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:226
-#: lib/dpul_collections_web/live/search_live.ex:688
+#: lib/dpul_collections_web/live/search_live.ex:708
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr ""
@@ -720,8 +720,8 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:699
-#: lib/dpul_collections_web/live/search_live.ex:705
+#: lib/dpul_collections_web/live/search_live.ex:719
+#: lib/dpul_collections_web/live/search_live.ex:725
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr ""
@@ -930,7 +930,7 @@ msgstr ""
 msgid "We sent an email to %{email}."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:319
+#: lib/dpul_collections_web/live/collections_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Copyright"
 msgstr ""
@@ -945,7 +945,7 @@ msgstr ""
 msgid "Digital Collection"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:262
+#: lib/dpul_collections_web/live/collections_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Explore the latest additions to our growing collection for"
 msgstr ""
@@ -976,11 +976,12 @@ msgid "Items"
 msgstr ""
 
 #: lib/dpul_collections_web/live/collections_live.ex:153
+#: lib/dpul_collections_web/live/collections_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:345
+#: lib/dpul_collections_web/live/collections_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Library of Congress Romanization tables"
 msgstr ""
@@ -990,7 +991,7 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:342
+#: lib/dpul_collections_web/live/collections_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "Please refer to the %{romanization_link} when searching the collection."
 msgstr ""
@@ -1000,17 +1001,17 @@ msgstr ""
 msgid "Please use this area to report errors, omissions, or %{description_link} that appear in the description of this collection. Corrections may include misspellings, incorrect or missing dates, misidentified individuals, places, or events, mislabeled folders, misfiled papers, etc."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:331
+#: lib/dpul_collections_web/live/collections_live.ex:341
 #, elixir-autogen, elixir-format
 msgid "Preferred Citation"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:323
+#: lib/dpul_collections_web/live/collections_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "Princeton University Library claims no copyright governing this digital resource. It is provided for free, on a non-commercial, open-access basis, for fair-use academic and research purposes only. Anyone who claims copyright over any part of these resources and feels that they should not be presented in this manner is invited to %{contact_link}, who will in turn consider such concerns and make reasonable efforts to respond to such concerns."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:338
+#: lib/dpul_collections_web/live/collections_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Romanization"
 msgstr ""
@@ -1045,14 +1046,14 @@ msgstr ""
 msgid "Thank you for your suggestion. We will reach out to you if we have any questions. Our staff will review your suggestion and assess the practicality of its implementation, as well as its conformance to national and international description standards and current best practices in the field. You may not hear back from us, but, rest assured, we assess each suggestion we receive carefully before determining if and how to implement it."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:326
+#: lib/dpul_collections_web/live/collections_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "contact Princeton University Library"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:152
-#: lib/dpul_collections_web/live/search_live.ex:562
-#: lib/dpul_collections_web/live/search_live.ex:632
+#: lib/dpul_collections_web/live/search_live.ex:572
+#: lib/dpul_collections_web/live/search_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr ""
@@ -1067,7 +1068,7 @@ msgstr ""
 msgid "Active Filters"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:462
+#: lib/dpul_collections_web/live/search_live.ex:472
 #, elixir-autogen, elixir-format
 msgid "Apply Year Range"
 msgstr ""
@@ -1174,7 +1175,7 @@ msgstr ""
 msgid "Scribe"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:489
+#: lib/dpul_collections_web/live/search_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Search filters..."
 msgstr ""
@@ -1189,7 +1190,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:483
+#: lib/dpul_collections_web/live/search_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "filters"
 msgstr ""
@@ -1222,7 +1223,7 @@ msgstr ""
 msgid "Changing..."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:277
+#: lib/dpul_collections_web/live/collections_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Contributors"
 msgstr ""
@@ -1297,7 +1298,7 @@ msgstr ""
 msgid "more"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:864
+#: lib/dpul_collections_web/live/search_live.ex:884
 #, elixir-autogen, elixir-format
 msgid "Collection not found"
 msgstr ""
@@ -1307,7 +1308,7 @@ msgstr ""
 msgid "Princeton University"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:429
+#: lib/dpul_collections_web/live/search_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Remove %{label}: %{value} filter"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr ""
 #: lib/dpul_collections_web/components/search_bar_component.ex:37
 #: lib/dpul_collections_web/components/search_bar_component.ex:43
 #: lib/dpul_collections_web/components/search_bar_component.ex:118
-#: lib/dpul_collections_web/live/search_live.ex:483
+#: lib/dpul_collections_web/live/search_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
@@ -56,12 +56,12 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:804
+#: lib/dpul_collections_web/live/search_live.ex:824
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:774
+#: lib/dpul_collections_web/live/search_live.ex:794
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
@@ -72,14 +72,14 @@ msgstr ""
 msgid "sort by"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:451
-#: lib/dpul_collections_web/live/search_live.ex:452
+#: lib/dpul_collections_web/live/search_live.ex:461
+#: lib/dpul_collections_web/live/search_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:456
-#: lib/dpul_collections_web/live/search_live.ex:457
+#: lib/dpul_collections_web/live/search_live.ex:466
+#: lib/dpul_collections_web/live/search_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr ""
@@ -160,7 +160,7 @@ msgstr ""
 msgid "The Trustees of Princeton University"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:640
+#: lib/dpul_collections_web/live/search_live.ex:660
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "Recently Added"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:251
+#: lib/dpul_collections_web/live/collections_live.ex:261
 #: lib/dpul_collections_web/live/home_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Recently Added Items"
@@ -540,7 +540,7 @@ msgstr ""
 msgid "main image display"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:764
+#: lib/dpul_collections_web/live/search_live.ex:784
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr ""
@@ -612,7 +612,7 @@ msgid "Categories"
 msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:219
-#: lib/dpul_collections_web/live/search_live.ex:681
+#: lib/dpul_collections_web/live/search_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
@@ -633,8 +633,8 @@ msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:170
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:665
-#: lib/dpul_collections_web/live/search_live.ex:735
+#: lib/dpul_collections_web/live/search_live.ex:685
+#: lib/dpul_collections_web/live/search_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr ""
@@ -693,7 +693,7 @@ msgid "My Sets"
 msgstr ""
 
 #: lib/dpul_collections_web/components/browse_item.ex:226
-#: lib/dpul_collections_web/live/search_live.ex:688
+#: lib/dpul_collections_web/live/search_live.ex:708
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr ""
@@ -720,8 +720,8 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:699
-#: lib/dpul_collections_web/live/search_live.ex:705
+#: lib/dpul_collections_web/live/search_live.ex:719
+#: lib/dpul_collections_web/live/search_live.ex:725
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr ""
@@ -930,7 +930,7 @@ msgstr ""
 msgid "We sent an email to %{email}."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:319
+#: lib/dpul_collections_web/live/collections_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Copyright"
 msgstr ""
@@ -945,7 +945,7 @@ msgstr ""
 msgid "Digital Collection"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:262
+#: lib/dpul_collections_web/live/collections_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Explore the latest additions to our growing collection for"
 msgstr ""
@@ -976,11 +976,12 @@ msgid "Items"
 msgstr ""
 
 #: lib/dpul_collections_web/live/collections_live.ex:153
+#: lib/dpul_collections_web/live/collections_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:345
+#: lib/dpul_collections_web/live/collections_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Library of Congress Romanization tables"
 msgstr ""
@@ -990,7 +991,7 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:342
+#: lib/dpul_collections_web/live/collections_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "Please refer to the %{romanization_link} when searching the collection."
 msgstr ""
@@ -1000,17 +1001,17 @@ msgstr ""
 msgid "Please use this area to report errors, omissions, or %{description_link} that appear in the description of this collection. Corrections may include misspellings, incorrect or missing dates, misidentified individuals, places, or events, mislabeled folders, misfiled papers, etc."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:331
+#: lib/dpul_collections_web/live/collections_live.ex:341
 #, elixir-autogen, elixir-format
 msgid "Preferred Citation"
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:323
+#: lib/dpul_collections_web/live/collections_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "Princeton University Library claims no copyright governing this digital resource. It is provided for free, on a non-commercial, open-access basis, for fair-use academic and research purposes only. Anyone who claims copyright over any part of these resources and feels that they should not be presented in this manner is invited to %{contact_link}, who will in turn consider such concerns and make reasonable efforts to respond to such concerns."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:338
+#: lib/dpul_collections_web/live/collections_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Romanization"
 msgstr ""
@@ -1045,14 +1046,14 @@ msgstr ""
 msgid "Thank you for your suggestion. We will reach out to you if we have any questions. Our staff will review your suggestion and assess the practicality of its implementation, as well as its conformance to national and international description standards and current best practices in the field. You may not hear back from us, but, rest assured, we assess each suggestion we receive carefully before determining if and how to implement it."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:326
+#: lib/dpul_collections_web/live/collections_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "contact Princeton University Library"
 msgstr ""
 
 #: lib/dpul_collections_web/live/item_live.ex:152
-#: lib/dpul_collections_web/live/search_live.ex:562
-#: lib/dpul_collections_web/live/search_live.ex:632
+#: lib/dpul_collections_web/live/search_live.ex:572
+#: lib/dpul_collections_web/live/search_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr ""
@@ -1067,7 +1068,7 @@ msgstr ""
 msgid "Active Filters"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:462
+#: lib/dpul_collections_web/live/search_live.ex:472
 #, elixir-autogen, elixir-format
 msgid "Apply Year Range"
 msgstr ""
@@ -1174,7 +1175,7 @@ msgstr ""
 msgid "Scribe"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:489
+#: lib/dpul_collections_web/live/search_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Search filters..."
 msgstr ""
@@ -1189,7 +1190,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:483
+#: lib/dpul_collections_web/live/search_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "filters"
 msgstr ""
@@ -1222,7 +1223,7 @@ msgstr ""
 msgid "Changing..."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:277
+#: lib/dpul_collections_web/live/collections_live.ex:287
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contributors"
 msgstr ""
@@ -1297,7 +1298,7 @@ msgstr ""
 msgid "more"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:864
+#: lib/dpul_collections_web/live/search_live.ex:884
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Collection not found"
 msgstr ""
@@ -1307,7 +1308,7 @@ msgstr ""
 msgid "Princeton University"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:429
+#: lib/dpul_collections_web/live/search_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Remove %{label}: %{value} filter"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr "Aguanta mientras volvemos al buen camino"
 #: lib/dpul_collections_web/components/search_bar_component.ex:37
 #: lib/dpul_collections_web/components/search_bar_component.ex:43
 #: lib/dpul_collections_web/components/search_bar_component.ex:118
-#: lib/dpul_collections_web/live/search_live.ex:483
+#: lib/dpul_collections_web/live/search_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Buscar"
@@ -56,12 +56,12 @@ msgstr "cerrar"
 msgid "Language"
 msgstr "Idioma"
 
-#: lib/dpul_collections_web/live/search_live.ex:804
+#: lib/dpul_collections_web/live/search_live.ex:824
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Proxima"
 
-#: lib/dpul_collections_web/live/search_live.ex:774
+#: lib/dpul_collections_web/live/search_live.ex:794
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Anterior"
@@ -72,14 +72,14 @@ msgstr "Anterior"
 msgid "sort by"
 msgstr "Ordenar por"
 
-#: lib/dpul_collections_web/live/search_live.ex:451
-#: lib/dpul_collections_web/live/search_live.ex:452
+#: lib/dpul_collections_web/live/search_live.ex:461
+#: lib/dpul_collections_web/live/search_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr "De"
 
-#: lib/dpul_collections_web/live/search_live.ex:456
-#: lib/dpul_collections_web/live/search_live.ex:457
+#: lib/dpul_collections_web/live/search_live.ex:466
+#: lib/dpul_collections_web/live/search_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr "A"
@@ -160,7 +160,7 @@ msgstr "Colecciones Digitales"
 msgid "The Trustees of Princeton University"
 msgstr "Los fideicomisarios de la Universidad de Princeton"
 
-#: lib/dpul_collections_web/live/search_live.ex:640
+#: lib/dpul_collections_web/live/search_live.ex:660
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Añadido"
@@ -474,7 +474,7 @@ msgstr "Descargar PDF"
 msgid "Recently Added"
 msgstr "Actualizado recientemente"
 
-#: lib/dpul_collections_web/live/collections_live.ex:251
+#: lib/dpul_collections_web/live/collections_live.ex:261
 #: lib/dpul_collections_web/live/home_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Recently Added Items"
@@ -540,7 +540,7 @@ msgstr "Ver elementos aleatorios"
 msgid "main image display"
 msgstr "visualización de la imagen principal"
 
-#: lib/dpul_collections_web/live/search_live.ex:764
+#: lib/dpul_collections_web/live/search_live.ex:784
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr "Resultados de la búsqueda por"
@@ -612,7 +612,7 @@ msgid "Categories"
 msgstr "Categorías"
 
 #: lib/dpul_collections_web/components/browse_item.ex:219
-#: lib/dpul_collections_web/live/search_live.ex:681
+#: lib/dpul_collections_web/live/search_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Fecha"
@@ -633,8 +633,8 @@ msgstr "Destacado"
 
 #: lib/dpul_collections_web/components/browse_item.ex:170
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:665
-#: lib/dpul_collections_web/live/search_live.ex:735
+#: lib/dpul_collections_web/live/search_live.ex:685
+#: lib/dpul_collections_web/live/search_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr "Archivos"
@@ -693,7 +693,7 @@ msgid "My Sets"
 msgstr "Mis Conjuntos"
 
 #: lib/dpul_collections_web/components/browse_item.ex:226
-#: lib/dpul_collections_web/live/search_live.ex:688
+#: lib/dpul_collections_web/live/search_live.ex:708
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr "Origen"
@@ -720,8 +720,8 @@ msgstr "Pósteres"
 msgid "Save"
 msgstr "Guardar"
 
-#: lib/dpul_collections_web/live/search_live.ex:699
-#: lib/dpul_collections_web/live/search_live.ex:705
+#: lib/dpul_collections_web/live/search_live.ex:719
+#: lib/dpul_collections_web/live/search_live.ex:725
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr "Resultados de la búsqueda"
@@ -930,7 +930,7 @@ msgstr "Le enviamos un código por correo electrónico"
 msgid "We sent an email to %{email}."
 msgstr "Enviamos un correo electrónico a %{email}."
 
-#: lib/dpul_collections_web/live/collections_live.ex:319
+#: lib/dpul_collections_web/live/collections_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Copyright"
 msgstr "Política de derechos de autor"
@@ -945,7 +945,7 @@ msgstr "Corregir"
 msgid "Digital Collection"
 msgstr "Colecciones Digitales"
 
-#: lib/dpul_collections_web/live/collections_live.ex:262
+#: lib/dpul_collections_web/live/collections_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Explore the latest additions to our growing collection for"
 msgstr "Explore las últimas incorporaciones a nuestra creciente colección de"
@@ -976,11 +976,12 @@ msgid "Items"
 msgstr "Artículos"
 
 #: lib/dpul_collections_web/live/collections_live.ex:153
+#: lib/dpul_collections_web/live/collections_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Idioma"
 
-#: lib/dpul_collections_web/live/collections_live.ex:345
+#: lib/dpul_collections_web/live/collections_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Library of Congress Romanization tables"
 msgstr "tablas de romanización de la Biblioteca del Congreso"
@@ -990,7 +991,7 @@ msgstr "tablas de romanización de la Biblioteca del Congreso"
 msgid "Locations"
 msgstr "Ubicaciones"
 
-#: lib/dpul_collections_web/live/collections_live.ex:342
+#: lib/dpul_collections_web/live/collections_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "Please refer to the %{romanization_link} when searching the collection."
 msgstr "Por favor consulte las %{romanization_link} al buscar en la colección."
@@ -1000,17 +1001,17 @@ msgstr "Por favor consulte las %{romanization_link} al buscar en la colección."
 msgid "Please use this area to report errors, omissions, or %{description_link} that appear in the description of this collection. Corrections may include misspellings, incorrect or missing dates, misidentified individuals, places, or events, mislabeled folders, misfiled papers, etc."
 msgstr "Utilice esta área para informar errores, omisiones o %{description_link} que aparezcan en la descripción de esta colección. Las correcciones pueden incluir errores ortográficos, fechas incorrectas o faltantes, personas, lugares o eventos mal identificados, carpetas mal etiquetadas, documentos mal archivados, etc."
 
-#: lib/dpul_collections_web/live/collections_live.ex:331
+#: lib/dpul_collections_web/live/collections_live.ex:341
 #, elixir-autogen, elixir-format
 msgid "Preferred Citation"
 msgstr "Cita preferida"
 
-#: lib/dpul_collections_web/live/collections_live.ex:323
+#: lib/dpul_collections_web/live/collections_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "Princeton University Library claims no copyright governing this digital resource. It is provided for free, on a non-commercial, open-access basis, for fair-use academic and research purposes only. Anyone who claims copyright over any part of these resources and feels that they should not be presented in this manner is invited to %{contact_link}, who will in turn consider such concerns and make reasonable efforts to respond to such concerns."
 msgstr "La Biblioteca de la Universidad de Princeton no reclama derechos de autor sobre este recurso digital. Se proporciona de forma gratuita, sin fines comerciales y de acceso abierto, únicamente para fines académicos y de investigación de uso justo. Cualquier persona que reclame derechos de autor sobre cualquier parte de estos recursos y considere que no deberían presentarse de esta manera está invitada a %{contact_link}, quienes a su vez considerarán dichas inquietudes y harán esfuerzos razonables para responder a las mismas."
 
-#: lib/dpul_collections_web/live/collections_live.ex:338
+#: lib/dpul_collections_web/live/collections_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Romanization"
 msgstr "Romanización"
@@ -1045,14 +1046,14 @@ msgstr "Sugerir una corrección"
 msgid "Thank you for your suggestion. We will reach out to you if we have any questions. Our staff will review your suggestion and assess the practicality of its implementation, as well as its conformance to national and international description standards and current best practices in the field. You may not hear back from us, but, rest assured, we assess each suggestion we receive carefully before determining if and how to implement it."
 msgstr "Gracias por su sugerencia. Nos comunicaremos con usted si tenemos alguna pregunta. Nuestro personal revisará su sugerencia y evaluará la viabilidad de su implementación, así como su conformidad con los estándares de descripción nacionales e internacionales y las mejores prácticas actuales en el campo. Es posible que no reciba respuesta de nuestra parte, pero tenga la seguridad de que evaluamos cuidadosamente cada sugerencia que recibimos antes de determinar si implementarla y cómo hacerlo."
 
-#: lib/dpul_collections_web/live/collections_live.ex:326
+#: lib/dpul_collections_web/live/collections_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "contact Princeton University Library"
 msgstr "contactar a la Biblioteca de la Universidad de Princeton"
 
 #: lib/dpul_collections_web/live/item_live.ex:152
-#: lib/dpul_collections_web/live/search_live.ex:562
-#: lib/dpul_collections_web/live/search_live.ex:632
+#: lib/dpul_collections_web/live/search_live.ex:572
+#: lib/dpul_collections_web/live/search_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr "formato"
@@ -1067,7 +1068,7 @@ msgstr "lenguaje problemático"
 msgid "Active Filters"
 msgstr "Filtros Activos"
 
-#: lib/dpul_collections_web/live/search_live.ex:462
+#: lib/dpul_collections_web/live/search_live.ex:472
 #, elixir-autogen, elixir-format
 msgid "Apply Year Range"
 msgstr "Aplicar Rango de Años"
@@ -1174,7 +1175,7 @@ msgstr "Resultados"
 msgid "Scribe"
 msgstr "Escriba"
 
-#: lib/dpul_collections_web/live/search_live.ex:489
+#: lib/dpul_collections_web/live/search_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Search filters..."
 msgstr "Filtros de búsqueda..."
@@ -1189,7 +1190,7 @@ msgstr "Adquisición de Fuente"
 msgid "View"
 msgstr "Abrir"
 
-#: lib/dpul_collections_web/live/search_live.ex:483
+#: lib/dpul_collections_web/live/search_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "filters"
 msgstr "Filtros"
@@ -1222,7 +1223,7 @@ msgstr ""
 msgid "Changing..."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:277
+#: lib/dpul_collections_web/live/collections_live.ex:287
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contributors"
 msgstr "Colaborador"
@@ -1297,7 +1298,7 @@ msgstr ""
 msgid "more"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:864
+#: lib/dpul_collections_web/live/search_live.ex:884
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Collection not found"
 msgstr "Coleccion"
@@ -1307,7 +1308,7 @@ msgstr "Coleccion"
 msgid "Princeton University"
 msgstr "Biblioteca de la Universidad de Princeton"
 
-#: lib/dpul_collections_web/live/search_live.ex:429
+#: lib/dpul_collections_web/live/search_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Remove %{label}: %{value} filter"
 msgstr ""

--- a/priv/gettext/pt/LC_MESSAGES/default.po
+++ b/priv/gettext/pt/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr "Aguarde enquanto voltamos ao normal"
 #: lib/dpul_collections_web/components/search_bar_component.ex:37
 #: lib/dpul_collections_web/components/search_bar_component.ex:43
 #: lib/dpul_collections_web/components/search_bar_component.ex:118
-#: lib/dpul_collections_web/live/search_live.ex:483
+#: lib/dpul_collections_web/live/search_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Pesquisar"
@@ -56,12 +56,12 @@ msgstr "fechar"
 msgid "Language"
 msgstr "Idioma"
 
-#: lib/dpul_collections_web/live/search_live.ex:804
+#: lib/dpul_collections_web/live/search_live.ex:824
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Próxima"
 
-#: lib/dpul_collections_web/live/search_live.ex:774
+#: lib/dpul_collections_web/live/search_live.ex:794
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Anterior"
@@ -72,14 +72,14 @@ msgstr "Anterior"
 msgid "sort by"
 msgstr "ordenar por"
 
-#: lib/dpul_collections_web/live/search_live.ex:451
-#: lib/dpul_collections_web/live/search_live.ex:452
+#: lib/dpul_collections_web/live/search_live.ex:461
+#: lib/dpul_collections_web/live/search_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr "De"
 
-#: lib/dpul_collections_web/live/search_live.ex:456
-#: lib/dpul_collections_web/live/search_live.ex:457
+#: lib/dpul_collections_web/live/search_live.ex:466
+#: lib/dpul_collections_web/live/search_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr "Até"
@@ -160,7 +160,7 @@ msgstr "Coleções Digitais"
 msgid "The Trustees of Princeton University"
 msgstr "Os Curadores da Universidade de Princeton"
 
-#: lib/dpul_collections_web/live/search_live.ex:640
+#: lib/dpul_collections_web/live/search_live.ex:660
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Adicionado"
@@ -474,7 +474,7 @@ msgstr "Baixar PDF"
 msgid "Recently Added"
 msgstr "Adicionado Recentemente"
 
-#: lib/dpul_collections_web/live/collections_live.ex:251
+#: lib/dpul_collections_web/live/collections_live.ex:261
 #: lib/dpul_collections_web/live/home_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Recently Added Items"
@@ -540,7 +540,7 @@ msgstr "Ver Itens Aleatórios"
 msgid "main image display"
 msgstr "exibição da imagem principal"
 
-#: lib/dpul_collections_web/live/search_live.ex:764
+#: lib/dpul_collections_web/live/search_live.ex:784
 #, elixir-autogen, elixir-format
 msgid "Search Results Page Navigation"
 msgstr "Navegação da Página de Resultados da Pesquisa"
@@ -612,7 +612,7 @@ msgid "Categories"
 msgstr "Categorias"
 
 #: lib/dpul_collections_web/components/browse_item.ex:219
-#: lib/dpul_collections_web/live/search_live.ex:681
+#: lib/dpul_collections_web/live/search_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Data"
@@ -633,8 +633,8 @@ msgstr "Destaques"
 
 #: lib/dpul_collections_web/components/browse_item.ex:170
 #: lib/dpul_collections_web/live/item_live.ex:199
-#: lib/dpul_collections_web/live/search_live.ex:665
-#: lib/dpul_collections_web/live/search_live.ex:735
+#: lib/dpul_collections_web/live/search_live.ex:685
+#: lib/dpul_collections_web/live/search_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Files"
 msgstr "Arquivos"
@@ -693,7 +693,7 @@ msgid "My Sets"
 msgstr "Meus Conjuntos"
 
 #: lib/dpul_collections_web/components/browse_item.ex:226
-#: lib/dpul_collections_web/live/search_live.ex:688
+#: lib/dpul_collections_web/live/search_live.ex:708
 #, elixir-autogen, elixir-format
 msgid "Origin"
 msgstr "Origem"
@@ -720,8 +720,8 @@ msgstr "Pôsteres"
 msgid "Save"
 msgstr "Salvar"
 
-#: lib/dpul_collections_web/live/search_live.ex:699
-#: lib/dpul_collections_web/live/search_live.ex:705
+#: lib/dpul_collections_web/live/search_live.ex:719
+#: lib/dpul_collections_web/live/search_live.ex:725
 #, elixir-autogen, elixir-format
 msgid "Search Results"
 msgstr "Resultados da Pesquisa"
@@ -930,7 +930,7 @@ msgstr "Enviamos um código por e-mail"
 msgid "We sent an email to %{email}."
 msgstr "Enviamos um e-mail para %{email}."
 
-#: lib/dpul_collections_web/live/collections_live.ex:319
+#: lib/dpul_collections_web/live/collections_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Copyright"
 msgstr "Política de Direitos Autorais"
@@ -945,7 +945,7 @@ msgstr "Corrigir"
 msgid "Digital Collection"
 msgstr "Coleções Digitais"
 
-#: lib/dpul_collections_web/live/collections_live.ex:262
+#: lib/dpul_collections_web/live/collections_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Explore the latest additions to our growing collection for"
 msgstr "Explore as últimas adições à nossa crescente coleção de"
@@ -976,11 +976,12 @@ msgid "Items"
 msgstr "Itens"
 
 #: lib/dpul_collections_web/live/collections_live.ex:153
+#: lib/dpul_collections_web/live/collections_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Idioma"
 
-#: lib/dpul_collections_web/live/collections_live.ex:345
+#: lib/dpul_collections_web/live/collections_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Library of Congress Romanization tables"
 msgstr "tabelas de romanização da Biblioteca do Congresso"
@@ -990,7 +991,7 @@ msgstr "tabelas de romanização da Biblioteca do Congresso"
 msgid "Locations"
 msgstr "Localizações"
 
-#: lib/dpul_collections_web/live/collections_live.ex:342
+#: lib/dpul_collections_web/live/collections_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "Please refer to the %{romanization_link} when searching the collection."
 msgstr "Por favor consulte as %{romanization_link} ao pesquisar na coleção."
@@ -1000,17 +1001,17 @@ msgstr "Por favor consulte as %{romanization_link} ao pesquisar na coleção."
 msgid "Please use this area to report errors, omissions, or %{description_link} that appear in the description of this collection. Corrections may include misspellings, incorrect or missing dates, misidentified individuals, places, or events, mislabeled folders, misfiled papers, etc."
 msgstr "Utilize esta área para relatar erros, omissões ou %{description_link} que aparecem na descrição desta coleção. As correções podem incluir erros ortográficos, datas incorretas ou ausentes, indivíduos, lugares ou eventos mal identificados, pastas mal rotuladas, documentos arquivados incorretamente, etc."
 
-#: lib/dpul_collections_web/live/collections_live.ex:331
+#: lib/dpul_collections_web/live/collections_live.ex:341
 #, elixir-autogen, elixir-format
 msgid "Preferred Citation"
 msgstr "Citação preferida"
 
-#: lib/dpul_collections_web/live/collections_live.ex:323
+#: lib/dpul_collections_web/live/collections_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "Princeton University Library claims no copyright governing this digital resource. It is provided for free, on a non-commercial, open-access basis, for fair-use academic and research purposes only. Anyone who claims copyright over any part of these resources and feels that they should not be presented in this manner is invited to %{contact_link}, who will in turn consider such concerns and make reasonable efforts to respond to such concerns."
 msgstr "A Biblioteca da Universidade de Princeton não reivindica direitos autorais sobre este recurso digital. Ele é fornecido gratuitamente, em uma base não comercial e de acesso aberto, apenas para fins acadêmicos e de pesquisa de uso justo. Qualquer pessoa que reivindique direitos autorais sobre qualquer parte destes recursos e considere que não deveriam ser apresentados desta maneira está convidada a %{contact_link}, que por sua vez considerarão tais preocupações e farão esforços razoáveis para responder a essas preocupações."
 
-#: lib/dpul_collections_web/live/collections_live.ex:338
+#: lib/dpul_collections_web/live/collections_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Romanization"
 msgstr "Romanização"
@@ -1045,14 +1046,14 @@ msgstr "Sugerir uma correção"
 msgid "Thank you for your suggestion. We will reach out to you if we have any questions. Our staff will review your suggestion and assess the practicality of its implementation, as well as its conformance to national and international description standards and current best practices in the field. You may not hear back from us, but, rest assured, we assess each suggestion we receive carefully before determining if and how to implement it."
 msgstr "Obrigado pela sua sugestão. Entraremos em contato se tivermos alguma dúvida. Nossa equipe analisará sua sugestão e avaliará a viabilidade de sua implementação, bem como sua conformidade com os padrões de descrição nacionais e internacionais e as melhores práticas atuais na área. Você pode não receber uma resposta nossa, mas fique tranquilo, avaliamos cuidadosamente cada sugestão que recebemos antes de determinar se e como implementá-la."
 
-#: lib/dpul_collections_web/live/collections_live.ex:326
+#: lib/dpul_collections_web/live/collections_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "contact Princeton University Library"
 msgstr "entrar em contato com a Biblioteca da Universidade de Princeton"
 
 #: lib/dpul_collections_web/live/item_live.ex:152
-#: lib/dpul_collections_web/live/search_live.ex:562
-#: lib/dpul_collections_web/live/search_live.ex:632
+#: lib/dpul_collections_web/live/search_live.ex:572
+#: lib/dpul_collections_web/live/search_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "format"
 msgstr "formato"
@@ -1067,7 +1068,7 @@ msgstr "linguagem problemática"
 msgid "Active Filters"
 msgstr "Filtros Ativos"
 
-#: lib/dpul_collections_web/live/search_live.ex:462
+#: lib/dpul_collections_web/live/search_live.ex:472
 #, elixir-autogen, elixir-format
 msgid "Apply Year Range"
 msgstr "Aplicar Faixa Anual"
@@ -1174,7 +1175,7 @@ msgstr "Resultados"
 msgid "Scribe"
 msgstr "Escriba"
 
-#: lib/dpul_collections_web/live/search_live.ex:489
+#: lib/dpul_collections_web/live/search_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Search filters..."
 msgstr "Filtros de pesquisa..."
@@ -1189,7 +1190,7 @@ msgstr "Aquisição de Fonte"
 msgid "View"
 msgstr "Visualizador"
 
-#: lib/dpul_collections_web/live/search_live.ex:483
+#: lib/dpul_collections_web/live/search_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "filters"
 msgstr "Filtros"
@@ -1222,7 +1223,7 @@ msgstr ""
 msgid "Changing..."
 msgstr ""
 
-#: lib/dpul_collections_web/live/collections_live.ex:277
+#: lib/dpul_collections_web/live/collections_live.ex:287
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contributors"
 msgstr "Contribuinte"
@@ -1297,7 +1298,7 @@ msgstr ""
 msgid "more"
 msgstr ""
 
-#: lib/dpul_collections_web/live/search_live.ex:864
+#: lib/dpul_collections_web/live/search_live.ex:884
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Collection not found"
 msgstr "Coleção"
@@ -1307,7 +1308,7 @@ msgstr "Coleção"
 msgid "Princeton University"
 msgstr "Biblioteca da Universidade de Princeton"
 
-#: lib/dpul_collections_web/live/search_live.ex:429
+#: lib/dpul_collections_web/live/search_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Remove %{label}: %{value} filter"
 msgstr ""

--- a/test/dpul_collections_web/features/collection_test.exs
+++ b/test/dpul_collections_web/features/collection_test.exs
@@ -80,6 +80,8 @@ defmodule DpulCollectionsWeb.Features.CollectionViewTest do
       |> assert_has("li", text: "Posters")
       # No more link if it's displaying them all
       |> refute_has("li", text: "+0 more")
+      # Languages
+      |> assert_has("li", text: "Hindi")
       # Recently updated more link
       |> assert_has(
         "a[href='/search?filter[collection][]=South+Asian+Ephemera&sort_by=recently_added']"


### PR DESCRIPTION
We have more space now that we're back to a two-column layout, let's try adding languages again.

Closes #985 

<img width="1398" height="594" alt="Screenshot 2026-05-13 at 2 22 36 PM" src="https://github.com/user-attachments/assets/a2860a60-0007-4856-85cb-67183bb15cea" />
<img width="501" height="844" alt="Screenshot 2026-05-13 at 2 22 45 PM" src="https://github.com/user-attachments/assets/83fe3437-bc2e-4927-8b79-4ba1701160f6" />
