### PR TITLE
Display row of small thumbnails in mobile search results

### DIFF
--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -175,13 +175,14 @@ defmodule DpulCollectionsWeb.SearchItem do
     <div class={[
       "search-thumbnail",
       "row-span-2 col-span-1",
-      "bg-search flex justify-center relative"
+      "grid grid-cols-1 auto-rows-auto gap-2",
+      "bg-search flex justify-center relative p-2"
     ]}>
       <img
         class={[
           "h-[350px] w-[350px]",
-          "sm:h-[225px] md:w-[225px]",
-          "bg-search object-contain p-2",
+          "sm:h-[225px] sm:w-[225px]",
+          "bg-search object-contain",
           Helpers.obfuscate_item?(assigns) && "obfuscate",
           "thumbnail-#{@item.id}",
           "place-self-center"
@@ -189,6 +190,16 @@ defmodule DpulCollectionsWeb.SearchItem do
         src={"#{@thumb}/full/!350,350/0/default.jpg"}
         alt=""
       />
+      <div class="small-thumbnails sm:hidden flex flex-row flex-wrap gap-5 max-h-[100px] justify-start overflow-hidden">
+        <.thumbs
+          :for={{thumb, thumb_num} <- thumbnail_service_urls(1, 6, @item)}
+            :if={@item.file_count > 1}
+            thumb={thumb}
+            thumb_num={thumb_num + 1}
+            item={@item}
+            show_images={@show_images}
+            />
+        </div>
       <div
         :if={@item.file_count > 1}
         class="absolute sm:hidden diagonal-rise right-0 bottom-0 bg-sage-100 pr-4 py-2"
@@ -255,7 +266,7 @@ defmodule DpulCollectionsWeb.SearchItem do
     <div class="relative">
       <img
         class={[
-          "h-[125px] w-[125px] md:h-[125px] md:w-[125px] border border-solid border-gray-400",
+          "h-[100px] w-[100px] sm:h-[125px] sm:w-[125px] border border-solid border-gray-400",
           "object-cover",
           Helpers.obfuscate_item?(assigns) && "obfuscate",
           "thumbnail-#{@item.id}"

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -190,7 +190,13 @@ defmodule DpulCollectionsWeb.SearchItem do
         src={"#{@thumb}/full/!350,350/0/default.jpg"}
         alt=""
       />
-      <div class="small-thumbnails sm:hidden flex flex-row flex-wrap gap-5 max-h-[100px] justify-start overflow-hidden">
+      <div
+        class={["small-thumbnails sm:hidden",
+        "grid grid-template-rows-[auto] grid-cols-[repeat(auto-fit,minmax(96px,_1fr))]",
+        "max-h-[100px] overflow-hidden",
+        "gap-2 justify-between"
+        ]}
+      >
         <.thumbs
           :for={{thumb, thumb_num} <- thumbnail_service_urls(1, 6, @item)}
             :if={@item.file_count > 1}
@@ -263,7 +269,7 @@ defmodule DpulCollectionsWeb.SearchItem do
 
   def thumbs(assigns) do
     ~H"""
-    <div class="relative">
+    <div class="relative w-full sm:w-[125px] flex justify-center">
       <img
         class={[
           "h-[100px] w-[100px] sm:h-[125px] sm:w-[125px] border border-solid border-gray-400",

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -180,6 +180,7 @@ defmodule DpulCollectionsWeb.SearchItem do
     ]}>
       <img
         class={[
+          "primary-thumbnail",
           "h-[350px] w-[350px]",
           "sm:h-[225px] sm:w-[225px]",
           "bg-search object-contain",

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -190,22 +190,23 @@ defmodule DpulCollectionsWeb.SearchItem do
         src={"#{@thumb}/full/!350,350/0/default.jpg"}
         alt=""
       />
-      <div
-        class={["small-thumbnails sm:hidden",
-        "grid grid-template-rows-[auto] grid-cols-[repeat(auto-fit,minmax(96px,_1fr))]",
-        "max-h-[100px] overflow-hidden",
-        "gap-2 justify-between"
-        ]}
-      >
+      <div class={[
+        "small-thumbnails sm:hidden",
+        "grid grid-template-rows-[auto]",
+        "grid-cols-[repeat(auto-fill,minmax(80px,1fr))]",
+        "max-h-[80px] overflow-hidden gap-1",
+        @item.file_count > 5 && "justify-evenly",
+        @item.file_count <= 5 && "justify-start"
+      ]}>
         <.thumbs
           :for={{thumb, thumb_num} <- thumbnail_service_urls(1, 6, @item)}
-            :if={@item.file_count > 1}
-            thumb={thumb}
-            thumb_num={thumb_num + 1}
-            item={@item}
-            show_images={@show_images}
-            />
-        </div>
+          :if={@item.file_count > 1}
+          thumb={thumb}
+          thumb_num={thumb_num + 1}
+          item={@item}
+          show_images={@show_images}
+        />
+      </div>
       <div
         :if={@item.file_count > 1}
         class="absolute sm:hidden diagonal-rise right-0 bottom-0 bg-sage-100 pr-4 py-2"
@@ -269,10 +270,10 @@ defmodule DpulCollectionsWeb.SearchItem do
 
   def thumbs(assigns) do
     ~H"""
-    <div class="relative w-full sm:w-[125px] flex justify-center">
+    <div class="relative sm:w-[125px] flex justify-center">
       <img
         class={[
-          "h-[100px] w-[100px] sm:h-[125px] sm:w-[125px] border border-solid border-gray-400",
+          "h-[80px] w-[80px] sm:h-[125px] sm:w-[125px] border border-solid border-gray-400",
           "object-cover",
           Helpers.obfuscate_item?(assigns) && "obfuscate",
           "thumbnail-#{@item.id}"

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -1,0 +1,272 @@
+defmodule DpulCollectionsWeb.SearchItem do
+  alias DpulCollections.Collection
+  alias DpulCollections.Item
+  alias DpulCollectionsWeb.Live.Helpers
+  alias DpulCollectionsWeb.UserSets
+  alias DpulCollectionsWeb.ContentWarnings
+  use DpulCollectionsWeb, :html
+  use Phoenix.Component
+  use Gettext, backend: DpulCollectionsWeb.Gettext
+
+  def search_item(assigns = %{item: %Collection{}}) do
+    ~H"""
+    <li
+      id={"item-#{@item.id}"}
+      class="item card"
+      data-id={@item.id}
+      aria-label={@item.title |> hd}
+    >
+      <div class="grid-rows-2 bg-sage-100 grid sm:grid-rows-1 sm:grid-cols-4 gap-0">
+        <div class={[
+          "search-thumbnail",
+          "row-span-2 col-span-1",
+          "bg-search flex justify-center relative",
+          "h-[350px]"
+        ]}>
+          <div class="grid grid-cols-2 w-full gap-2 h-[350px] p-2">
+            <img
+              :for={item <- @item.featured_items}
+              src={"#{item.primary_thumbnail_service_url}/full/!#{item.primary_thumbnail_width},#{item.primary_thumbnail_height}/0/default.jpg"}
+              width={item.primary_thumbnail_width}
+              height={item.primary_thumbnail_height}
+              class="min-h-0 min-w-0 object-cover object-top h-full w-full max-h-full"
+              alt={item.title |> hd}
+            />
+          </div>
+        </div>
+        <div
+          class="metadata sm:col-span-3 flex flex-col gap-2 sm:gap-4 p-4"
+          id={"item-metadata-#{@item.id}"}
+        >
+          <div class="flex flex-wrap flex-row sm:flex-row justify-between">
+            <h2 dir="auto" class="w-full flex-grow sm:w-fit">
+              <.link
+                navigate={@item.url}
+                class="card-link"
+              >
+                {@item.title}
+              </.link>
+            </h2>
+            <span
+              aria-label={gettext("format")}
+              data-field="format"
+              class="w-full sm:w-fit flex-grow sm:flex-none text-gray-600 font-bold text-base uppercase sm:text-right"
+            >
+              {@item.format}
+            </span>
+          </div>
+          <div :if={@item.tagline} class="text-base">{@item.tagline}</div>
+          <div class="brief-metadata flex flex-auto flex-row gap-4">
+            <div class="flex flex-col pe-4 gap-0 py-0 h-min">
+              <div class="text-lg">{format_number(@item.item_count)}</div>
+              <div class="text-base">Items</div>
+            </div>
+            <div class="flex flex-col pe-4 gap-0 py-0 h-min">
+              <div class="text-lg">{format_number(length(@item.languages))}</div>
+              <div class="text-base">Languages</div>
+            </div>
+            <div class="flex flex-col pe-4 gap-0 py-0 h-min">
+              <div class="text-lg">{format_number(length(@item.geographic_origins))}</div>
+              <div class="text-base">Locations</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    """
+  end
+
+  def search_item(assigns = %{item: %Item{}}) do
+    ~H"""
+    <li
+      id={"item-#{@item.id}"}
+      class="item card text-start"
+      aria-label={@item.title |> hd}
+      phx-hook="ShowPageCount"
+      data-id={@item.id}
+      data-filecount={@item.file_count}
+    >
+      <div
+        :if={Helpers.obfuscate_item?(assigns)}
+        class="h-[2.5rem]"
+      >
+        <ContentWarnings.show_images_banner
+          item_id={@item.id}
+          content_warning={@item.content_warning}
+        />
+      </div>
+      <div class="grid-rows-2 bg-sage-100 grid sm:grid-rows-1 sm:grid-cols-4 gap-0">
+        <.large_thumb
+          :if={@item.file_count && length(@item.image_service_urls) > 0}
+          thumb={elem(hd(thumbnail_service_urls(0, 1, @item)), 0)}
+          thumb_num={0}
+          item={@item}
+          show_images={@show_images}
+        />
+        <div
+          class="metadata sm:col-span-3 sm:col-start-2 flex flex-col gap-2 sm:gap-4 p-4"
+          id={"item-metadata-#{@item.id}"}
+        >
+          <div class="flex flex-wrap flex-row sm:flex-row justify-between">
+            <h2 dir="auto" class="w-full flex-grow sm:w-fit pr-3">
+              <.link
+                navigate={@item.url}
+                class="card-link"
+                id={"item-title-#{@item.id}"}
+              >
+                {@item.title}
+              </.link>
+            </h2>
+            <span
+              aria-label={gettext("format")}
+              data-field="format"
+              class="w-full sm:w-fit flex-grow sm:flex-none text-gray-600 font-bold text-base uppercase sm:text-right"
+            >
+              {@item.format}
+            </span>
+          </div>
+          <div :if={!Enum.empty?(@item.transliterated_title) || !Enum.empty?(@item.alternative_title)}>
+            <h3
+              :for={ttitle <- @item.transliterated_title}
+              dir="auto"
+              class="mt-[-1rem] font-medium text-gray-500"
+              id={"item-translit-title-#{@item.id}"}
+            >
+              {ttitle}
+            </h3>
+          </div>
+          <div :if={@sort_by == :recently_added && @item.updated_at} class="updated-at w-full">
+            {gettext("Added")} {DpulCollectionsWeb.BrowseItem.time_ago(@item.updated_at)}
+          </div>
+          <div class="flex">
+            <div class="grow">
+              <.search_brief_metadata item={@item} />
+            </div>
+            <UserSets.AddToSetComponent.add_button
+              current_scope={@current_scope}
+              item_id={@item.id}
+              current_path={@current_path}
+            />
+          </div>
+          <div class="small-thumbnails hidden sm:flex flex-row flex-wrap gap-5 max-h-[125px] justify-start overflow-hidden">
+            <.thumbs
+              :for={{thumb, thumb_num} <- thumbnail_service_urls(1, 6, @item)}
+              :if={@item.file_count > 1}
+              thumb={thumb}
+              thumb_num={thumb_num + 1}
+              item={@item}
+              show_images={@show_images}
+            />
+            <div
+              id={"filecount-#{@item.id}"}
+              class="hidden absolute diagonal-rise -right-px -bottom-px bg-sage-100 pr-4 py-2 text-sm"
+            >
+              {format_number(@item.file_count)} {gettext("Files")}
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    """
+  end
+
+  def large_thumb(assigns) do
+    ~H"""
+    <div class={[
+      "search-thumbnail",
+      "row-span-2 col-span-1",
+      "bg-search flex justify-center relative"
+    ]}>
+      <img
+        class={[
+          "h-[350px] w-[350px]",
+          "sm:h-[225px] md:w-[225px]",
+          "bg-search object-contain p-2",
+          Helpers.obfuscate_item?(assigns) && "obfuscate",
+          "thumbnail-#{@item.id}",
+          "place-self-center"
+        ]}
+        src={"#{@thumb}/full/!350,350/0/default.jpg"}
+        alt=""
+      />
+      <div
+        :if={@item.file_count > 1}
+        class="absolute sm:hidden diagonal-rise right-0 bottom-0 bg-sage-100 pr-4 py-2"
+      >
+        {format_number(@item.file_count)} {gettext("Files")}
+      </div>
+    </div>
+    """
+  end
+
+  defp thumbnail_service_urls(start, max_thumbnails, item) do
+    thumbnail_service_urls(
+      start,
+      max_thumbnails,
+      item.image_service_urls,
+      item.primary_thumbnail_service_url
+    )
+  end
+
+  defp thumbnail_service_urls(start, max_thumbnails, image_service_urls, nil) do
+    # Truncate image service urls to max value
+    image_service_urls
+    |> Enum.slice(start, max_thumbnails)
+    |> Enum.with_index()
+  end
+
+  defp thumbnail_service_urls(
+         start,
+         max_thumbnails,
+         image_service_urls,
+         primary_thumbnail_service_url
+       ) do
+    # Move thumbnail url to front of list and then truncate to max value
+    image_service_urls
+    |> Enum.filter(&(&1 != primary_thumbnail_service_url))
+    |> List.insert_at(0, primary_thumbnail_service_url)
+    |> Enum.slice(start, max_thumbnails)
+    |> Enum.with_index()
+  end
+
+  defp search_brief_metadata(assigns) do
+    ~H"""
+    <div class="brief-metadata">
+      <div
+        :if={@item.date}
+        class="date"
+      >
+        <div class="text-base">{gettext("Date")}</div>
+        <div class="text-lg">{@item.date}</div>
+      </div>
+      <div
+        :if={length(@item.geographic_origin) > 0}
+        class="origin"
+      >
+        <div class="text-base">{gettext("Origin")}</div>
+        <div class="text-lg">{@item.geographic_origin}</div>
+      </div>
+    </div>
+    """
+  end
+
+  def thumbs(assigns) do
+    ~H"""
+    <div class="relative">
+      <img
+        class={[
+          "h-[125px] w-[125px] md:h-[125px] md:w-[125px] border border-solid border-gray-400",
+          "object-cover",
+          Helpers.obfuscate_item?(assigns) && "obfuscate",
+          "thumbnail-#{@item.id}"
+        ]}
+        src={"#{@thumb}/square/!350,350/0/default.jpg"}
+        alt=""
+        style="background-color: lightgray;"
+        width="125"
+        height="125"
+      />
+    </div>
+    """
+  end
+end

--- a/lib/dpul_collections_web/live/search_live.ex
+++ b/lib/dpul_collections_web/live/search_live.ex
@@ -1,13 +1,12 @@
 defmodule DpulCollectionsWeb.SearchLive do
   alias DpulCollections.Collection
-  alias DpulCollectionsWeb.UserSets
   use DpulCollectionsWeb, :live_view
   use Gettext, backend: DpulCollectionsWeb.Gettext
-  alias DpulCollections.{Item, Solr}
+  alias DpulCollections.Solr
   use Solr.Constants
   alias DpulCollectionsWeb.Live.Helpers
   alias DpulCollectionsWeb.SearchLive.SearchState
-  alias DpulCollectionsWeb.ContentWarnings
+  import DpulCollectionsWeb.SearchItem
 
   def mount(_params, _session, socket) do
     {:ok, socket}
@@ -529,189 +528,6 @@ defmodule DpulCollectionsWeb.SearchLive do
     |> Enum.map(fn {k, v} -> {v[:label], k} end)
   end
 
-  def search_item(assigns = %{item: %Collection{}}) do
-    ~H"""
-    <li
-      id={"item-#{@item.id}"}
-      class="item card"
-      data-id={@item.id}
-      aria-label={@item.title |> hd}
-    >
-      <div class="grid-rows-2 bg-sage-100 grid sm:grid-rows-1 sm:grid-cols-4 gap-0">
-        <div class={[
-          "search-thumbnail",
-          "row-span-2 col-span-1",
-          "bg-search flex justify-center relative",
-          "h-[350px]"
-        ]}>
-          <div class="grid grid-cols-2 w-full gap-2 h-[350px] p-2">
-            <img
-              :for={item <- @item.featured_items}
-              src={"#{item.primary_thumbnail_service_url}/full/!#{item.primary_thumbnail_width},#{item.primary_thumbnail_height}/0/default.jpg"}
-              width={item.primary_thumbnail_width}
-              height={item.primary_thumbnail_height}
-              class="min-h-0 min-w-0 object-cover object-top h-full w-full max-h-full"
-              alt={item.title |> hd}
-            />
-          </div>
-        </div>
-        <div
-          class="metadata sm:col-span-3 flex flex-col gap-2 sm:gap-4 p-4"
-          id={"item-metadata-#{@item.id}"}
-        >
-          <div class="flex flex-wrap flex-row sm:flex-row justify-between">
-            <h2 dir="auto" class="w-full flex-grow sm:w-fit">
-              <.link
-                navigate={@item.url}
-                class="card-link"
-              >
-                {@item.title}
-              </.link>
-            </h2>
-            <span
-              aria-label={gettext("format")}
-              data-field="format"
-              class="w-full sm:w-fit flex-grow sm:flex-none text-gray-600 font-bold text-base uppercase sm:text-right"
-            >
-              {@item.format}
-            </span>
-          </div>
-          <div :if={@item.tagline} class="text-base">{@item.tagline}</div>
-          <div class="brief-metadata flex flex-auto flex-row gap-4">
-            <div class="flex flex-col pe-4 gap-0 py-0 h-min">
-              <div class="text-lg">{format_number(@item.item_count)}</div>
-              <div class="text-base">Items</div>
-            </div>
-            <div class="flex flex-col pe-4 gap-0 py-0 h-min">
-              <div class="text-lg">{format_number(length(@item.languages))}</div>
-              <div class="text-base">Languages</div>
-            </div>
-            <div class="flex flex-col pe-4 gap-0 py-0 h-min">
-              <div class="text-lg">{format_number(length(@item.geographic_origins))}</div>
-              <div class="text-base">Locations</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </li>
-    """
-  end
-
-  def search_item(assigns = %{item: %Item{}}) do
-    ~H"""
-    <li
-      id={"item-#{@item.id}"}
-      class="item card text-start"
-      aria-label={@item.title |> hd}
-      phx-hook="ShowPageCount"
-      data-id={@item.id}
-      data-filecount={@item.file_count}
-    >
-      <div
-        :if={Helpers.obfuscate_item?(assigns)}
-        class="h-[2.5rem]"
-      >
-        <ContentWarnings.show_images_banner
-          item_id={@item.id}
-          content_warning={@item.content_warning}
-        />
-      </div>
-      <div class="grid-rows-2 bg-sage-100 grid sm:grid-rows-1 sm:grid-cols-4 gap-0">
-        <.large_thumb
-          :if={@item.file_count && length(@item.image_service_urls) > 0}
-          thumb={elem(hd(thumbnail_service_urls(0, 1, @item)), 0)}
-          thumb_num={0}
-          item={@item}
-          show_images={@show_images}
-        />
-        <div
-          class="metadata sm:col-span-3 sm:col-start-2 flex flex-col gap-2 sm:gap-4 p-4"
-          id={"item-metadata-#{@item.id}"}
-        >
-          <div class="flex flex-wrap flex-row sm:flex-row justify-between">
-            <h2 dir="auto" class="w-full flex-grow sm:w-fit pr-3">
-              <.link
-                navigate={@item.url}
-                class="card-link"
-                id={"item-title-#{@item.id}"}
-              >
-                {@item.title}
-              </.link>
-            </h2>
-            <span
-              aria-label={gettext("format")}
-              data-field="format"
-              class="w-full sm:w-fit flex-grow sm:flex-none text-gray-600 font-bold text-base uppercase sm:text-right"
-            >
-              {@item.format}
-            </span>
-          </div>
-          <div :if={!Enum.empty?(@item.transliterated_title) || !Enum.empty?(@item.alternative_title)}>
-            <h3
-              :for={ttitle <- @item.transliterated_title}
-              dir="auto"
-              class="mt-[-1rem] font-medium text-gray-500"
-              id={"item-translit-title-#{@item.id}"}
-            >
-              {ttitle}
-            </h3>
-          </div>
-          <div :if={@sort_by == :recently_added && @item.updated_at} class="updated-at w-full">
-            {gettext("Added")} {DpulCollectionsWeb.BrowseItem.time_ago(@item.updated_at)}
-          </div>
-          <div class="flex">
-            <div class="grow">
-              <.search_brief_metadata item={@item} />
-            </div>
-            <UserSets.AddToSetComponent.add_button
-              current_scope={@current_scope}
-              item_id={@item.id}
-              current_path={@current_path}
-            />
-          </div>
-          <div class="small-thumbnails hidden sm:flex flex-row flex-wrap gap-5 max-h-[125px] justify-start overflow-hidden">
-            <.thumbs
-              :for={{thumb, thumb_num} <- thumbnail_service_urls(1, 6, @item)}
-              :if={@item.file_count > 1}
-              thumb={thumb}
-              thumb_num={thumb_num + 1}
-              item={@item}
-              show_images={@show_images}
-            />
-            <div
-              id={"filecount-#{@item.id}"}
-              class="hidden absolute diagonal-rise -right-px -bottom-px bg-sage-100 pr-4 py-2 text-sm"
-            >
-              {format_number(@item.file_count)} {gettext("Files")}
-            </div>
-          </div>
-        </div>
-      </div>
-    </li>
-    """
-  end
-
-  defp search_brief_metadata(assigns) do
-    ~H"""
-    <div class="brief-metadata">
-      <div
-        :if={@item.date}
-        class="date"
-      >
-        <div class="text-base">{gettext("Date")}</div>
-        <div class="text-lg">{@item.date}</div>
-      </div>
-      <div
-        :if={length(@item.geographic_origin) > 0}
-        class="origin"
-      >
-        <div class="text-base">{gettext("Origin")}</div>
-        <div class="text-lg">{@item.geographic_origin}</div>
-      </div>
-    </div>
-    """
-  end
-
   def results_for_keywords_heading(assigns) do
     ~H"""
     <h1 class="flex flex-wrap">
@@ -726,55 +542,6 @@ defmodule DpulCollectionsWeb.SearchLive do
         </div>
       <% end %>
     </h1>
-    """
-  end
-
-  def large_thumb(assigns) do
-    ~H"""
-    <div class={[
-      "search-thumbnail",
-      "row-span-2 col-span-1",
-      "bg-search flex justify-center relative"
-    ]}>
-      <img
-        class={[
-          "h-[350px] w-[350px]",
-          "sm:h-[225px] md:w-[225px]",
-          "bg-search object-contain p-2",
-          Helpers.obfuscate_item?(assigns) && "obfuscate",
-          "thumbnail-#{@item.id}",
-          "place-self-center"
-        ]}
-        src={"#{@thumb}/full/!350,350/0/default.jpg"}
-        alt=""
-      />
-      <div
-        :if={@item.file_count > 1}
-        class="absolute sm:hidden diagonal-rise right-0 bottom-0 bg-sage-100 pr-4 py-2"
-      >
-        {format_number(@item.file_count)} {gettext("Files")}
-      </div>
-    </div>
-    """
-  end
-
-  def thumbs(assigns) do
-    ~H"""
-    <div class="relative">
-      <img
-        class={[
-          "h-[125px] w-[125px] md:h-[125px] md:w-[125px] border border-solid border-gray-400",
-          "object-cover",
-          Helpers.obfuscate_item?(assigns) && "obfuscate",
-          "thumbnail-#{@item.id}"
-        ]}
-        src={"#{@thumb}/square/!350,350/0/default.jpg"}
-        alt=""
-        style="background-color: lightgray;"
-        width="125"
-        height="125"
-      />
-    </div>
     """
   end
 
@@ -988,35 +755,5 @@ defmodule DpulCollectionsWeb.SearchLive do
       type == :pre -> [{page, false}, {"...", false}]
       type == :post -> [{"...", false}, {page, false}]
     end
-  end
-
-  defp thumbnail_service_urls(start, max_thumbnails, item) do
-    thumbnail_service_urls(
-      start,
-      max_thumbnails,
-      item.image_service_urls,
-      item.primary_thumbnail_service_url
-    )
-  end
-
-  defp thumbnail_service_urls(start, max_thumbnails, image_service_urls, nil) do
-    # Truncate image service urls to max value
-    image_service_urls
-    |> Enum.slice(start, max_thumbnails)
-    |> Enum.with_index()
-  end
-
-  defp thumbnail_service_urls(
-         start,
-         max_thumbnails,
-         image_service_urls,
-         primary_thumbnail_service_url
-       ) do
-    # Move thumbnail url to front of list and then truncate to max value
-    image_service_urls
-    |> Enum.filter(&(&1 != primary_thumbnail_service_url))
-    |> List.insert_at(0, primary_thumbnail_service_url)
-    |> Enum.slice(start, max_thumbnails)
-    |> Enum.with_index()
   end
 end

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -839,32 +839,36 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
         html
         |> Floki.parse_document()
 
-      # There should be a maximum of 5 thumbnails on the search results page
-      assert document |> Floki.find("#item-1 img") |> Enum.count() == 7
+      assert document |> Floki.find("#item-1 img.primary-thumbnail") |> Enum.count() == 1
+
+      # There should be a maximum of 6 small thumbnails on the search results page
+      assert document |> Floki.find("#item-1 .metadata img") |> Enum.count() == 6
 
       # Odd numbered documents in test data do not have a thumbnail id
       # so the order of thumbnails should be the same as the image member order
       assert document
-             |> Floki.attribute("#item-1 .search-thumbnail img", "src") == [
+             |> Floki.attribute("#item-1 img.primary-thumbnail", "src") == [
                "https://example.com/iiif/2/image1/full/!350,350/0/default.jpg"
              ]
 
       assert document
-             |> Floki.attribute("#item-1 .small-thumbnails > :first-child > img", "src") == [
-               "https://example.com/iiif/2/image2/square/!350,350/0/default.jpg"
-             ]
+             |> Floki.attribute("#item-1 .metadata .small-thumbnails > :first-child > img", "src") ==
+               [
+                 "https://example.com/iiif/2/image2/square/!350,350/0/default.jpg"
+               ]
 
       # Even numbered documents in test data have a thumbnail id so the order
       # of thumbnails should be different from the image member order
       assert document
-             |> Floki.attribute("#item-2 .search-thumbnail img", "src") == [
+             |> Floki.attribute("#item-2 img.primary-thumbnail", "src") == [
                "https://example.com/iiif/2/image2/full/!350,350/0/default.jpg"
              ]
 
       assert document
-             |> Floki.attribute("#item-2 .small-thumbnails > :first-child > img", "src") == [
-               "https://example.com/iiif/2/image1/square/!350,350/0/default.jpg"
-             ]
+             |> Floki.attribute("#item-2 .metadata .small-thumbnails > :first-child > img", "src") ==
+               [
+                 "https://example.com/iiif/2/image1/square/!350,350/0/default.jpg"
+               ]
     end
 
     test "displays ephemera projects", %{conn: conn} do


### PR DESCRIPTION
Advances #1192 by bringing the two designs closer to one another, and extracting the search item into its own component.

- **Extract search item to its own component file**
- **Include small thumbnails in search result mobile view**
- **Style small thumbnails in mobile to take up all the space**
- **Style small search thumbnails in mobile depending on number of files**

screenshots:

<img width="393" height="633" alt="Screenshot 2026-05-18 at 10 52 24 AM" src="https://github.com/user-attachments/assets/13e5934b-fc90-4852-81fb-542070538f53" />
<img width="393" height="624" alt="Screenshot 2026-05-18 at 10 52 14 AM" src="https://github.com/user-attachments/assets/031566c1-4e3f-446a-b777-44ec4ccda519" />


