### PR TITLE
[Refactor] Playing w/ refactoring HydrationConsumer

### DIFF
--- a/lib/dpul_collections/indexing_pipeline.ex
+++ b/lib/dpul_collections/indexing_pipeline.ex
@@ -260,7 +260,8 @@ defmodule DpulCollections.IndexingPipeline do
 
   """
   @decorate trace()
-  def get_figgy_resource!(id), do: FiggyRepo.get!(Figgy.Resource, id)
+  def get_figgy_resource!(id),
+    do: FiggyRepo.get!(Figgy.Resource, id) |> Figgy.Resource.populate_virtual()
 
   @decorate trace()
   def get_figgy_parents(id) do

--- a/lib/dpul_collections/indexing_pipeline/figgy/deletion_record.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/deletion_record.ex
@@ -1,3 +1,35 @@
 defmodule DpulCollections.IndexingPipeline.Figgy.DeletionRecord do
+  alias DpulCollections.IndexingPipeline.Figgy
+  alias DpulCollections.IndexingPipeline.DatabaseProducer.CacheEntryMarker
   defstruct [:marker, :internal_resource, :id]
+
+  def from(
+        resource = %{
+          internal_resource: "DeletionMarker",
+          metadata_resource_id: [%{"id" => resource_id}],
+          metadata_resource_type: [resource_type]
+        }
+      ) do
+    %__MODULE__{
+      marker: CacheEntryMarker.from(resource),
+      internal_resource: resource_type,
+      id: resource_id
+    }
+  end
+
+  def from(resource = %{internal_resource: internal_resource, id: id}) do
+    %__MODULE__{
+      marker: CacheEntryMarker.from(resource),
+      internal_resource: internal_resource,
+      id: id
+    }
+  end
+
+  def from(combined_resource = %Figgy.CombinedFiggyResource{}) do
+    %__MODULE__{
+      marker: combined_resource.latest_updated_marker,
+      internal_resource: combined_resource.resource.internal_resource,
+      id: combined_resource.resource.id
+    }
+  end
 end

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry.ex
@@ -68,6 +68,10 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntry do
     }
   end
 
+  def from(uncombined_resource = %Figgy.Resource{}, cache_version) do
+    from(Figgy.Resource.to_combined(uncombined_resource), cache_version)
+  end
+
   def from(
         combined_resource = %Figgy.CombinedFiggyResource{resource: resource},
         cache_version

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -71,8 +71,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     # save them all.
     resource
     |> early_conversion(cache_version)
-    |> process(cache_version)
-    |> to_hydration_cache_entries(cache_version)
+    # |> process(cache_version)
+    # |> to_hydration_cache_entries(cache_version)
     |> save_all()
   end
 
@@ -150,6 +150,51 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
           [HydrationCacheEntry.from(deletion_record, cache_version)]
         else
           [HydrationCacheEntry.from(combined_figgy_resource, cache_version)]
+        end
+
+      _ ->
+        # Delete it if we've seen it before.
+        existing_resource =
+          IndexingPipeline.get_hydration_cache_entry!(resource.id, cache_version)
+
+        if existing_resource do
+          deletion_record = %Figgy.DeletionRecord{
+            marker: CacheEntryMarker.from(resource),
+            internal_resource: resource.internal_resource,
+            id: resource.id
+          }
+
+          [HydrationCacheEntry.from(deletion_record, cache_version)]
+        else
+          []
+        end
+    end
+  end
+
+  # Ingest ScannedResources
+  def early_conversion(resource = %{internal_resource: "ScannedResource"}, cache_version) do
+    case resource do
+      # Process open/complete
+      %{state: ["complete"], visibility: ["open"], member_of_collection_ids: [_ | _]} ->
+        if member_of_allowed_collection?(resource) do
+          combined_figgy_resource = Figgy.Resource.to_combined(resource)
+          # Delete it when it has no member_ids.
+          if combined_figgy_resource.persisted_member_ids == [] do
+            # NOTE: This is actually a bug, we shouldn't be creating a deletion
+            # record if we've never seen it, probably, but we have a test in
+            # FullIntegrationTest checking that it exists.
+            deletion_record = %Figgy.DeletionRecord{
+              marker: CacheEntryMarker.from(resource),
+              internal_resource: resource.internal_resource,
+              id: resource.id
+            }
+
+            [HydrationCacheEntry.from(deletion_record, cache_version)]
+          else
+            [HydrationCacheEntry.from(combined_figgy_resource, cache_version)]
+          end
+        else
+          []
         end
 
       _ ->

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -229,8 +229,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     related_records(resource, cache_version)
   end
 
-  defp member_of_allowed_collection?(%{member_of_collection_ids: nil}), do: false
-
   defp member_of_allowed_collection?(resource) do
     collection_ids = Enum.map(resource.member_of_collection_ids, & &1["id"])
     Enum.any?(collection_ids, &ResourceTypeRegistry.allowed_collection?/1)

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -70,7 +70,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     # save all of them together.
     all_resources =
       Stream.concat(
-        to_hydration_cache_entries(resource, cache_version),
+        [to_hydration_cache_entry(resource, cache_version)],
         related_records(resource, cache_version)
       )
 
@@ -79,6 +79,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
 
   defp save_all(resources) do
     resources
+    |> Stream.reject(&is_nil/1)
     |> Enum.each(&IndexingPipeline.write_hydration_cache_entry/1)
 
     {:ok, nil}
@@ -87,15 +88,16 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   @indexable_resource_types ResourceTypeRegistry.indexable_types()
   @related_record_types ResourceTypeRegistry.related_record_types()
   @processed_types ResourceTypeRegistry.processed_types()
+
   # Immediately skip anything not in processed_types.
-  def to_hydration_cache_entries(%{internal_resource: internal_resource}, _cache_version)
+  def to_hydration_cache_entry(%{internal_resource: internal_resource}, _cache_version)
       when internal_resource not in @processed_types do
-    []
+    nil
   end
 
   # DeletionMarkers delete any records it's pointing to it if they've been
   # processed before.
-  def to_hydration_cache_entries(resource = %{internal_resource: "DeletionMarker"}, cache_version) do
+  def to_hydration_cache_entry(resource = %{internal_resource: "DeletionMarker"}, cache_version) do
     case resource do
       %{
         metadata_resource_id: [%{"id" => resource_id}],
@@ -106,30 +108,26 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
           IndexingPipeline.get_hydration_cache_entry!(resource_id, cache_version)
 
         if existing_resource do
-          [HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)]
-        else
-          []
+          HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)
         end
 
       _ ->
-        []
+        nil
     end
   end
 
   # Collections only update if they're allowed.
-  def to_hydration_cache_entries(
+  def to_hydration_cache_entry(
         resource = %{internal_resource: "Collection", id: id},
         cache_version
       ) do
     if ResourceTypeRegistry.allowed_collection?(id) do
-      [HydrationCacheEntry.from(resource, cache_version)]
-    else
-      []
+      HydrationCacheEntry.from(resource, cache_version)
     end
   end
 
   # Ingest EphemeraFolders
-  def to_hydration_cache_entries(resource = %{internal_resource: "EphemeraFolder"}, cache_version) do
+  def to_hydration_cache_entry(resource = %{internal_resource: "EphemeraFolder"}, cache_version) do
     case resource do
       # Process open/complete
       %{state: ["complete"], visibility: ["open"]} ->
@@ -139,9 +137,9 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
           # NOTE: This is actually a bug, we shouldn't be creating a deletion
           # record if we've never seen it, probably, but we have a test in
           # FullIntegrationTest checking that it exists.
-          [HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)]
+          HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)
         else
-          [HydrationCacheEntry.from(combined_figgy_resource, cache_version)]
+          HydrationCacheEntry.from(combined_figgy_resource, cache_version)
         end
 
       _ ->
@@ -150,15 +148,13 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
           IndexingPipeline.get_hydration_cache_entry!(resource.id, cache_version)
 
         if existing_resource do
-          [HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)]
-        else
-          []
+          HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)
         end
     end
   end
 
   # Ingest ScannedResources
-  def to_hydration_cache_entries(
+  def to_hydration_cache_entry(
         resource = %{internal_resource: "ScannedResource"},
         cache_version
       ) do
@@ -173,12 +169,10 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
             # record if we've never seen it, probably, but we have a test in
             # FullIntegrationTest checking that it exists.
 
-            [HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)]
+            HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)
           else
-            [HydrationCacheEntry.from(combined_figgy_resource, cache_version)]
+            HydrationCacheEntry.from(combined_figgy_resource, cache_version)
           end
-        else
-          []
         end
 
       _ ->
@@ -187,14 +181,12 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
           IndexingPipeline.get_hydration_cache_entry!(resource.id, cache_version)
 
         if existing_resource do
-          [HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)]
-        else
-          []
+          HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)
         end
     end
   end
 
-  def to_hydration_cache_entries(
+  def to_hydration_cache_entry(
         resource = %{internal_resource: "EphemeraProject", id: id},
         cache_version
       ) do
@@ -203,26 +195,22 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     case combined_resource.resource.metadata do
       %{"publish" => ["1"]} ->
         # Save published EphemeraProjects, update related records
-        [HydrationCacheEntry.from(combined_resource, cache_version)]
+        HydrationCacheEntry.from(combined_resource, cache_version)
 
       _ ->
         # Delete if we've seen it before
         existing_resource = IndexingPipeline.get_hydration_cache_entry!(id, cache_version)
 
         if existing_resource do
-          [
-            HydrationCacheEntry.from(
-              Figgy.DeletionRecord.from(combined_resource),
-              cache_version
-            )
-          ]
-        else
-          []
+          HydrationCacheEntry.from(
+            Figgy.DeletionRecord.from(combined_resource),
+            cache_version
+          )
         end
     end
   end
 
-  def to_hydration_cache_entries(_resource, _cache_version), do: []
+  def to_hydration_cache_entry(_resource, _cache_version), do: nil
 
   defp member_of_allowed_collection?(resource) do
     collection_ids = Enum.map(resource.member_of_collection_ids, & &1["id"])
@@ -237,7 +225,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     IndexingPipeline.get_related_hydration_cache_record_ids!(id, timestamp, cache_version)
     |> Stream.flat_map(fn id ->
       IndexingPipeline.get_figgy_resource!(id)
-      |> to_hydration_cache_entries(cache_version)
+      |> to_hydration_cache_entry(cache_version)
     end)
   end
 

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -244,13 +244,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     end)
   end
 
-  # @spec store_result(process_return(), message :: Broadway.Message.t()) ::
-  #         Broadway.Message.t()
-  # def store_result({:skip, _record}, message), do: Broadway.Message.put_batcher(message, :noop)
-
-  def store_result(_, message),
-    do: message
-
   def start_over!(cache_version) do
     String.to_atom("#{__MODULE__}_#{cache_version}")
     |> Broadway.producer_names()

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -70,9 +70,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     # Take a resource, convert it into a stream of hydration_cache_entries, then
     # save them all.
     resource
-    |> early_conversion(cache_version)
-    # |> process(cache_version)
-    # |> to_hydration_cache_entries(cache_version)
+    |> to_hydration_cache_entries(cache_version)
     |> save_all()
   end
 
@@ -87,14 +85,14 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   @related_record_types ResourceTypeRegistry.related_record_types()
   @processed_types ResourceTypeRegistry.processed_types()
   # Immediately skip anything not in processed_types.
-  def early_conversion(%{internal_resource: internal_resource}, _cache_version)
+  def to_hydration_cache_entries(%{internal_resource: internal_resource}, _cache_version)
       when internal_resource not in @processed_types do
     []
   end
 
   # DeletionMarkers delete any records it's pointing to it if they've been
   # processed before.
-  def early_conversion(resource = %{internal_resource: "DeletionMarker"}, cache_version) do
+  def to_hydration_cache_entries(resource = %{internal_resource: "DeletionMarker"}, cache_version) do
     case resource do
       %{
         metadata_resource_id: [%{"id" => resource_id}],
@@ -122,7 +120,10 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   end
 
   # Collections only update if they're allowed.
-  def early_conversion(resource = %{internal_resource: "Collection", id: id}, cache_version) do
+  def to_hydration_cache_entries(
+        resource = %{internal_resource: "Collection", id: id},
+        cache_version
+      ) do
     if ResourceTypeRegistry.allowed_collection?(id) do
       [HydrationCacheEntry.from(resource, cache_version)]
     else
@@ -131,7 +132,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   end
 
   # Ingest EphemeraFolders
-  def early_conversion(resource = %{internal_resource: "EphemeraFolder"}, cache_version) do
+  def to_hydration_cache_entries(resource = %{internal_resource: "EphemeraFolder"}, cache_version) do
     case resource do
       # Process open/complete
       %{state: ["complete"], visibility: ["open"]} ->
@@ -172,7 +173,10 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   end
 
   # Ingest ScannedResources
-  def early_conversion(resource = %{internal_resource: "ScannedResource"}, cache_version) do
+  def to_hydration_cache_entries(
+        resource = %{internal_resource: "ScannedResource"},
+        cache_version
+      ) do
     case resource do
       # Process open/complete
       %{state: ["complete"], visibility: ["open"], member_of_collection_ids: [_ | _]} ->
@@ -216,7 +220,10 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     end
   end
 
-  def early_conversion(resource = %{internal_resource: "EphemeraProject", id: id}, cache_version) do
+  def to_hydration_cache_entries(
+        resource = %{internal_resource: "EphemeraProject", id: id},
+        cache_version
+      ) do
     combined_resource = Figgy.Resource.to_combined(resource)
 
     Stream.concat(
@@ -245,120 +252,17 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     )
   end
 
-  def early_conversion(resource = %{internal_resource: internal_resource}, cache_version)
+  def to_hydration_cache_entries(
+        resource = %{internal_resource: internal_resource},
+        cache_version
+      )
       when internal_resource in @related_record_types do
     related_records(resource, cache_version)
   end
 
-  def early_conversion(resource, _cache_version) do
+  def to_hydration_cache_entries(resource, _cache_version) do
     resource
   end
-
-  def related_records(%{updated_at: timestamp, id: id}, cache_version) do
-    IndexingPipeline.get_related_hydration_cache_record_ids!(id, timestamp, cache_version)
-    |> Stream.flat_map(fn id ->
-      IndexingPipeline.get_figgy_resource!(id)
-      |> early_conversion(cache_version)
-      |> process(cache_version)
-      |> to_hydration_cache_entries(cache_version)
-    end)
-  end
-
-  # Allow fall-through if early conversion solved it already.
-  def process(cache_entry = %HydrationCacheEntry{}, _cache_version), do: cache_entry
-  def process(cache_entries = [%HydrationCacheEntry{} | _], _cache_version), do: cache_entries
-  def process(cache_entries = %Stream{}, _cache_version), do: cache_entries
-  def process([], _cache_version), do: []
-
-  # Classification requires all figgy resources to have the virtual attributes
-  # set. Resources pulled by the hydrator via `get_figgy_resources_since!` have
-  # them, but related records fetched via `get_figgy_resource!` do not, so add
-  # them first then recurse.
-  @type process_return() ::
-          {:update | :delete | :skip,
-           [String]
-           | %Figgy.Resource{}
-           | %Figgy.DeletionRecord{}
-           | %Figgy.CombinedFiggyResource{}}
-  @spec process(resource :: %Figgy.Resource{}, cache_version :: integer) :: process_return()
-  def process(
-        resource = %Figgy.Resource{metadata: %{"visibility" => _visibility}, visibility: nil},
-        cache_version
-      ) do
-    process(Figgy.Resource.populate_virtual(resource), cache_version)
-  end
-
-  def process(resource = %Figgy.Resource{}, cache_version) do
-    resource
-    # Determine early on if we're deleting, skipping, or updating.
-    |> initial_classification(cache_version)
-    # Add extra data
-    |> enrich(cache_version)
-    # Determine if after enrichment we should continue updating, delete, or skip.
-    |> post_classification(cache_version)
-  end
-
-  def process(fallthrough, _cache_version), do: fallthrough
-
-  @spec initial_classification(resource :: %Figgy.Resource{}, cache_version :: integer) ::
-          process_return()
-  def initial_classification(resource = %Figgy.Resource{id: id}, cache_version) do
-    case resource do
-      # Process open/complete indexable resources (EphemeraFolder, ScannedResource).
-      # ScannedResources are filtered by collection membership.
-      %{internal_resource: internal_resource, state: ["complete"], visibility: ["open"]}
-      when internal_resource in @indexable_resource_types ->
-        classify_open_resource(resource)
-
-      # Projects need to both update and get related.
-      %{internal_resource: "EphemeraProject"} ->
-        [{:update, resource}, {:update_related, resource}]
-
-      # Process things that could be related records
-      %{internal_resource: internal_resource} when internal_resource in @related_record_types ->
-        {:update_related, resource}
-
-      # Delete indexable resources that are already cached but no longer
-      # eligible (e.g. no longer open/complete), otherwise skip them.
-      %{internal_resource: internal_resource} when internal_resource in @indexable_resource_types ->
-        existing_resource = IndexingPipeline.get_hydration_cache_entry!(id, cache_version)
-
-        if existing_resource do
-          {:delete, resource}
-        else
-          {:skip, resource}
-        end
-
-      # Delete resources with DeletionMarkers if they're cached, otherwise skip.
-      %{
-        internal_resource: "DeletionMarker",
-        metadata_resource_id: [%{"id" => resource_id}],
-        metadata_resource_type: [resource_type]
-      }
-      when resource_type in @indexable_resource_types ->
-        existing_resource =
-          IndexingPipeline.get_hydration_cache_entry!(resource_id, cache_version)
-
-        if existing_resource do
-          {:delete, resource}
-        else
-          {:skip, resource}
-        end
-
-      _ ->
-        {:skip, resource}
-    end
-  end
-
-  defp classify_open_resource(%{internal_resource: "ScannedResource"} = resource) do
-    if member_of_allowed_collection?(resource) do
-      {:update, resource}
-    else
-      {:skip, resource}
-    end
-  end
-
-  defp classify_open_resource(resource), do: {:update, resource}
 
   defp member_of_allowed_collection?(%{member_of_collection_ids: nil}), do: false
 
@@ -367,137 +271,13 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     Enum.any?(collection_ids, &ResourceTypeRegistry.allowed_collection?/1)
   end
 
-  # If we got a list of them, enrich each one.
-  def enrich(process_list = [{_, _} | _], cache_version) do
-    process_list
-    |> Enum.map(&enrich(&1, cache_version))
+  def related_records(%{updated_at: timestamp, id: id}, cache_version) do
+    IndexingPipeline.get_related_hydration_cache_record_ids!(id, timestamp, cache_version)
+    |> Stream.flat_map(fn id ->
+      IndexingPipeline.get_figgy_resource!(id)
+      |> to_hydration_cache_entries(cache_version)
+    end)
   end
-
-  # If it's a related resource, get ids of all records dependent on this one
-  # one.
-  @spec process(process_return(), cache_version :: integer) :: process_return()
-  def enrich(
-        {:update_related,
-         %Figgy.Resource{id: id, updated_at: timestamp, internal_resource: internal_resource}},
-        cache_version
-      )
-      when internal_resource in @related_record_types do
-    related_record_ids =
-      IndexingPipeline.get_related_hydration_cache_record_ids!(id, timestamp, cache_version)
-
-    {
-      :update_related,
-      related_record_ids
-    }
-  end
-
-  # We don't have the full resource yet, fetch it and re-enrich.
-  def enrich({:update, %Figgy.Resource{id: id, metadata: nil}}, cache_version) do
-    enrich({:update, IndexingPipeline.get_figgy_resource!(id)}, cache_version)
-  end
-
-  # Resources we're updating need to become combined figgy resources.
-  def enrich({:update, resource}, _cache_version) do
-    combined_resource = Figgy.Resource.to_combined(resource)
-    {:update, combined_resource}
-  end
-
-  # Deletion markers need to become DeletionRecords
-  def enrich(
-        {:delete,
-         resource = %Figgy.Resource{
-           internal_resource: "DeletionMarker",
-           metadata_resource_id: [%{"id" => resource_id}],
-           metadata_resource_type: [resource_type]
-         }},
-        _cache_version
-      ) do
-    {:delete,
-     %Figgy.DeletionRecord{
-       marker: CacheEntryMarker.from(resource),
-       internal_resource: resource_type,
-       id: resource_id
-     }}
-  end
-
-  # Deleted resources need to become DeletionRecords
-  def enrich({:delete, resource = %Figgy.Resource{}}, _cache_version) do
-    {:delete,
-     %Figgy.DeletionRecord{
-       marker: CacheEntryMarker.from(resource),
-       internal_resource: resource.internal_resource,
-       id: resource.id
-     }}
-  end
-
-  def enrich(resource_and_classification, _cache_version), do: resource_and_classification
-
-  def post_classification(process_list = [{_, _} | _], cache_version) do
-    process_list
-    |> Enum.map(&post_classification(&1, cache_version))
-  end
-
-  # Published ephemera projects go through.
-  def post_classification(
-        {:update,
-         resource = %Figgy.CombinedFiggyResource{
-           resource: %{
-             id: id,
-             internal_resource: "EphemeraProject",
-             metadata: metadata
-           },
-           latest_updated_marker: marker
-         }},
-        cache_version
-      ) do
-    case metadata do
-      %{"publish" => ["1"]} ->
-        {:update, resource}
-
-      _ ->
-        # Delete if we've seen the project before.
-        existing_resource = IndexingPipeline.get_hydration_cache_entry!(id, cache_version)
-
-        if existing_resource do
-          {:delete,
-           %Figgy.DeletionRecord{
-             marker: marker,
-             internal_resource: resource.resource.internal_resource,
-             id: id
-           }}
-        else
-          {:skip, resource}
-        end
-    end
-  end
-
-  # Delete things which have no persisted members.
-  @spec post_classification(process_return(), cache_version :: integer) ::
-          process_return()
-  def post_classification(
-        {:update,
-         %Figgy.CombinedFiggyResource{
-           resource: resource,
-           persisted_member_ids: [],
-           latest_updated_marker: marker
-         }},
-        _cache_version
-      ) do
-    {:delete,
-     %Figgy.DeletionRecord{
-       marker: marker,
-       internal_resource: resource.internal_resource,
-       id: resource.id
-     }}
-  end
-
-  # A related resource returned an empty list, skip.
-  def post_classification({:update_related, []}, _cache_version) do
-    {:skip, []}
-  end
-
-  def post_classification(resource_and_classification, _cache_version),
-    do: resource_and_classification
 
   # If there's a bunch of actions, only no-op if all of them are skips.
   def store_result(process_list = [{_, _} | _], message) do
@@ -507,46 +287,12 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     end
   end
 
-  @spec store_result(process_return(), message :: Broadway.Message.t()) ::
-          Broadway.Message.t()
-  def store_result({:skip, _record}, message), do: Broadway.Message.put_batcher(message, :noop)
+  # @spec store_result(process_return(), message :: Broadway.Message.t()) ::
+  #         Broadway.Message.t()
+  # def store_result({:skip, _record}, message), do: Broadway.Message.put_batcher(message, :noop)
 
   def store_result(_, message),
     do: message
-
-  # to_hydration_cache_entries converts a list of actions into a stream of
-  # HydrationCacheEntries. We don't convert to a list so we don't store every
-  # resource in memory to save them later.
-  # If we're passed a bunch of process_returns, iterate.
-  defp to_hydration_cache_entries(action_list = [{_, _} | _], cache_version) do
-    action_list
-    |> Stream.flat_map(&to_hydration_cache_entries(&1, cache_version))
-  end
-
-  # If we're passed several IDs, process them in order and persist.
-  @spec to_hydration_cache_entries(process_return(), cache_version :: integer) ::
-          [%Figgy.HydrationCacheEntry{}] | []
-  defp to_hydration_cache_entries({:update_related, id_list = [id | _]}, cache_version)
-       when is_binary(id) do
-    # Do one at a time to prevent memory ballooning.
-    id_list
-    |> Stream.flat_map(fn id ->
-      IndexingPipeline.get_figgy_resource!(id)
-      |> process(cache_version)
-      |> to_hydration_cache_entries(cache_version)
-    end)
-  end
-
-  defp to_hydration_cache_entries({action, resource}, cache_version)
-       when action in [:delete, :update] do
-    # Maybe move to HydrationCacheEntry.from?
-    [HydrationCacheEntry.from(resource, cache_version)]
-  end
-
-  defp to_hydration_cache_entries({:skip, _}, _cache_version), do: []
-
-  # Fallthrough in case early_conversion handled it.
-  defp to_hydration_cache_entries(other, _cache_version), do: other
 
   def start_over!(cache_version) do
     String.to_atom("#{__MODULE__}_#{cache_version}")

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -127,62 +127,27 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   end
 
   # Ingest EphemeraFolders
-  def to_hydration_cache_entry(resource = %{internal_resource: "EphemeraFolder"}, cache_version) do
-    case resource do
-      # Process open/complete
-      %{state: ["complete"], visibility: ["open"]} ->
-        combined_figgy_resource = Figgy.Resource.to_combined(resource)
-        # Delete it it has no member_ids.
-        if combined_figgy_resource.persisted_member_ids == [] do
-          # NOTE: This is actually a bug, we shouldn't be creating a deletion
-          # record if we've never seen it, probably, but we have a test in
-          # FullIntegrationTest checking that it exists.
-          HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)
-        else
-          HydrationCacheEntry.from(combined_figgy_resource, cache_version)
-        end
+  def to_hydration_cache_entry(resource = %{internal_resource: internal_resource}, cache_version)
+      when internal_resource in @indexable_resource_types do
+    if process?(resource) do
+      combined_figgy_resource = Figgy.Resource.to_combined(resource)
+      # Delete it it has no member_ids.
+      if combined_figgy_resource.persisted_member_ids == [] do
+        # NOTE: This is actually a bug, we shouldn't be creating a deletion
+        # record if we've never seen it, probably, but we have a test in
+        # FullIntegrationTest checking that it exists.
+        HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)
+      else
+        HydrationCacheEntry.from(combined_figgy_resource, cache_version)
+      end
+    else
+      # Delete it if we've seen it before.
+      existing_resource =
+        IndexingPipeline.get_hydration_cache_entry!(resource.id, cache_version)
 
-      _ ->
-        # Delete it if we've seen it before.
-        existing_resource =
-          IndexingPipeline.get_hydration_cache_entry!(resource.id, cache_version)
-
-        if existing_resource do
-          HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)
-        end
-    end
-  end
-
-  # Ingest ScannedResources
-  def to_hydration_cache_entry(
-        resource = %{internal_resource: "ScannedResource"},
-        cache_version
-      ) do
-    case resource do
-      # Process open/complete
-      %{state: ["complete"], visibility: ["open"], member_of_collection_ids: [_ | _]} ->
-        if member_of_allowed_collection?(resource) do
-          combined_figgy_resource = Figgy.Resource.to_combined(resource)
-          # Delete it when it has no member_ids.
-          if combined_figgy_resource.persisted_member_ids == [] do
-            # NOTE: This is actually a bug, we shouldn't be creating a deletion
-            # record if we've never seen it, probably, but we have a test in
-            # FullIntegrationTest checking that it exists.
-
-            HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)
-          else
-            HydrationCacheEntry.from(combined_figgy_resource, cache_version)
-          end
-        end
-
-      _ ->
-        # Delete it if we've seen it before.
-        existing_resource =
-          IndexingPipeline.get_hydration_cache_entry!(resource.id, cache_version)
-
-        if existing_resource do
-          HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)
-        end
+      if existing_resource do
+        HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)
+      end
     end
   end
 
@@ -212,6 +177,34 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
 
   def to_hydration_cache_entry(_resource, _cache_version), do: nil
 
+  # Scanned resources must be complete, open, and a member of an allowed
+  # collection.
+  defp process?(
+         resource = %{
+           internal_resource: "ScannedResource",
+           state: ["complete"],
+           visibility: ["open"],
+           member_of_collection_ids: [_ | _]
+         }
+       ) do
+    if member_of_allowed_collection?(resource) do
+      true
+    else
+      false
+    end
+  end
+
+  # Ephemera Folders must be complete and open.
+  defp process?(%{
+         internal_resource: "EphemeraFolder",
+         state: ["complete"],
+         visibility: ["open"]
+       }) do
+    true
+  end
+
+  defp process?(_resource), do: false
+
   defp member_of_allowed_collection?(resource) do
     collection_ids = Enum.map(resource.member_of_collection_ids, & &1["id"])
     Enum.any?(collection_ids, &ResourceTypeRegistry.allowed_collection?/1)
@@ -223,7 +216,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
       )
       when internal_resource in @related_record_types do
     IndexingPipeline.get_related_hydration_cache_record_ids!(id, timestamp, cache_version)
-    |> Stream.flat_map(fn id ->
+    |> Stream.map(fn id ->
       IndexingPipeline.get_figgy_resource!(id)
       |> to_hydration_cache_entry(cache_version)
     end)

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -67,9 +67,19 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   end
 
   def process_and_persist(resource, cache_version) do
+    # Take a resource, convert it into a stream of hydration_cache_entries, then
+    # save them all.
     resource
     |> process(cache_version)
-    |> persist(cache_version)
+    |> to_hydration_cache_entries(cache_version)
+    |> save_all()
+  end
+
+  defp save_all(resources) do
+    resources
+    |> Enum.each(&IndexingPipeline.write_hydration_cache_entry/1)
+
+    {:ok, nil}
   end
 
   # Classification requires all figgy resources to have the virtual attributes
@@ -325,41 +335,51 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   def post_classification(resource_and_classification, _cache_version),
     do: resource_and_classification
 
-  # If we're passed a bunch of process_returns, iterate.
-  defp persist(action_list = [{_, _} | _], cache_version) do
-    action_list
-    |> Enum.each(&persist(&1, cache_version))
+  # If there's a bunch of actions, only no-op if all of them are skips.
+  def store_result(process_list = [{_, _} | _], message) do
+    case Enum.filter(process_list, fn {action, _} -> action != :skip end) do
+      [] -> Broadway.Message.put_batcher(message, :noop)
+      _ -> message
+    end
+  end
 
-    # Return the action_list with data stripped..
+  @spec store_result(process_return(), message :: Broadway.Message.t()) ::
+          Broadway.Message.t()
+  def store_result({:skip, _record}, message), do: Broadway.Message.put_batcher(message, :noop)
+
+  def store_result(_, message),
+    do: message
+
+  # to_hydration_cache_entries converts a list of actions into a stream of
+  # HydrationCacheEntries. We don't convert to a list so we don't store every
+  # resource in memory to save them later.
+  # If we're passed a bunch of process_returns, iterate.
+  defp to_hydration_cache_entries(action_list = [{_, _} | _], cache_version) do
     action_list
-    |> Enum.map(fn {action, _} -> {action, nil} end)
+    |> Stream.flat_map(&to_hydration_cache_entries(&1, cache_version))
   end
 
   # If we're passed several IDs, process them in order and persist.
-  @spec persist(process_return(), cache_version :: integer) ::
-          {:ok, %Figgy.HydrationCacheEntry{}}
-  defp persist(update = {:update_related, id_list = [id | _]}, cache_version)
+  @spec to_hydration_cache_entries(process_return(), cache_version :: integer) ::
+          [%Figgy.HydrationCacheEntry{}] | []
+  defp to_hydration_cache_entries({:update_related, id_list = [id | _]}, cache_version)
        when is_binary(id) do
     # Do one at a time to prevent memory ballooning.
     id_list
-    |> Enum.each(fn id ->
+    |> Stream.flat_map(fn id ->
       IndexingPipeline.get_figgy_resource!(id)
-      |> process_and_persist(cache_version)
+      |> process(cache_version)
+      |> to_hydration_cache_entries(cache_version)
     end)
-
-    update
   end
 
-  defp persist({action, resource}, cache_version)
+  defp to_hydration_cache_entries({action, resource}, cache_version)
        when action in [:delete, :update] do
     # Maybe move to HydrationCacheEntry.from?
-    {:ok, _response} =
-      resource
-      |> HydrationCacheEntry.from(cache_version)
-      |> IndexingPipeline.write_hydration_cache_entry()
+    [HydrationCacheEntry.from(resource, cache_version)]
   end
 
-  defp persist({:skip, _}, _cache_version), do: {:skip, nil}
+  defp to_hydration_cache_entries({:skip, _}, _cache_version), do: []
 
   def start_over!(cache_version) do
     String.to_atom("#{__MODULE__}_#{cache_version}")

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -146,6 +146,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
             internal_resource: resource.internal_resource,
             id: resource.id
           }
+
           [HydrationCacheEntry.from(deletion_record, cache_version)]
         else
           [HydrationCacheEntry.from(combined_figgy_resource, cache_version)]
@@ -170,8 +171,52 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     end
   end
 
+  def early_conversion(resource = %{internal_resource: "EphemeraProject", id: id}, cache_version) do
+    combined_resource = Figgy.Resource.to_combined(resource)
+
+    Stream.concat(
+      case combined_resource.resource.metadata do
+        %{"publish" => ["1"]} ->
+          # Save published EphemeraProjects, update related records
+          [HydrationCacheEntry.from(combined_resource, cache_version)]
+
+        _ ->
+          # Delete if we've seen it before
+          existing_resource = IndexingPipeline.get_hydration_cache_entry!(id, cache_version)
+
+          if existing_resource do
+            deletion_record = %Figgy.DeletionRecord{
+              marker: combined_resource.latest_updated_marker,
+              internal_resource: "EphemeraProject",
+              id: id
+            }
+
+            [HydrationCacheEntry.from(deletion_record, cache_version)]
+          else
+            []
+          end
+      end,
+      related_records(resource, cache_version)
+    )
+  end
+
+  def early_conversion(resource = %{internal_resource: internal_resource}, cache_version)
+      when internal_resource in @related_record_types do
+    related_records(resource, cache_version)
+  end
+
   def early_conversion(resource, _cache_version) do
     resource
+  end
+
+  def related_records(%{updated_at: timestamp, id: id}, cache_version) do
+    IndexingPipeline.get_related_hydration_cache_record_ids!(id, timestamp, cache_version)
+    |> Stream.flat_map(fn id ->
+      IndexingPipeline.get_figgy_resource!(id)
+      |> early_conversion(cache_version)
+      |> process(cache_version)
+      |> to_hydration_cache_entries(cache_version)
+    end)
   end
 
   # Allow fall-through if early conversion solved it already.
@@ -198,7 +243,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     process(Figgy.Resource.populate_virtual(resource), cache_version)
   end
 
-  def process(resource, cache_version) do
+  def process(resource = %Figgy.Resource{}, cache_version) do
     resource
     # Determine early on if we're deleting, skipping, or updating.
     |> initial_classification(cache_version)
@@ -207,6 +252,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     # Determine if after enrichment we should continue updating, delete, or skip.
     |> post_classification(cache_version)
   end
+
+  def process(fallthrough, _cache_version), do: fallthrough
 
   @spec initial_classification(resource :: %Figgy.Resource{}, cache_version :: integer) ::
           process_return()

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -66,11 +66,15 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   end
 
   def process_and_persist(resource, cache_version) do
-    # Take a resource, convert it into a stream of hydration_cache_entries, then
-    # save them all.
-    resource
-    |> to_hydration_cache_entries(cache_version)
-    |> save_all()
+    # Convert the resource to a cache entry and append any related records, then
+    # save all of them together.
+    all_resources =
+      Stream.concat(
+        to_hydration_cache_entries(resource, cache_version),
+        related_records(resource, cache_version)
+      )
+
+    save_all(all_resources)
   end
 
   defp save_all(resources) do
@@ -196,51 +200,48 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
       ) do
     combined_resource = Figgy.Resource.to_combined(resource)
 
-    Stream.concat(
-      case combined_resource.resource.metadata do
-        %{"publish" => ["1"]} ->
-          # Save published EphemeraProjects, update related records
-          [HydrationCacheEntry.from(combined_resource, cache_version)]
+    case combined_resource.resource.metadata do
+      %{"publish" => ["1"]} ->
+        # Save published EphemeraProjects, update related records
+        [HydrationCacheEntry.from(combined_resource, cache_version)]
 
-        _ ->
-          # Delete if we've seen it before
-          existing_resource = IndexingPipeline.get_hydration_cache_entry!(id, cache_version)
+      _ ->
+        # Delete if we've seen it before
+        existing_resource = IndexingPipeline.get_hydration_cache_entry!(id, cache_version)
 
-          if existing_resource do
-            [
-              HydrationCacheEntry.from(
-                Figgy.DeletionRecord.from(combined_resource),
-                cache_version
-              )
-            ]
-          else
-            []
-          end
-      end,
-      related_records(resource, cache_version)
-    )
+        if existing_resource do
+          [
+            HydrationCacheEntry.from(
+              Figgy.DeletionRecord.from(combined_resource),
+              cache_version
+            )
+          ]
+        else
+          []
+        end
+    end
   end
 
-  def to_hydration_cache_entries(
-        resource = %{internal_resource: internal_resource},
-        cache_version
-      )
-      when internal_resource in @related_record_types do
-    related_records(resource, cache_version)
-  end
+  def to_hydration_cache_entries(_resource, _cache_version), do: []
 
   defp member_of_allowed_collection?(resource) do
     collection_ids = Enum.map(resource.member_of_collection_ids, & &1["id"])
     Enum.any?(collection_ids, &ResourceTypeRegistry.allowed_collection?/1)
   end
 
-  def related_records(%{updated_at: timestamp, id: id}, cache_version) do
+  def related_records(
+        %{updated_at: timestamp, id: id, internal_resource: internal_resource},
+        cache_version
+      )
+      when internal_resource in @related_record_types do
     IndexingPipeline.get_related_hydration_cache_record_ids!(id, timestamp, cache_version)
     |> Stream.flat_map(fn id ->
       IndexingPipeline.get_figgy_resource!(id)
       |> to_hydration_cache_entries(cache_version)
     end)
   end
+
+  def related_records(_resource, _cache_version), do: []
 
   def start_over!(cache_version) do
     String.to_atom("#{__MODULE__}_#{cache_version}")

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -70,6 +70,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     # Take a resource, convert it into a stream of hydration_cache_entries, then
     # save them all.
     resource
+    |> early_conversion(cache_version)
     |> process(cache_version)
     |> to_hydration_cache_entries(cache_version)
     |> save_all()
@@ -81,6 +82,63 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
 
     {:ok, nil}
   end
+
+  @indexable_resource_types ResourceTypeRegistry.indexable_types()
+  @related_record_types ResourceTypeRegistry.related_record_types()
+  @processed_types ResourceTypeRegistry.processed_types()
+  # Immediately skip anything not in processed_types.
+  def early_conversion(%{internal_resource: internal_resource}, _cache_version)
+      when internal_resource not in @processed_types do
+    []
+  end
+
+  # DeletionMarkers delete any records it's pointing to it if they've been
+  # processed before.
+  def early_conversion(resource = %{internal_resource: "DeletionMarker"}, cache_version) do
+    case resource do
+      %{
+        metadata_resource_id: [%{"id" => resource_id}],
+        metadata_resource_type: [resource_type]
+      }
+      when resource_type in @indexable_resource_types ->
+        existing_resource =
+          IndexingPipeline.get_hydration_cache_entry!(resource_id, cache_version)
+
+        if existing_resource do
+          deletion_record = %Figgy.DeletionRecord{
+            marker: CacheEntryMarker.from(resource),
+            internal_resource: resource_type,
+            id: resource_id
+          }
+
+          [HydrationCacheEntry.from(deletion_record, cache_version)]
+        else
+          []
+        end
+
+      _ ->
+        []
+    end
+  end
+
+  # Collections only update if they're allowed.
+  def early_conversion(resource = %{internal_resource: "Collection", id: id}, cache_version) do
+    if ResourceTypeRegistry.allowed_collection?(id) do
+      [HydrationCacheEntry.from(resource, cache_version)]
+    else
+      []
+    end
+  end
+
+  def early_conversion(resource, _cache_version) do
+    resource
+  end
+
+  # Allow fall-through if early conversion solved it already.
+  def process(cache_entry = %HydrationCacheEntry{}, _cache_version), do: cache_entry
+  def process(cache_entries = [%HydrationCacheEntry{} | _], _cache_version), do: cache_entries
+  def process(cache_entries = %Stream{}, _cache_version), do: cache_entries
+  def process([], _cache_version), do: []
 
   # Classification requires all figgy resources to have the virtual attributes
   # set. Resources pulled by the hydrator via `get_figgy_resources_since!` have
@@ -100,8 +158,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     process(Figgy.Resource.populate_virtual(resource), cache_version)
   end
 
-  @indexable_resource_types ResourceTypeRegistry.indexable_types()
-  @related_record_types ResourceTypeRegistry.related_record_types()
   def process(resource, cache_version) do
     resource
     # Determine early on if we're deleting, skipping, or updating.
@@ -121,14 +177,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
       %{internal_resource: internal_resource, state: ["complete"], visibility: ["open"]}
       when internal_resource in @indexable_resource_types ->
         classify_open_resource(resource)
-
-      # Collections need to both update
-      %{internal_resource: "Collection"} ->
-        if ResourceTypeRegistry.allowed_collection?(id) do
-          {:update, resource}
-        else
-          {:skip, resource}
-        end
 
       # Projects need to both update and get related.
       %{internal_resource: "EphemeraProject"} ->
@@ -291,22 +339,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     end
   end
 
-  # Collections go through.
-  def post_classification(
-        {:update,
-         resource = %Figgy.CombinedFiggyResource{
-           resource: %{
-             internal_resource: "Collection"
-           }
-         }},
-        _cache_version
-      ) do
-    {:update, resource}
-  end
-
-  # Every other ephemera project does not.
-  #
-
   # Delete things which have no persisted members.
   @spec post_classification(process_return(), cache_version :: integer) ::
           process_return()
@@ -380,6 +412,9 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   end
 
   defp to_hydration_cache_entries({:skip, _}, _cache_version), do: []
+
+  # Fallthrough in case early_conversion handled it.
+  defp to_hydration_cache_entries(other, _cache_version), do: other
 
   def start_over!(cache_version) do
     String.to_atom("#{__MODULE__}_#{cache_version}")

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -130,6 +130,32 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     end
   end
 
+  # Ingest EphemeraFolders
+  def early_conversion(resource = %{internal_resource: "EphemeraFolder"}, cache_version) do
+    case resource do
+      # Process open/complete
+      %{state: ["complete"], visibility: ["open"]} ->
+        [HydrationCacheEntry.from(resource, cache_version)]
+
+      _ ->
+        # Delete it if we've seen it before.
+        existing_resource =
+          IndexingPipeline.get_hydration_cache_entry!(resource.id, cache_version)
+
+        if existing_resource do
+          deletion_record = %Figgy.DeletionRecord{
+            marker: CacheEntryMarker.from(resource),
+            internal_resource: resource.internal_resource,
+            id: resource.id
+          }
+
+          [HydrationCacheEntry.from(deletion_record, cache_version)]
+        else
+          []
+        end
+    end
+  end
+
   def early_conversion(resource, _cache_version) do
     resource
   end

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -2,7 +2,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   @moduledoc """
   Broadway consumer that demands Figgy records and caches them in the database.
   """
-  alias DpulCollections.IndexingPipeline.DatabaseProducer.CacheEntryMarker
   alias DpulCollections.IndexingPipeline
   alias DpulCollections.IndexingPipeline.Figgy
   alias DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntry
@@ -103,13 +102,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
           IndexingPipeline.get_hydration_cache_entry!(resource_id, cache_version)
 
         if existing_resource do
-          deletion_record = %Figgy.DeletionRecord{
-            marker: CacheEntryMarker.from(resource),
-            internal_resource: resource_type,
-            id: resource_id
-          }
-
-          [HydrationCacheEntry.from(deletion_record, cache_version)]
+          [HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)]
         else
           []
         end
@@ -142,13 +135,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
           # NOTE: This is actually a bug, we shouldn't be creating a deletion
           # record if we've never seen it, probably, but we have a test in
           # FullIntegrationTest checking that it exists.
-          deletion_record = %Figgy.DeletionRecord{
-            marker: CacheEntryMarker.from(resource),
-            internal_resource: resource.internal_resource,
-            id: resource.id
-          }
-
-          [HydrationCacheEntry.from(deletion_record, cache_version)]
+          [HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)]
         else
           [HydrationCacheEntry.from(combined_figgy_resource, cache_version)]
         end
@@ -159,13 +146,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
           IndexingPipeline.get_hydration_cache_entry!(resource.id, cache_version)
 
         if existing_resource do
-          deletion_record = %Figgy.DeletionRecord{
-            marker: CacheEntryMarker.from(resource),
-            internal_resource: resource.internal_resource,
-            id: resource.id
-          }
-
-          [HydrationCacheEntry.from(deletion_record, cache_version)]
+          [HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)]
         else
           []
         end
@@ -187,13 +168,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
             # NOTE: This is actually a bug, we shouldn't be creating a deletion
             # record if we've never seen it, probably, but we have a test in
             # FullIntegrationTest checking that it exists.
-            deletion_record = %Figgy.DeletionRecord{
-              marker: CacheEntryMarker.from(resource),
-              internal_resource: resource.internal_resource,
-              id: resource.id
-            }
 
-            [HydrationCacheEntry.from(deletion_record, cache_version)]
+            [HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)]
           else
             [HydrationCacheEntry.from(combined_figgy_resource, cache_version)]
           end
@@ -207,13 +183,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
           IndexingPipeline.get_hydration_cache_entry!(resource.id, cache_version)
 
         if existing_resource do
-          deletion_record = %Figgy.DeletionRecord{
-            marker: CacheEntryMarker.from(resource),
-            internal_resource: resource.internal_resource,
-            id: resource.id
-          }
-
-          [HydrationCacheEntry.from(deletion_record, cache_version)]
+          [HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)]
         else
           []
         end
@@ -237,13 +207,12 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
           existing_resource = IndexingPipeline.get_hydration_cache_entry!(id, cache_version)
 
           if existing_resource do
-            deletion_record = %Figgy.DeletionRecord{
-              marker: combined_resource.latest_updated_marker,
-              internal_resource: "EphemeraProject",
-              id: id
-            }
-
-            [HydrationCacheEntry.from(deletion_record, cache_version)]
+            [
+              HydrationCacheEntry.from(
+                Figgy.DeletionRecord.from(combined_resource),
+                cache_version
+              )
+            ]
           else
             []
           end

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -229,10 +229,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     related_records(resource, cache_version)
   end
 
-  def to_hydration_cache_entries(resource, _cache_version) do
-    resource
-  end
-
   defp member_of_allowed_collection?(%{member_of_collection_ids: nil}), do: false
 
   defp member_of_allowed_collection?(resource) do
@@ -246,14 +242,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
       IndexingPipeline.get_figgy_resource!(id)
       |> to_hydration_cache_entries(cache_version)
     end)
-  end
-
-  # If there's a bunch of actions, only no-op if all of them are skips.
-  def store_result(process_list = [{_, _} | _], message) do
-    case Enum.filter(process_list, fn {action, _} -> action != :skip end) do
-      [] -> Broadway.Message.put_batcher(message, :noop)
-      _ -> message
-    end
   end
 
   # @spec store_result(process_return(), message :: Broadway.Message.t()) ::

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -126,7 +126,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     end
   end
 
-  # Ingest EphemeraFolders
+  # Ingest EphemeraFolders / ScannedResources
   def to_hydration_cache_entry(resource = %{internal_resource: internal_resource}, cache_version)
       when internal_resource in @indexable_resource_types do
     if process?(resource) do

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -135,7 +135,21 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     case resource do
       # Process open/complete
       %{state: ["complete"], visibility: ["open"]} ->
-        [HydrationCacheEntry.from(resource, cache_version)]
+        combined_figgy_resource = Figgy.Resource.to_combined(resource)
+        # Delete it it has no member_ids.
+        if combined_figgy_resource.persisted_member_ids == [] do
+          # NOTE: This is actually a bug, we shouldn't be creating a deletion
+          # record if we've never seen it, probably, but we have a test in
+          # FullIntegrationTest checking that it exists.
+          deletion_record = %Figgy.DeletionRecord{
+            marker: CacheEntryMarker.from(resource),
+            internal_resource: resource.internal_resource,
+            id: resource.id
+          }
+          [HydrationCacheEntry.from(deletion_record, cache_version)]
+        else
+          [HydrationCacheEntry.from(combined_figgy_resource, cache_version)]
+        end
 
       _ ->
         # Delete it if we've seen it before.

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -95,7 +95,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     nil
   end
 
-  # DeletionMarkers delete any records it's pointing to it if they've been
+  # DeletionMarkers delete any records it's pointing to if they've been
   # processed before.
   def to_hydration_cache_entry(resource = %{internal_resource: "DeletionMarker"}, cache_version) do
     case resource do
@@ -104,12 +104,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
         metadata_resource_type: [resource_type]
       }
       when resource_type in @indexable_resource_types ->
-        existing_resource =
-          IndexingPipeline.get_hydration_cache_entry!(resource_id, cache_version)
-
-        if existing_resource do
-          HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)
-        end
+        delete_if_seen(resource_id, resource, cache_version)
 
       _ ->
         nil
@@ -131,23 +126,18 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
       when internal_resource in @indexable_resource_types do
     if process?(resource) do
       combined_figgy_resource = Figgy.Resource.to_combined(resource)
-      # Delete it it has no member_ids.
+
+      # Delete if it has no member_ids.
+      # NOTE: This is actually a bug, we shouldn't be creating a deletion
+      # record if we've never seen it, probably, but we have a test in
+      # FullIntegrationTest checking that it exists.
       if combined_figgy_resource.persisted_member_ids == [] do
-        # NOTE: This is actually a bug, we shouldn't be creating a deletion
-        # record if we've never seen it, probably, but we have a test in
-        # FullIntegrationTest checking that it exists.
         HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)
       else
         HydrationCacheEntry.from(combined_figgy_resource, cache_version)
       end
     else
-      # Delete it if we've seen it before.
-      existing_resource =
-        IndexingPipeline.get_hydration_cache_entry!(resource.id, cache_version)
-
-      if existing_resource do
-        HydrationCacheEntry.from(Figgy.DeletionRecord.from(resource), cache_version)
-      end
+      delete_if_seen(resource.id, resource, cache_version)
     end
   end
 
@@ -159,19 +149,10 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
 
     case combined_resource.resource.metadata do
       %{"publish" => ["1"]} ->
-        # Save published EphemeraProjects, update related records
         HydrationCacheEntry.from(combined_resource, cache_version)
 
       _ ->
-        # Delete if we've seen it before
-        existing_resource = IndexingPipeline.get_hydration_cache_entry!(id, cache_version)
-
-        if existing_resource do
-          HydrationCacheEntry.from(
-            Figgy.DeletionRecord.from(combined_resource),
-            cache_version
-          )
-        end
+        delete_if_seen(id, combined_resource, cache_version)
     end
   end
 
@@ -187,11 +168,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
            member_of_collection_ids: [_ | _]
          }
        ) do
-    if member_of_allowed_collection?(resource) do
-      true
-    else
-      false
-    end
+    member_of_allowed_collection?(resource)
   end
 
   # Ephemera Folders must be complete and open.
@@ -204,6 +181,12 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
   end
 
   defp process?(_resource), do: false
+
+  defp delete_if_seen(record_id, source, cache_version) do
+    if IndexingPipeline.get_hydration_cache_entry!(record_id, cache_version) do
+      HydrationCacheEntry.from(Figgy.DeletionRecord.from(source), cache_version)
+    end
+  end
 
   defp member_of_allowed_collection?(resource) do
     collection_ids = Enum.map(resource.member_of_collection_ids, & &1["id"])

--- a/lib/dpul_collections/indexing_pipeline/figgy/resource.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/resource.ex
@@ -52,6 +52,11 @@ defmodule DpulCollections.IndexingPipeline.Figgy.Resource do
   def populate_virtual(resource), do: resource
 
   @spec to_combined(%__MODULE__{}) :: %Figgy.CombinedFiggyResource{}
+  def to_combined(%Figgy.Resource{id: id, metadata: nil}) do
+    IndexingPipeline.get_figgy_resource!(id)
+    |> to_combined()
+  end
+
   def to_combined(resource = %Figgy.Resource{metadata: %{"member_ids" => member_ids}}) do
     related_data = extract_related_data(resource)
 

--- a/lib/dpul_collections/indexing_pipeline/figgy/resource_type_registry.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/resource_type_registry.ex
@@ -15,6 +15,10 @@ defmodule DpulCollections.IndexingPipeline.Figgy.ResourceTypeRegistry do
   # Types used in the transformation pipeline
   @transformable_types @indexable_types ++ @collection_types
 
+  # Types that are processed at all.
+  @processed_types @indexable_types ++
+                     @collection_types ++ @related_record_types ++ ["DeletionMarker"]
+
   # Temporary restrictions to allow gradual ingest of different types
   @allowed_collections ["52abe8f7-e2a1-46e9-9d13-3dc4fbc0bf0a"]
 
@@ -22,5 +26,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.ResourceTypeRegistry do
   def collection_types, do: @collection_types
   def related_record_types, do: @related_record_types
   def transformable_types, do: @transformable_types
+  def processed_types, do: @processed_types
   def allowed_collection?(id), do: id in @allowed_collections
 end

--- a/lib/dpul_collections/indexing_pipeline/figgy/transformation_producer_source.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/transformation_producer_source.ex
@@ -21,7 +21,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationProducerSource do
 
     :telemetry.attach(
       "hydration-listener-#{producer_pid |> :erlang.pid_to_list()}",
-      [:broadway, :processor, :stop],
+      [:broadway, :batch_processor, :stop],
       &handle_batch_closed(&1, &2, &3, &4, cache_version),
       %{producer_pid: producer_pid}
     )

--- a/lib/dpul_collections/indexing_pipeline/figgy/transformation_producer_source.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/transformation_producer_source.ex
@@ -21,7 +21,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationProducerSource do
 
     :telemetry.attach(
       "hydration-listener-#{producer_pid |> :erlang.pid_to_list()}",
-      [:broadway, :batch_processor, :stop],
+      [:broadway, :processor, :stop],
       &handle_batch_closed(&1, &2, &3, &4, cache_version),
       %{producer_pid: producer_pid}
     )

--- a/test/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry_test.exs
@@ -13,8 +13,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntryTest do
           (%Resource{} = folder)
           | metadata: %{folder.metadata | "genre" => [%{"id" => ""}]}
         }
-        |> HydrationConsumer.to_hydration_cache_entries(1)
-        |> Enum.at(0)
+        |> HydrationConsumer.to_hydration_cache_entry(1)
         |> get_in([Access.key!(:related_data)])
         |> get_in(["resources"])
         |> Map.keys()
@@ -28,8 +27,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntryTest do
 
       metadata =
         folder
-        |> HydrationConsumer.to_hydration_cache_entries(1)
-        |> Enum.at(0)
+        |> HydrationConsumer.to_hydration_cache_entry(1)
         |> get_in([Access.key!(:data)])
         |> get_in([Access.key!(:metadata)])
 
@@ -41,8 +39,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntryTest do
 
       metadata =
         %Resource{(%Resource{} = folder) | metadata: %{folder.metadata | "member_ids" => []}}
-        |> HydrationConsumer.to_hydration_cache_entries(1)
-        |> Enum.at(0)
+        |> HydrationConsumer.to_hydration_cache_entry(1)
         |> get_in([Access.key!(:data)])
         |> get_in([Access.key!(:metadata)])
 
@@ -64,8 +61,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntryTest do
           (%Resource{} = folder)
           | metadata: %{folder.metadata | "member_ids" => member_ids}
         }
-        |> HydrationConsumer.to_hydration_cache_entries(1)
-        |> Enum.at(0)
+        |> HydrationConsumer.to_hydration_cache_entry(1)
         |> get_in([Access.key!(:related_data)])
         |> get_in(["resources"])
         |> Map.keys()
@@ -78,8 +74,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntryTest do
 
       resource_ids =
         folder
-        |> HydrationConsumer.to_hydration_cache_entries(1)
-        |> Enum.at(0)
+        |> HydrationConsumer.to_hydration_cache_entry(1)
         |> get_in([Access.key!(:related_data)])
         |> get_in(["resources"])
         |> Map.keys()

--- a/test/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/hydration_cache_entry_test.exs
@@ -2,7 +2,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntryTest do
   use DpulCollections.DataCase
 
   alias DpulCollections.IndexingPipeline
-  alias DpulCollections.IndexingPipeline.Figgy.{Resource, HydrationConsumer, HydrationCacheEntry}
+  alias DpulCollections.IndexingPipeline.Figgy.{Resource, HydrationConsumer}
 
   describe "from/2" do
     test "it doesn't error when the related resource id is an empty string" do
@@ -13,9 +13,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntryTest do
           (%Resource{} = folder)
           | metadata: %{folder.metadata | "genre" => [%{"id" => ""}]}
         }
-        |> HydrationConsumer.process(1)
-        |> elem(1)
-        |> HydrationCacheEntry.from(1)
+        |> HydrationConsumer.to_hydration_cache_entries(1)
+        |> Enum.at(0)
         |> get_in([Access.key!(:related_data)])
         |> get_in(["resources"])
         |> Map.keys()
@@ -29,9 +28,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntryTest do
 
       metadata =
         folder
-        |> HydrationConsumer.process(1)
-        |> elem(1)
-        |> HydrationCacheEntry.from(1)
+        |> HydrationConsumer.to_hydration_cache_entries(1)
+        |> Enum.at(0)
         |> get_in([Access.key!(:data)])
         |> get_in([Access.key!(:metadata)])
 
@@ -43,9 +41,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntryTest do
 
       metadata =
         %Resource{(%Resource{} = folder) | metadata: %{folder.metadata | "member_ids" => []}}
-        |> HydrationConsumer.process(1)
-        |> elem(1)
-        |> HydrationCacheEntry.from(1)
+        |> HydrationConsumer.to_hydration_cache_entries(1)
+        |> Enum.at(0)
         |> get_in([Access.key!(:data)])
         |> get_in([Access.key!(:metadata)])
 
@@ -67,9 +64,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntryTest do
           (%Resource{} = folder)
           | metadata: %{folder.metadata | "member_ids" => member_ids}
         }
-        |> HydrationConsumer.process(1)
-        |> elem(1)
-        |> HydrationCacheEntry.from(1)
+        |> HydrationConsumer.to_hydration_cache_entries(1)
+        |> Enum.at(0)
         |> get_in([Access.key!(:related_data)])
         |> get_in(["resources"])
         |> Map.keys()
@@ -82,9 +78,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationCacheEntryTest do
 
       resource_ids =
         folder
-        |> HydrationConsumer.process(1)
-        |> elem(1)
-        |> HydrationCacheEntry.from(1)
+        |> HydrationConsumer.to_hydration_cache_entries(1)
+        |> Enum.at(0)
         |> get_in([Access.key!(:related_data)])
         |> get_in(["resources"])
         |> Map.keys()

--- a/test/dpul_collections/indexing_pipeline/figgy/resource_type_registry_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/resource_type_registry_test.exs
@@ -35,4 +35,20 @@ defmodule DpulCollections.IndexingPipeline.Figgy.ResourceTypeRegistryTest do
              ]
     end
   end
+
+  describe "processed types" do
+    test "processed_types returns a list" do
+      assert ResourceTypeRegistry.processed_types() == [
+               "EphemeraFolder",
+               "ScannedResource",
+               "EphemeraProject",
+               "Collection",
+               "EphemeraProject",
+               "EphemeraBox",
+               "EphemeraTerm",
+               "FileSet",
+               "DeletionMarker"
+             ]
+    end
+  end
 end

--- a/test/support/figgy_test_support.ex
+++ b/test/support/figgy_test_support.ex
@@ -69,11 +69,10 @@ defmodule FiggyTestSupport do
     marker = IndexingPipeline.DatabaseProducer.CacheEntryMarker.from(record)
 
     cache_attrs =
-      Figgy.HydrationConsumer.to_hydration_cache_entries(
+      Figgy.HydrationConsumer.to_hydration_cache_entry(
         IndexingPipeline.Figgy.Resource.populate_virtual(record),
         1
       )
-      |> Enum.at(0)
 
     {:ok, cache_entry} =
       IndexingPipeline.write_hydration_cache_entry(%{

--- a/test/support/figgy_test_support.ex
+++ b/test/support/figgy_test_support.ex
@@ -29,6 +29,7 @@ defmodule FiggyTestSupport do
     # This doesn't literally pull the first one, just the one we've been using
     # as the first so far.
     FiggyRepo.get!(Figgy.Resource, "2ebc1872-eb41-4bc6-a523-5069108bf504")
+    |> Figgy.Resource.populate_virtual()
   end
 
   def ephemera_folder_count do
@@ -68,9 +69,11 @@ defmodule FiggyTestSupport do
     marker = IndexingPipeline.DatabaseProducer.CacheEntryMarker.from(record)
 
     cache_attrs =
-      Figgy.HydrationConsumer.process(record, 1)
-      |> elem(1)
-      |> Figgy.HydrationCacheEntry.from(1)
+      Figgy.HydrationConsumer.to_hydration_cache_entries(
+        IndexingPipeline.Figgy.Resource.populate_virtual(record),
+        1
+      )
+      |> Enum.at(0)
 
     {:ok, cache_entry} =
       IndexingPipeline.write_hydration_cache_entry(%{


### PR DESCRIPTION
Trying out the Sandi Metz method to try refactoring HydrationConsumer, it's been interesting.

Theory is that if we back out all the classification stuff some cleaner refactors might become clear.

May not merge, just wanted to share. Commits show process.

Some refactors from here to try might be:

- [x] Extract related record handling to its own method and explicitly call it rather than have it part of the type
- [x] Extract consistent logic around "delete if exists"
- [x] Maybe extract some sort of `.process?` method?

This should be merge-able whenever, I think it's easier to read now than before and makes it clearer where opportunities to refactor are from here.