### PR TITLE
Extract HydrationCacheEntry#from

### DIFF
--- a/lib/dpul_collections/indexing_pipeline.ex
+++ b/lib/dpul_collections/indexing_pipeline.ex
@@ -8,6 +8,7 @@ defmodule DpulCollections.IndexingPipeline do
   alias DpulCollections.{Repo, FiggyRepo}
 
   alias DpulCollections.IndexingPipeline.Figgy
+  alias DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntry
   alias DpulCollections.IndexingPipeline.DatabaseProducer.CacheEntryMarker
 
   @doc """
@@ -62,16 +63,21 @@ defmodule DpulCollections.IndexingPipeline do
   @doc """
   Writes or updates hydration cache entries.
   """
-  def write_hydration_cache_entry(attrs \\ %{}) do
+  def write_hydration_cache_entry(attrs = %HydrationCacheEntry{}),
+    do: write_hydration_cache_entry(Map.from_struct(attrs))
+
+  def write_hydration_cache_entry(attrs = %{}) do
+    # Use EXCLUDED to avoid having to reference attrs in conflict query.
+    # See https://hexdocs.pm/ecto/Ecto.Repo.html#c:insert/2-advanced-upserts
     conflict_query =
       Figgy.HydrationCacheEntry
       |> update(
         set: [
-          data: ^attrs.data,
-          related_data: ^attrs[:related_data],
-          related_ids: ^attrs.related_ids,
-          source_cache_order: ^attrs.source_cache_order,
-          source_cache_order_record_id: ^attrs.source_cache_order_record_id,
+          data: fragment("EXCLUDED.data"),
+          related_data: fragment("EXCLUDED.related_data"),
+          related_ids: fragment("EXCLUDED.related_ids"),
+          source_cache_order: fragment("EXCLUDED.source_cache_order"),
+          source_cache_order_record_id: fragment("EXCLUDED.source_cache_order_record_id"),
           cache_order: ^DateTime.utc_now()
         ]
       )

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry.ex
@@ -1,6 +1,7 @@
 defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntry do
   use Ecto.Schema
   import Ecto.Changeset
+  alias DpulCollections.IndexingPipeline.Figgy
 
   schema "figgy_hydration_cache_entries" do
     field :data, :map
@@ -34,5 +35,51 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntry do
       :source_cache_order,
       :source_cache_order_record_id
     ])
+  end
+
+  # store in HydrationCache:
+  # - cache_version (this only changes manually, we have to hold onto it as state)
+  # - record_id (varchar) - the figgy UUID
+  # - data (blob) - this is the record
+  # - related_data (blob) - map of related data
+  # - related_ids (array<string>) - array of IDs that are contained in
+  #   related_data
+  # - source_cache_order (datetime) - most recent figgy or related resource updated_at
+  # - source_cache_order_record_id (varchar) - record id of the source_cache_order value
+  @spec from(
+          %Figgy.DeletionRecord{} | %Figgy.CombinedFiggyResource{},
+          cache_version :: integer
+        ) :: %__MODULE__{}
+  def from(
+        %Figgy.DeletionRecord{
+          marker: marker,
+          id: id,
+          internal_resource: internal_resource
+        },
+        cache_version
+      ) do
+    %__MODULE__{
+      cache_version: cache_version,
+      record_id: id,
+      related_ids: [],
+      source_cache_order: marker.timestamp,
+      source_cache_order_record_id: marker.id,
+      data: %{internal_resource: internal_resource, id: id, metadata: %{"deleted" => true}}
+    }
+  end
+
+  def from(
+        combined_resource = %Figgy.CombinedFiggyResource{resource: resource},
+        cache_version
+      ) do
+    %__MODULE__{
+      cache_version: cache_version,
+      record_id: resource.id,
+      data: resource,
+      related_data: combined_resource.related_data,
+      related_ids: combined_resource.related_ids,
+      source_cache_order: combined_resource.latest_updated_marker.timestamp,
+      source_cache_order_record_id: combined_resource.latest_updated_marker.id
+    }
   end
 end

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -5,6 +5,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   alias DpulCollections.IndexingPipeline.DatabaseProducer.CacheEntryMarker
   alias DpulCollections.IndexingPipeline
   alias DpulCollections.IndexingPipeline.Figgy
+  alias DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntry
   alias DpulCollections.IndexingPipeline.Figgy.ResourceTypeRegistry
   alias DpulCollections.IndexingPipeline.DatabaseProducer
   use Broadway
@@ -400,7 +401,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
         },
         cache_version
       ) do
-    %{
+    %HydrationCacheEntry{
       cache_version: cache_version,
       record_id: id,
       related_ids: [],
@@ -414,7 +415,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
         combined_resource = %Figgy.CombinedFiggyResource{resource: resource},
         cache_version
       ) do
-    %{
+    %HydrationCacheEntry{
       cache_version: cache_version,
       record_id: resource.id,
       data: resource,

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -365,66 +365,16 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     update
   end
 
-  defp persist(process_return = {action, _resource}, cache_version)
+  defp persist({action, resource}, cache_version)
        when action in [:delete, :update] do
     # Maybe move to HydrationCacheEntry.from?
-    attributes = hydration_cache_attributes(process_return, cache_version)
-    {:ok, _response} = IndexingPipeline.write_hydration_cache_entry(attributes)
+    {:ok, _response} =
+      resource
+      |> HydrationCacheEntry.from(cache_version)
+      |> IndexingPipeline.write_hydration_cache_entry()
   end
 
   defp persist({:skip, _}, _cache_version), do: {:skip, nil}
-
-  @spec hydration_cache_attributes(
-          %Figgy.DeletionRecord{} | %Figgy.CombinedFiggyResource{},
-          cache_version :: integer
-        ) :: %{
-          :handled_data => map(),
-          :related_data => Figgy.CombinedFiggyResource.related_data()
-        }
-  def hydration_cache_attributes({_action, resource}, cache_version),
-    do: hydration_cache_attributes(resource, cache_version)
-
-  # store in HydrationCache:
-  # - cache_version (this only changes manually, we have to hold onto it as state)
-  # - record_id (varchar) - the figgy UUID
-  # - data (blob) - this is the record
-  # - related_data (blob) - map of related data
-  # - related_ids (array<string>) - array of IDs that are contained in
-  #   related_data
-  # - source_cache_order (datetime) - most recent figgy or related resource updated_at
-  # - source_cache_order_record_id (varchar) - record id of the source_cache_order value
-  def hydration_cache_attributes(
-        %Figgy.DeletionRecord{
-          marker: marker,
-          id: id,
-          internal_resource: internal_resource
-        },
-        cache_version
-      ) do
-    %HydrationCacheEntry{
-      cache_version: cache_version,
-      record_id: id,
-      related_ids: [],
-      source_cache_order: marker.timestamp,
-      source_cache_order_record_id: marker.id,
-      data: %{internal_resource: internal_resource, id: id, metadata: %{"deleted" => true}}
-    }
-  end
-
-  def hydration_cache_attributes(
-        combined_resource = %Figgy.CombinedFiggyResource{resource: resource},
-        cache_version
-      ) do
-    %HydrationCacheEntry{
-      cache_version: cache_version,
-      record_id: resource.id,
-      data: resource,
-      related_data: combined_resource.related_data,
-      related_ids: combined_resource.related_ids,
-      source_cache_order: combined_resource.latest_updated_marker.timestamp,
-      source_cache_order_record_id: combined_resource.latest_updated_marker.id
-    }
-  end
 
   def start_over!(cache_version) do
     String.to_atom("#{__MODULE__}_#{cache_version}")

--- a/test/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry_test.exs
@@ -1,0 +1,95 @@
+defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntryTest do
+  use DpulCollections.DataCase
+
+  alias DpulCollections.IndexingPipeline
+  alias DpulCollections.IndexingPipeline.Figgy.{Resource, HydrationConsumer, HydrationCacheEntry}
+
+  describe "from/2" do
+    test "it doesn't error when the related resource id is an empty string" do
+      folder = FiggyTestSupport.first_ephemera_folder()
+
+      related_resource_count =
+        %Resource{
+          (%Resource{} = folder)
+          | metadata: %{folder.metadata | "genre" => [%{"id" => ""}]}
+        }
+        |> HydrationConsumer.process(1)
+        |> elem(1)
+        |> HydrationCacheEntry.from(1)
+        |> get_in([Access.key!(:related_data)])
+        |> get_in(["resources"])
+        |> Map.keys()
+        |> length()
+
+      assert(related_resource_count == 19)
+    end
+
+    test "when there are no image members, the resource is marked for deletion" do
+      folder = IndexingPipeline.get_figgy_resource!("f134f41f-63c5-4fdf-b801-0774e3bc3b2d")
+
+      metadata =
+        folder
+        |> HydrationConsumer.process(1)
+        |> elem(1)
+        |> HydrationCacheEntry.from(1)
+        |> get_in([Access.key!(:data)])
+        |> get_in([Access.key!(:metadata)])
+
+      assert(metadata["deleted"] == true)
+    end
+
+    test "when there are no members at all, the resource is marked for deletion" do
+      folder = IndexingPipeline.get_figgy_resource!("f134f41f-63c5-4fdf-b801-0774e3bc3b2d")
+
+      metadata =
+        %Resource{(%Resource{} = folder) | metadata: %{folder.metadata | "member_ids" => []}}
+        |> HydrationConsumer.process(1)
+        |> elem(1)
+        |> HydrationCacheEntry.from(1)
+        |> get_in([Access.key!(:data)])
+        |> get_in([Access.key!(:metadata)])
+
+      assert(metadata["deleted"] == true)
+    end
+
+    test "it filters out non-image members" do
+      folder = IndexingPipeline.get_figgy_resource!("f134f41f-63c5-4fdf-b801-0774e3bc3b2d")
+
+      member_ids = [
+        # Video FileSet
+        %{"id" => "e55355f9-a410-4f96-83d2-cfa165203d01"},
+        # Image FileSet
+        %{"id" => "06838583-59a4-4ab8-ac65-2b5ea9ee6425"}
+      ]
+
+      resource_ids =
+        %Resource{
+          (%Resource{} = folder)
+          | metadata: %{folder.metadata | "member_ids" => member_ids}
+        }
+        |> HydrationConsumer.process(1)
+        |> elem(1)
+        |> HydrationCacheEntry.from(1)
+        |> get_in([Access.key!(:related_data)])
+        |> get_in(["resources"])
+        |> Map.keys()
+
+      assert("e55355f9-a410-4f96-83d2-cfa165203d01" not in resource_ids)
+    end
+
+    test "it filters out parent resources in related resources map" do
+      folder = IndexingPipeline.get_figgy_resource!("26713a31-d615-49fd-adfc-93770b4f66b3")
+
+      resource_ids =
+        folder
+        |> HydrationConsumer.process(1)
+        |> elem(1)
+        |> HydrationCacheEntry.from(1)
+        |> get_in([Access.key!(:related_data)])
+        |> get_in(["resources"])
+        |> Map.keys()
+
+      assert("82624edb-c360-4d8a-b202-f103ee639e8e" not in resource_ids)
+    end
+  end
+end

--- a/test/dpul_collections/indexing_pipeline/figgy/hydration_consumer_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/hydration_consumer_test.exs
@@ -812,7 +812,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         }
         |> HydrationConsumer.process(1)
         |> HydrationConsumer.hydration_cache_attributes(1)
-        |> get_in([:related_data])
+        |> get_in([Access.key!(:related_data)])
         |> get_in(["resources"])
         |> Map.keys()
         |> length()
@@ -827,7 +827,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         folder
         |> HydrationConsumer.process(1)
         |> HydrationConsumer.hydration_cache_attributes(1)
-        |> get_in([:data])
+        |> get_in([Access.key!(:data)])
         |> get_in([Access.key!(:metadata)])
 
       assert(metadata["deleted"] == true)
@@ -840,7 +840,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         %Resource{(%Resource{} = folder) | metadata: %{folder.metadata | "member_ids" => []}}
         |> HydrationConsumer.process(1)
         |> HydrationConsumer.hydration_cache_attributes(1)
-        |> get_in([:data])
+        |> get_in([Access.key!(:data)])
         |> get_in([Access.key!(:metadata)])
 
       assert(metadata["deleted"] == true)
@@ -863,7 +863,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         }
         |> HydrationConsumer.process(1)
         |> HydrationConsumer.hydration_cache_attributes(1)
-        |> get_in([:related_data])
+        |> get_in([Access.key!(:related_data)])
         |> get_in(["resources"])
         |> Map.keys()
 
@@ -877,7 +877,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         folder
         |> HydrationConsumer.process(1)
         |> HydrationConsumer.hydration_cache_attributes(1)
-        |> get_in([:related_data])
+        |> get_in([Access.key!(:related_data)])
         |> get_in(["resources"])
         |> Map.keys()
 

--- a/test/dpul_collections/indexing_pipeline/figgy/hydration_consumer_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/hydration_consumer_test.exs
@@ -4,7 +4,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
 
   alias DpulCollections.IndexingPipeline
   alias DpulCollections.IndexingPipeline.Figgy
-  alias DpulCollections.IndexingPipeline.Figgy.{Resource, HydrationConsumer}
+  alias DpulCollections.IndexingPipeline.Figgy.HydrationConsumer
 
   describe "Figgy.HydrationConsumer" do
     test "process/1 returns a skip for ephemera terms that don't have any related IDs" do
@@ -798,90 +798,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
 
         assert related_resource_entry["metadata"]["title"] == ["Updated EphemeraProject Title"]
       end
-    end
-  end
-
-  describe "hydration_cache_attributes/1" do
-    test "it doesn't error when the related resource id is an empty string" do
-      folder = FiggyTestSupport.first_ephemera_folder()
-
-      related_resource_count =
-        %Resource{
-          (%Resource{} = folder)
-          | metadata: %{folder.metadata | "genre" => [%{"id" => ""}]}
-        }
-        |> HydrationConsumer.process(1)
-        |> HydrationConsumer.hydration_cache_attributes(1)
-        |> get_in([Access.key!(:related_data)])
-        |> get_in(["resources"])
-        |> Map.keys()
-        |> length()
-
-      assert(related_resource_count == 19)
-    end
-
-    test "when there are no image members, the resource is marked for deletion" do
-      folder = IndexingPipeline.get_figgy_resource!("f134f41f-63c5-4fdf-b801-0774e3bc3b2d")
-
-      metadata =
-        folder
-        |> HydrationConsumer.process(1)
-        |> HydrationConsumer.hydration_cache_attributes(1)
-        |> get_in([Access.key!(:data)])
-        |> get_in([Access.key!(:metadata)])
-
-      assert(metadata["deleted"] == true)
-    end
-
-    test "when there are no members at all, the resource is marked for deletion" do
-      folder = IndexingPipeline.get_figgy_resource!("f134f41f-63c5-4fdf-b801-0774e3bc3b2d")
-
-      metadata =
-        %Resource{(%Resource{} = folder) | metadata: %{folder.metadata | "member_ids" => []}}
-        |> HydrationConsumer.process(1)
-        |> HydrationConsumer.hydration_cache_attributes(1)
-        |> get_in([Access.key!(:data)])
-        |> get_in([Access.key!(:metadata)])
-
-      assert(metadata["deleted"] == true)
-    end
-
-    test "it filters out non-image members" do
-      folder = IndexingPipeline.get_figgy_resource!("f134f41f-63c5-4fdf-b801-0774e3bc3b2d")
-
-      member_ids = [
-        # Video FileSet
-        %{"id" => "e55355f9-a410-4f96-83d2-cfa165203d01"},
-        # Image FileSet
-        %{"id" => "06838583-59a4-4ab8-ac65-2b5ea9ee6425"}
-      ]
-
-      resource_ids =
-        %Resource{
-          (%Resource{} = folder)
-          | metadata: %{folder.metadata | "member_ids" => member_ids}
-        }
-        |> HydrationConsumer.process(1)
-        |> HydrationConsumer.hydration_cache_attributes(1)
-        |> get_in([Access.key!(:related_data)])
-        |> get_in(["resources"])
-        |> Map.keys()
-
-      assert("e55355f9-a410-4f96-83d2-cfa165203d01" not in resource_ids)
-    end
-
-    test "it filters out parent resources in related resources map" do
-      folder = IndexingPipeline.get_figgy_resource!("26713a31-d615-49fd-adfc-93770b4f66b3")
-
-      resource_ids =
-        folder
-        |> HydrationConsumer.process(1)
-        |> HydrationConsumer.hydration_cache_attributes(1)
-        |> get_in([Access.key!(:related_data)])
-        |> get_in(["resources"])
-        |> Map.keys()
-
-      assert("82624edb-c360-4d8a-b202-f103ee639e8e" not in resource_ids)
     end
   end
 

--- a/test/support/figgy_test_support.ex
+++ b/test/support/figgy_test_support.ex
@@ -72,7 +72,8 @@ defmodule FiggyTestSupport do
 
     cache_attrs =
       Figgy.HydrationConsumer.process(record, 1)
-      |> Figgy.HydrationConsumer.hydration_cache_attributes(1)
+      |> elem(1)
+      |> Figgy.HydrationCacheEntry.from(1)
 
     {:ok, cache_entry} =
       IndexingPipeline.write_hydration_cache_entry(%{


### PR DESCRIPTION
Small refactor that I think will make things clearer going forward. It also makes it so we can build HydrationCacheEntries, instead of attributes, which should let compile time safety tell us when attributes are wrong.