### PR TITLE
Try performance of poll delay for transformation.

### DIFF
--- a/lib/dpul_collections/indexing_pipeline.ex
+++ b/lib/dpul_collections/indexing_pipeline.ex
@@ -87,7 +87,7 @@ defmodule DpulCollections.IndexingPipeline do
       try do
         # Serialize writes for a cache version by acquiring an advisory lock.
         # It takes two integers - 1 here is special and for Hydration.
-        Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [attrs.cache_version, 1])
+        # Repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [attrs.cache_version, 1])
 
         %Figgy.HydrationCacheEntry{}
         |> Figgy.HydrationCacheEntry.changeset(attrs)
@@ -111,12 +111,14 @@ defmodule DpulCollections.IndexingPipeline do
         count,
         cache_version
       ) do
+    poll_delay = DateTime.utc_now() |> DateTime.add(-5, :second)
+
     query =
       from r in Figgy.HydrationCacheEntry,
         where:
           r.cache_version == ^cache_version and
             ((r.cache_order == ^cache_order and r.record_id > ^id) or
-               r.cache_order > ^cache_order),
+               r.cache_order > ^cache_order) and r.cache_order < ^poll_delay,
         # Don't pull data or related_data, they're too big to parse in bulk.
         select: [
           :id,

--- a/lib/dpul_collections/indexing_pipeline/database_producer.ex
+++ b/lib/dpul_collections/indexing_pipeline/database_producer.ex
@@ -97,7 +97,7 @@ defmodule DpulCollections.IndexingPipeline.DatabaseProducer do
     # fallback.
     if new_state.stored_demand > 0 do
       DpulCollections.IndexMetricsTracker.register_polling_started(source_module, cache_version)
-      Process.send_after(self(), :check_for_updates, 60000)
+      Process.send_after(self(), :check_for_updates, 2000)
     end
 
     {:noreply, Enum.map(records, &wrap_record/1), new_state}

--- a/test/dpul_collections/indexing_pipeline/database_producer_test.exs
+++ b/test/dpul_collections/indexing_pipeline/database_producer_test.exs
@@ -38,6 +38,7 @@ defmodule DpulCollections.IndexingPipeline.DatabaseProducerTest do
 
     test "handle_demand/2 with consecutive state returns a new record" do
       {marker1, marker2, marker3} = FiggyTestFixtures.hydration_cache_markers()
+      :timer.sleep(5000)
 
       {:producer, initial_state} = DatabaseProducer.init({Figgy.TransformationProducerSource, 0})
 

--- a/test/dpul_collections/indexing_pipeline/integration/figgy/transformation_integration_test.exs
+++ b/test/dpul_collections/indexing_pipeline/integration/figgy/transformation_integration_test.exs
@@ -28,6 +28,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.TransformationIntegrationTest d
 
   test "transformation cache entry creation" do
     {marker1, _marker2, _marker3} = FiggyTestFixtures.hydration_cache_markers()
+    :timer.sleep(5000)
 
     transformer = start_transformation_producer()
 


### PR DESCRIPTION
There's a bunch of logs showing contention for the advisory lock. This sets a poll delay as an alternative strategy, like what we do for Figgy's db.

If we like this there's probably some test stuff to figure out..