### PR TITLE
[Performance] Don't parse metadata from producer.

### DIFF
--- a/config/deploy/solr/staging.json
+++ b/config/deploy/solr/staging.json
@@ -9,6 +9,12 @@
       "base_url": "http://lib-solr9-staging.princeton.edu:8983",
       "collection": "dpulc9",
       "config_set": "dpulc-staging"
+    },
+    {
+      "cache_version": 10,
+      "base_url": "http://lib-solr9-staging.princeton.edu:8983",
+      "collection": "dpulc10",
+      "config_set": "dpulc-staging"
     }
   ]
 }

--- a/lib/dpul_collections/indexing_pipeline.ex
+++ b/lib/dpul_collections/indexing_pipeline.ex
@@ -407,14 +407,7 @@ defmodule DpulCollections.IndexingPipeline do
             (r.updated_at >= ^updated_at and
                (r.updated_at > ^updated_at or r.id > ^id) and
                r.updated_at < ^poll_delay),
-        select: %{
-          struct(r, [:id, :updated_at, :internal_resource])
-          | visibility: fragment("metadata->'visibility'"),
-            state: fragment("metadata->'state'"),
-            member_of_collection_ids: fragment("metadata->'member_of_collection_ids'"),
-            metadata_resource_id: fragment("metadata->'resource_id'"),
-            metadata_resource_type: fragment("metadata->'resource_type'")
-        },
+        select: struct(r, [:id, :updated_at, :internal_resource]),
         limit: ^count,
         order_by: [asc: r.updated_at, asc: r.id]
 
@@ -430,14 +423,7 @@ defmodule DpulCollections.IndexingPipeline do
     query =
       from r in Figgy.Resource,
         where: r.internal_resource != "Event" and r.internal_resource != "PreservationObject",
-        select: %{
-          struct(r, [:id, :updated_at, :internal_resource])
-          | visibility: fragment("metadata->'visibility'"),
-            state: fragment("metadata->'state'"),
-            metadata_resource_id: fragment("metadata->'resource_id'"),
-            member_of_collection_ids: fragment("metadata->'member_of_collection_ids'"),
-            metadata_resource_type: fragment("metadata->'resource_type'")
-        },
+        select: struct(r, [:id, :updated_at, :internal_resource]),
         limit: ^count,
         order_by: [asc: r.updated_at, asc: r.id]
 

--- a/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/hydration_consumer.ex
@@ -96,6 +96,11 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumer do
     nil
   end
 
+  # Pull all the metadata if we're gonna process it.
+  def to_hydration_cache_entry(%{id: id, metadata: nil}, cache_version) do
+    to_hydration_cache_entry(IndexingPipeline.get_figgy_resource!(id), cache_version)
+  end
+
   # DeletionMarkers delete any records it's pointing to if they've been
   # processed before.
   def to_hydration_cache_entry(resource = %{internal_resource: "DeletionMarker"}, cache_version) do

--- a/lib/dpul_collections/indexing_pipeline/figgy/resource.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/resource.ex
@@ -51,11 +51,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.Resource do
   def populate_virtual(resource), do: resource
 
   @spec to_combined(%__MODULE__{}) :: %Figgy.CombinedFiggyResource{}
-  def to_combined(%Figgy.Resource{id: id, metadata: nil}) do
-    IndexingPipeline.get_figgy_resource!(id)
-    |> to_combined()
-  end
-
   def to_combined(resource = %Figgy.Resource{metadata: %{"member_ids" => member_ids}}) do
     related_data = extract_related_data(resource)
 

--- a/test/dpul_collections/indexing_pipeline/figgy/hydration_consumer_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/hydration_consumer_test.exs
@@ -21,8 +21,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         id: "561ea64a-9cd1-4994-b2a7-ac169f33ba84",
         updated_at: ~U[2024-04-18 14:28:57.526110Z],
         internal_resource: "EphemeraFolder",
-        state: ["complete"],
-        visibility: ["open"],
         metadata: %{
           "title" => ["title"],
           "state" => ["complete"],
@@ -43,8 +41,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
           id: "561ea64a-9cd1-4994-b2a7-ac169f33ba84",
           updated_at: ~U[2024-04-18 14:28:57.526110Z],
           internal_resource: "EphemeraFolder",
-          state: ["pending"],
-          visibility: ["open"],
           metadata: %{
             "title" => ["title"],
             "state" => ["pending"],
@@ -64,8 +60,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
           id: "561ea64a-9cd1-4994-b2a7-ac169f33ba84",
           updated_at: ~U[2024-04-18 14:29:57.526110Z],
           internal_resource: "EphemeraFolder",
-          state: ["complete"],
-          visibility: ["restricted"],
           metadata: %{
             "title" => ["title"],
             "state" => ["complete"],
@@ -102,7 +96,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         %Figgy.Resource{
           id: "2fa1b92b-9e62-4694-aeab-0c4fab72ac24",
           updated_at: ~U[2025-08-18 20:19:34.465203Z],
-          internal_resource: "ScannedResource"
+          internal_resource: "ScannedResource",
+          metadata: %{}
         }
 
       Figgy.HydrationConsumer.process_and_persist(scanned_resource, 1)
@@ -116,8 +111,10 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
           id: "9773417d-1c36-4692-bf81-f387be688460",
           updated_at: ~U[2025-01-02 19:47:21.726083Z],
           internal_resource: "DeletionMarker",
-          metadata_resource_id: [%{"id" => "a521113e-e77a-4000-b00a-17c09b3aa757"}],
-          metadata_resource_type: ["FileSet"]
+          metadata: %{
+            "resource_id" => [%{"id" => "a521113e-e77a-4000-b00a-17c09b3aa757"}],
+            "resource_type" => ["FileSet"]
+          }
         }
 
       Figgy.HydrationConsumer.process_and_persist(file_set_deletion_marker, 1)
@@ -132,8 +129,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
           id: "561ea64a-9cd1-4994-b2a7-ac169f33ba84",
           updated_at: ~U[2024-04-18 14:28:57.526110Z],
           internal_resource: "EphemeraFolder",
-          state: ["complete"],
-          visibility: ["open"],
           metadata: %{
             "title" => ["title"],
             "visibility" => ["open"],
@@ -206,13 +201,11 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         id: "2fa1b92b-9e62-4694-aeab-0c4fab72ac24",
         updated_at: ~U[2025-08-18 20:19:34.465203Z],
         internal_resource: "ScannedResource",
-        state: ["complete"],
-        visibility: ["open"],
-        member_of_collection_ids: nil,
         metadata: %{
           "title" => ["title"],
           "state" => ["complete"],
-          "visibility" => ["open"]
+          "visibility" => ["open"],
+          "member_of_collection_ids" => nil
         }
       }
 
@@ -225,8 +218,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
         updated_at: ~U[2025-04-18 14:28:57.52611Z],
         internal_resource: "EphemeraFolder",
-        state: ["complete"],
-        visibility: ["open"],
         metadata: %{
           "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
           "state" => ["complete"],
@@ -239,8 +230,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         id: "31732974-611e-4c06-8af3-928e553b6c9f",
         updated_at: ~U[2025-04-18 14:29:09.201335Z],
         internal_resource: "EphemeraFolder",
-        state: ["complete"],
-        visibility: ["open"],
         metadata: %{
           "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
           "state" => ["complete"],
@@ -253,8 +242,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
         updated_at: ~U[2025-04-19 14:28:57.52611Z],
         internal_resource: "EphemeraFolder",
-        state: ["complete"],
-        visibility: ["restricted"],
         metadata: %{
           "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
           "state" => ["complete"],
@@ -267,8 +254,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         id: "31732974-611e-4c06-8af3-928e553b6c9f",
         updated_at: ~U[2025-04-19 14:29:09.201335Z],
         internal_resource: "EphemeraFolder",
-        state: ["pending"],
-        visibility: ["open"],
         metadata: %{
           "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
           "state" => ["pending"],
@@ -313,8 +298,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
         updated_at: ~U[2024-04-18 14:28:57.526110Z],
         internal_resource: "EphemeraFolder",
-        state: ["complete"],
-        visibility: ["open"],
         metadata: %{
           "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
           "state" => ["complete"],
@@ -393,8 +376,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
         updated_at: ~U[2024-04-18 14:28:57.526110Z],
         internal_resource: "EphemeraFolder",
-        state: ["complete"],
-        visibility: ["open"],
         metadata: %{
           "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
           "state" => ["complete"],
@@ -454,8 +435,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
         updated_at: ~U[2024-04-18 14:28:57.526110Z],
         internal_resource: "EphemeraFolder",
-        state: ["complete"],
-        visibility: ["open"],
         metadata: %{
           "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
           "state" => ["complete"],
@@ -531,8 +510,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         id: "561ea64a-9cd1-4994-b2a7-ac169f33ba84",
         updated_at: ~U[2024-04-18 14:28:57.526110Z],
         internal_resource: "EphemeraFolder",
-        state: ["complete"],
-        visibility: ["open"],
         metadata: %{
           "cached_parent_id" => [%{"id" => "82624edb-c360-4d8a-b202-f103ee639e8e"}],
           "state" => ["complete"],
@@ -609,8 +586,6 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
         id: "561ea64a-9cd1-4994-b2a7-ac169f33ba84",
         updated_at: ~U[2024-04-18 14:28:57.526110Z],
         internal_resource: "EphemeraFolder",
-        state: ["complete"],
-        visibility: ["open"],
         metadata: %{
           "cached_parent_id" => [%{"id" => "82624edb-c360-4d8a-b202-f103ee639e8e"}],
           "state" => ["complete"],

--- a/test/dpul_collections/indexing_pipeline/figgy/hydration_consumer_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/hydration_consumer_test.exs
@@ -17,17 +17,19 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
 
     test "process_and_persist/2 when a message is not a complete and visible EphemeraFolder, it is not saved" do
       # First save an ephemera folder that creates a hydration cache entry.
-      ephemera_folder = %Figgy.Resource{
-        id: "561ea64a-9cd1-4994-b2a7-ac169f33ba84",
-        updated_at: ~U[2024-04-18 14:28:57.526110Z],
-        internal_resource: "EphemeraFolder",
-        metadata: %{
-          "title" => ["title"],
-          "state" => ["complete"],
-          "visibility" => ["open"],
-          "member_ids" => [%{"id" => "96f52803-f3d5-4cab-aba1-eceff648abdc"}]
+      ephemera_folder =
+        %Figgy.Resource{
+          id: "561ea64a-9cd1-4994-b2a7-ac169f33ba84",
+          updated_at: ~U[2024-04-18 14:28:57.526110Z],
+          internal_resource: "EphemeraFolder",
+          metadata: %{
+            "title" => ["title"],
+            "state" => ["complete"],
+            "visibility" => ["open"],
+            "member_ids" => [%{"id" => "96f52803-f3d5-4cab-aba1-eceff648abdc"}]
+          }
         }
-      }
+        |> Figgy.Resource.populate_virtual()
 
       Figgy.HydrationConsumer.process_and_persist(ephemera_folder, 1)
 
@@ -48,6 +50,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
             "member_ids" => [%{"id" => "96f52803-f3d5-4cab-aba1-eceff648abdc"}]
           }
         }
+        |> Figgy.Resource.populate_virtual()
 
       Figgy.HydrationConsumer.process_and_persist(pending_ephemera_folder, 1)
       assert [ephemera_folder_cache_entry] = IndexingPipeline.list_hydration_cache_entries()
@@ -136,6 +139,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
             "member_ids" => [%{"id" => "96f52803-f3d5-4cab-aba1-eceff648abdc"}]
           }
         }
+        |> Figgy.Resource.populate_virtual()
 
       # DeletionMarker that corresponds to a resource with a hydration cache entry
       ephemera_folder_deletion_marker =
@@ -144,7 +148,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
           updated_at: ~U[2025-01-02 19:47:21.726083Z],
           internal_resource: "DeletionMarker",
           metadata_resource_id: [%{"id" => "561ea64a-9cd1-4994-b2a7-ac169f33ba84"}],
-          metadata_resource_type: ["EphemeraFolder"]
+          metadata_resource_type: ["EphemeraFolder"],
+          metadata: %{}
         }
 
       # DeletionMarker that does not correspond to a resource with a hydration cache entry
@@ -154,7 +159,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
           updated_at: ~U[2025-01-02 19:47:21.726083Z],
           internal_resource: "DeletionMarker",
           metadata_resource_id: [%{"id" => "fc8d345b-6e87-461e-9182-41eaede1fab6"}],
-          metadata_resource_type: ["EphemeraFolder"]
+          metadata_resource_type: ["EphemeraFolder"],
+          metadata: %{}
         }
 
       # DeletionMarker that does not correspond to a resource with a hydration cache entry
@@ -164,7 +170,8 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
           updated_at: ~U[2025-01-02 19:47:21.726083Z],
           internal_resource: "DeletionMarker",
           metadata_resource_id: [%{"id" => "e0d4e6f6-29f2-4fd7-9c8a-7293ae0d7689"}],
-          metadata_resource_type: ["EphemeraFolder"]
+          metadata_resource_type: ["EphemeraFolder"],
+          metadata: %{}
         }
 
       # Create a cache entry for the ephemera folder.
@@ -214,53 +221,61 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
     end
 
     test "process_and_persist/2 deletes EphemeraFolders when their state or visibility change" do
-      ephemera_folder_1 = %Figgy.Resource{
-        id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
-        updated_at: ~U[2025-04-18 14:28:57.52611Z],
-        internal_resource: "EphemeraFolder",
-        metadata: %{
-          "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
-          "state" => ["complete"],
-          "visibility" => ["open"],
-          "member_ids" => [%{"id" => "c42bca4b-02c9-44ad-b6bd-132ab27a8986"}]
+      ephemera_folder_1 =
+        %Figgy.Resource{
+          id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
+          updated_at: ~U[2025-04-18 14:28:57.52611Z],
+          internal_resource: "EphemeraFolder",
+          metadata: %{
+            "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
+            "state" => ["complete"],
+            "visibility" => ["open"],
+            "member_ids" => [%{"id" => "c42bca4b-02c9-44ad-b6bd-132ab27a8986"}]
+          }
         }
-      }
+        |> Figgy.Resource.populate_virtual()
 
-      ephemera_folder_2 = %Figgy.Resource{
-        id: "31732974-611e-4c06-8af3-928e553b6c9f",
-        updated_at: ~U[2025-04-18 14:29:09.201335Z],
-        internal_resource: "EphemeraFolder",
-        metadata: %{
-          "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
-          "state" => ["complete"],
-          "visibility" => ["open"],
-          "member_ids" => [%{"id" => "ee769854-2d5f-4d79-81d9-3fdbb27fa168"}]
+      ephemera_folder_2 =
+        %Figgy.Resource{
+          id: "31732974-611e-4c06-8af3-928e553b6c9f",
+          updated_at: ~U[2025-04-18 14:29:09.201335Z],
+          internal_resource: "EphemeraFolder",
+          metadata: %{
+            "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
+            "state" => ["complete"],
+            "visibility" => ["open"],
+            "member_ids" => [%{"id" => "ee769854-2d5f-4d79-81d9-3fdbb27fa168"}]
+          }
         }
-      }
+        |> Figgy.Resource.populate_virtual()
 
-      updated_visibility_ephemera_folder = %Figgy.Resource{
-        id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
-        updated_at: ~U[2025-04-19 14:28:57.52611Z],
-        internal_resource: "EphemeraFolder",
-        metadata: %{
-          "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
-          "state" => ["complete"],
-          "visibility" => ["restricted"],
-          "member_ids" => [%{"id" => "c42bca4b-02c9-44ad-b6bd-132ab27a8986"}]
+      updated_visibility_ephemera_folder =
+        %Figgy.Resource{
+          id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
+          updated_at: ~U[2025-04-19 14:28:57.52611Z],
+          internal_resource: "EphemeraFolder",
+          metadata: %{
+            "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
+            "state" => ["complete"],
+            "visibility" => ["restricted"],
+            "member_ids" => [%{"id" => "c42bca4b-02c9-44ad-b6bd-132ab27a8986"}]
+          }
         }
-      }
+        |> Figgy.Resource.populate_virtual()
 
-      updated_state_ephemera_folder = %Figgy.Resource{
-        id: "31732974-611e-4c06-8af3-928e553b6c9f",
-        updated_at: ~U[2025-04-19 14:29:09.201335Z],
-        internal_resource: "EphemeraFolder",
-        metadata: %{
-          "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
-          "state" => ["pending"],
-          "visibility" => ["open"],
-          "member_ids" => [%{"id" => "ee769854-2d5f-4d79-81d9-3fdbb27fa168"}]
+      updated_state_ephemera_folder =
+        %Figgy.Resource{
+          id: "31732974-611e-4c06-8af3-928e553b6c9f",
+          updated_at: ~U[2025-04-19 14:29:09.201335Z],
+          internal_resource: "EphemeraFolder",
+          metadata: %{
+            "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
+            "state" => ["pending"],
+            "visibility" => ["open"],
+            "member_ids" => [%{"id" => "ee769854-2d5f-4d79-81d9-3fdbb27fa168"}]
+          }
         }
-      }
+        |> Figgy.Resource.populate_virtual()
 
       # Create hydration cache entries
       Figgy.HydrationConsumer.process_and_persist(ephemera_folder_1, 1)
@@ -294,18 +309,20 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
     end
 
     test "process_and_persist/2 updates an EphemeraFolder when a related EphemeraTerm changes" do
-      ephemera_folder = %Figgy.Resource{
-        id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
-        updated_at: ~U[2024-04-18 14:28:57.526110Z],
-        internal_resource: "EphemeraFolder",
-        metadata: %{
-          "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
-          "state" => ["complete"],
-          "visibility" => ["open"],
-          "member_ids" => [%{"id" => "c42bca4b-02c9-44ad-b6bd-132ab27a8986"}],
-          "genre" => [%{"id" => "01e15ce8-1a11-4342-b7b5-82cbff248b4d"}]
+      ephemera_folder =
+        %Figgy.Resource{
+          id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
+          updated_at: ~U[2024-04-18 14:28:57.526110Z],
+          internal_resource: "EphemeraFolder",
+          metadata: %{
+            "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
+            "state" => ["complete"],
+            "visibility" => ["open"],
+            "member_ids" => [%{"id" => "c42bca4b-02c9-44ad-b6bd-132ab27a8986"}],
+            "genre" => [%{"id" => "01e15ce8-1a11-4342-b7b5-82cbff248b4d"}]
+          }
         }
-      }
+        |> Figgy.Resource.populate_virtual()
 
       updated_ephemera_term_resource = %Figgy.Resource{
         id: "01e15ce8-1a11-4342-b7b5-82cbff248b4d",
@@ -372,18 +389,20 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
     end
 
     test "process_and_persist/2 does not update an EphemeraFolder when a related resources changes but has an older timestamp" do
-      ephemera_folder = %Figgy.Resource{
-        id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
-        updated_at: ~U[2024-04-18 14:28:57.526110Z],
-        internal_resource: "EphemeraFolder",
-        metadata: %{
-          "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
-          "state" => ["complete"],
-          "visibility" => ["open"],
-          "member_ids" => [%{"id" => "c42bca4b-02c9-44ad-b6bd-132ab27a8986"}],
-          "genre" => [%{"id" => "01e15ce8-1a11-4342-b7b5-82cbff248b4d"}]
+      ephemera_folder =
+        %Figgy.Resource{
+          id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
+          updated_at: ~U[2024-04-18 14:28:57.526110Z],
+          internal_resource: "EphemeraFolder",
+          metadata: %{
+            "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
+            "state" => ["complete"],
+            "visibility" => ["open"],
+            "member_ids" => [%{"id" => "c42bca4b-02c9-44ad-b6bd-132ab27a8986"}],
+            "genre" => [%{"id" => "01e15ce8-1a11-4342-b7b5-82cbff248b4d"}]
+          }
         }
-      }
+        |> Figgy.Resource.populate_virtual()
 
       updated_ephemera_term_resource = %Figgy.Resource{
         id: "01e15ce8-1a11-4342-b7b5-82cbff248b4d",
@@ -431,17 +450,19 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
     end
 
     test "process_and_persist/2 updates an EphemeraFolder when a related FileSet changes" do
-      ephemera_folder = %Figgy.Resource{
-        id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
-        updated_at: ~U[2024-04-18 14:28:57.526110Z],
-        internal_resource: "EphemeraFolder",
-        metadata: %{
-          "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
-          "state" => ["complete"],
-          "visibility" => ["open"],
-          "member_ids" => [%{"id" => "c42bca4b-02c9-44ad-b6bd-132ab27a8986"}]
+      ephemera_folder =
+        %Figgy.Resource{
+          id: "05092b7d-d33c-4d4d-885e-b6b8973deec4",
+          updated_at: ~U[2024-04-18 14:28:57.526110Z],
+          internal_resource: "EphemeraFolder",
+          metadata: %{
+            "cached_parent_id" => [%{"id" => "7b87fdfa-a760-49b9-85e9-093f2519f2fc"}],
+            "state" => ["complete"],
+            "visibility" => ["open"],
+            "member_ids" => [%{"id" => "c42bca4b-02c9-44ad-b6bd-132ab27a8986"}]
+          }
         }
-      }
+        |> Figgy.Resource.populate_virtual()
 
       updated_file_set_resource = %Figgy.Resource{
         id: "c42bca4b-02c9-44ad-b6bd-132ab27a8986",
@@ -506,32 +527,36 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
     end
 
     test "process_and_persist/2 updates an EphemeraFolder when a parent EphemeraBox changes" do
-      ephemera_folder = %Figgy.Resource{
-        id: "561ea64a-9cd1-4994-b2a7-ac169f33ba84",
-        updated_at: ~U[2024-04-18 14:28:57.526110Z],
-        internal_resource: "EphemeraFolder",
-        metadata: %{
-          "cached_parent_id" => [%{"id" => "82624edb-c360-4d8a-b202-f103ee639e8e"}],
-          "state" => ["complete"],
-          "visibility" => ["open"],
-          "member_ids" => [%{"id" => "96f52803-f3d5-4cab-aba1-eceff648abdc"}],
-          "title" => ["Folder"]
+      ephemera_folder =
+        %Figgy.Resource{
+          id: "561ea64a-9cd1-4994-b2a7-ac169f33ba84",
+          updated_at: ~U[2024-04-18 14:28:57.526110Z],
+          internal_resource: "EphemeraFolder",
+          metadata: %{
+            "cached_parent_id" => [%{"id" => "82624edb-c360-4d8a-b202-f103ee639e8e"}],
+            "state" => ["complete"],
+            "visibility" => ["open"],
+            "member_ids" => [%{"id" => "96f52803-f3d5-4cab-aba1-eceff648abdc"}],
+            "title" => ["Folder"]
+          }
         }
-      }
+        |> Figgy.Resource.populate_virtual()
 
-      updated_ephemera_box_resource = %Figgy.Resource{
-        id: "82624edb-c360-4d8a-b202-f103ee639e8e",
-        internal_resource: "EphemeraBox",
-        updated_at: ~U[2030-07-09 20:19:35.340016Z],
-        created_at: ~U[2030-07-09 20:19:35.340016Z],
-        metadata: %{
-          "box_number" => ["different_box"],
-          "cached_parent_id" => [%{"id" => "2961c153-54ab-4c6a-b5cd-aa992f4c349b"}],
-          "member_ids" => [
-            %{"id" => "561ea64a-9cd1-4994-b2a7-ac169f33ba84"}
-          ]
+      updated_ephemera_box_resource =
+        %Figgy.Resource{
+          id: "82624edb-c360-4d8a-b202-f103ee639e8e",
+          internal_resource: "EphemeraBox",
+          updated_at: ~U[2030-07-09 20:19:35.340016Z],
+          created_at: ~U[2030-07-09 20:19:35.340016Z],
+          metadata: %{
+            "box_number" => ["different_box"],
+            "cached_parent_id" => [%{"id" => "2961c153-54ab-4c6a-b5cd-aa992f4c349b"}],
+            "member_ids" => [
+              %{"id" => "561ea64a-9cd1-4994-b2a7-ac169f33ba84"}
+            ]
+          }
         }
-      }
+        |> Figgy.Resource.populate_virtual()
 
       # Create a hydration cache entry
       Figgy.HydrationConsumer.process_and_persist(ephemera_folder, 1)
@@ -582,31 +607,35 @@ defmodule DpulCollections.IndexingPipeline.Figgy.HydrationConsumerTest do
     end
 
     test "process_and_persist/2 updates an EphemeraFolder when a grandparent EphemeraProject changes" do
-      ephemera_folder = %Figgy.Resource{
-        id: "561ea64a-9cd1-4994-b2a7-ac169f33ba84",
-        updated_at: ~U[2024-04-18 14:28:57.526110Z],
-        internal_resource: "EphemeraFolder",
-        metadata: %{
-          "cached_parent_id" => [%{"id" => "82624edb-c360-4d8a-b202-f103ee639e8e"}],
-          "state" => ["complete"],
-          "visibility" => ["open"],
-          "member_ids" => [%{"id" => "96f52803-f3d5-4cab-aba1-eceff648abdc"}],
-          "title" => ["Folder"]
+      ephemera_folder =
+        %Figgy.Resource{
+          id: "561ea64a-9cd1-4994-b2a7-ac169f33ba84",
+          updated_at: ~U[2024-04-18 14:28:57.526110Z],
+          internal_resource: "EphemeraFolder",
+          metadata: %{
+            "cached_parent_id" => [%{"id" => "82624edb-c360-4d8a-b202-f103ee639e8e"}],
+            "state" => ["complete"],
+            "visibility" => ["open"],
+            "member_ids" => [%{"id" => "96f52803-f3d5-4cab-aba1-eceff648abdc"}],
+            "title" => ["Folder"]
+          }
         }
-      }
+        |> Figgy.Resource.populate_virtual()
 
-      updated_ephemera_project_resource = %Figgy.Resource{
-        id: "2961c153-54ab-4c6a-b5cd-aa992f4c349b",
-        internal_resource: "EphemeraProject",
-        updated_at: ~U[2030-07-09 20:19:35.340016Z],
-        created_at: ~U[2030-07-09 20:19:35.340016Z],
-        metadata: %{
-          "member_ids" => [
-            %{"id" => "82624edb-c360-4d8a-b202-f103ee639e8e"}
-          ],
-          "title" => ["Updated EphemeraProject Title"]
+      updated_ephemera_project_resource =
+        %Figgy.Resource{
+          id: "2961c153-54ab-4c6a-b5cd-aa992f4c349b",
+          internal_resource: "EphemeraProject",
+          updated_at: ~U[2030-07-09 20:19:35.340016Z],
+          created_at: ~U[2030-07-09 20:19:35.340016Z],
+          metadata: %{
+            "member_ids" => [
+              %{"id" => "82624edb-c360-4d8a-b202-f103ee639e8e"}
+            ],
+            "title" => ["Updated EphemeraProject Title"]
+          }
         }
-      }
+        |> Figgy.Resource.populate_virtual()
 
       # Create a hydration cache entry
       Figgy.HydrationConsumer.process_and_persist(ephemera_folder, 1)

--- a/test/dpul_collections/indexing_pipeline_test.exs
+++ b/test/dpul_collections/indexing_pipeline_test.exs
@@ -125,21 +125,8 @@ defmodule DpulCollections.IndexingPipelineTest do
       record = IndexingPipeline.get_figgy_resources_since!(marker, 1) |> hd
 
       assert record.metadata == nil
-      assert record.visibility == ["open"]
-      assert record.state == ["complete"]
-    end
-
-    test "get_figgy_resources_since!/2 pulls deleted resource IDs and types" do
-      record = IndexingPipeline.get_figgy_resource!("ea2bc758-e455-493f-87fe-ecf124117fd2")
-      marker = IndexingPipeline.DatabaseProducer.CacheEntryMarker.from(record)
-      marker = %{marker | timestamp: marker.timestamp |> DateTime.add(-1)}
-
-      record = IndexingPipeline.get_figgy_resources_since!(marker, 1) |> hd
-
-      assert record.id == "ea2bc758-e455-493f-87fe-ecf124117fd2"
-      assert record.metadata == nil
-      assert record.metadata_resource_id == [%{"id" => "b7fc05bb-fb01-414f-a603-c5e479576674"}]
-      assert record.metadata_resource_type == ["EphemeraFolder"]
+      assert record.visibility == nil
+      assert record.state == nil
     end
 
     test "get_figgy_resources_since!/2 does not return Events or PreservationObjects" do


### PR DESCRIPTION
Don't pull anything out of metadata for HydrationConsumer.

This should be faster, unless DeletionMarkers totally destroy the performance (since this'd pull all metadata for all DeletionMarkers in a second query.)

Total hydration:  01:37:55
