### PR TITLE
dashboard styles

### DIFF
--- a/lib/dpul_collections_web/live_dashboard/index_validation_page.ex
+++ b/lib/dpul_collections_web/live_dashboard/index_validation_page.ex
@@ -23,32 +23,39 @@ defmodule DpulCollectionsWeb.LiveDashboard.IndexValidationPage do
     <.row :for={validator <- @validators}>
       <:col>
         <.card_title title={validator.collection.title} />
+        <.row>
+          <:col>
+            <.card inner_title="Digital Collections count">
+              {validator.dc_count}
+            </.card>
+          </:col>
+          <:col>
+            <.card inner_title="Figgy count">
+              {validator.public_complete_figgy_count}
+            </.card>
+          </:col>
+        </.row>
 
-        <.fields_card
-          inner_title="Counts"
-          fields={[
-            dc_count: validator.dc_count,
-            figgy_count: validator.public_complete_figgy_count
-          ]}
-        />
-        <div :if={length(validator.missing_items) > 0}>
-          <h6>
-            {length(validator.missing_items)} Missing items (In Figgy, public, complete, has member_ids, but not in DC)
-          </h6>
+        <.card
+          :if={length(validator.missing_items) > 0}
+          inner_title={"#{length(validator.missing_items)} Missing items (In Figgy, public, complete, has member_ids, but not in DC)"}
+        >
           <ul>
             <li :for={id <- validator.missing_items}>
               <.link href={"https://figgy.princeton.edu/catalog/#{id}"}>{id}</.link>
             </li>
           </ul>
-        </div>
-        <div :if={length(validator.extra_items) > 0}>
-          <h6>{length(validator.extra_items)} Extra items (In DC, but not Figgy)</h6>
+        </.card>
+        <.card
+          :if={length(validator.extra_items) > 0}
+          inner_title={"#{length(validator.extra_items)} Extra items (In DC, but not Figgy)"}
+        >
           <ul>
             <li :for={id <- validator.extra_items}>
               <.link href={"/item/#{id}"}>{id}</.link>
             </li>
           </ul>
-        </div>
+        </.card>
       </:col>
     </.row>
     """

--- a/test/dpul_collections_web/live_dashboard/index_validation_page_test.exs
+++ b/test/dpul_collections_web/live_dashboard/index_validation_page_test.exs
@@ -39,7 +39,7 @@ defmodule DpulCollectionsWeb.LiveDashboard.IndexValidationPageTest do
       assert view
              |> has_element?(
                ".row",
-               ~r(South Asian Ephemera\s*Counts\s*dc_count\s*3\s*figgy_count\s*14)
+               ~r(South Asian Ephemera\s*Digital Collections count\s*3\s*Figgy count\s*14)
              )
 
       # There's a list of missing items.


### PR DESCRIPTION
depends on #1251

## screenshots

### before
<img width="1320" height="1079" alt="Screenshot 2026-06-11 at 4 48 41 PM" src="https://github.com/user-attachments/assets/48b2010e-d6ee-4463-a75c-e22ddb0593c1" />


### after
<img width="1239" height="1055" alt="Screenshot 2026-06-11 at 5 01 40 PM" src="https://github.com/user-attachments/assets/2ed0c25c-3e44-4996-a3fa-be25bb8d520c" />
