### PR TITLE
Refactors around card rows, collections, and fixtures

### DIFF
--- a/figgy-fixture-container/fixture-exports/synthetic/fixtures.md
+++ b/figgy-fixture-container/fixture-exports/synthetic/fixtures.md
@@ -5,8 +5,7 @@
 |ephemera_box_not_in_production.csv | "not_in_production" EphemeraBox with three complete child EphemeraFolders and their FileSets (will index) |
 |ephemera_project_with_folder.csv   | EphemeraProject with a directly attached complete EphemeraFolder and it's FileSet |
 |ephemera_folders_earliest.csv      | Three EphemeraFolders with created_at and updated_at values set to dates earlier than all other folders |
-|featured_islamic_manuscript.csv      | A featured item in the manuscripts collection, with one fileset and other member_ids removed |
-|pdf-resource-no-thumbnail.csv      | A pdf scanned resource with no thumbnail
-set|
-|sae-reading-room-folder.csv | A folder in the SAE project with reading room visibility, and its box |
-|sae-no-members.csv | A folder in the SAE project with no members |
+|featured_islamic_manuscript.csv    | A featured item in the manuscripts collection, with one fileset and other member_ids removed |
+|pdf-resource-no-thumbnail.csv      | A pdf scanned resource with no thumbnail set|
+|sae-reading-room-folder.csv        | A folder in the SAE project with reading room visibility, and its box |
+|sae-no-members.csv                 | A folder in the SAE project with no members |

--- a/lib/dpul_collections_web/components/browse_item.ex
+++ b/lib/dpul_collections_web/components/browse_item.ex
@@ -21,6 +21,8 @@ defmodule DpulCollectionsWeb.BrowseItem do
 
   slot :intro, doc: "the optional inner block that renders above the images"
 
+  # This is a container / wrapper div for `li` card components; it includes a title
+  # and a 'more' link, as well as an optional slot for some descriptive text
   def card_row(assigns) do
     ~H"""
     <div class={["grid-row", @color]} {@rest}>

--- a/lib/dpul_collections_web/components/browse_item.ex
+++ b/lib/dpul_collections_web/components/browse_item.ex
@@ -21,7 +21,7 @@ defmodule DpulCollectionsWeb.BrowseItem do
 
   slot :intro, doc: "the optional inner block that renders above the images"
 
-  def browse_item_row(assigns) do
+  def card_row(assigns) do
     ~H"""
     <div class={["grid-row", @color]} {@rest}>
       <div class={@layout}>
@@ -77,6 +77,7 @@ defmodule DpulCollectionsWeb.BrowseItem do
   slot :card_buttons, required: false
 
   # make sure to wrap these in a ul
+  # The basic item card, providing slots for buttons, footers, etc
   def item_card_li(assigns = %{thumb_source: %Item{}}) do
     ~H"""
     <li
@@ -188,7 +189,8 @@ defmodule DpulCollectionsWeb.BrowseItem do
   attr :heading_level, :string, default: "h3"
 
   # make sure to wrap these in a ul
-  def item_browse_li(assigns) do
+  # the "browse" flavor of item card
+  def item_browse_card_li(assigns) do
     ~H"""
     <.item_card_li
       target_item={@item}

--- a/lib/dpul_collections_web/components/browse_item.ex
+++ b/lib/dpul_collections_web/components/browse_item.ex
@@ -7,23 +7,19 @@ defmodule DpulCollectionsWeb.BrowseItem do
   alias DpulCollectionsWeb.Live.Helpers
   alias DpulCollectionsWeb.ContentWarnings
 
-  attr :items, :list, required: true
   attr :title, :string, required: true
-  attr :added?, :boolean, default: false
   attr :more_link, :string, default: nil
   attr :color, :string, default: "bg-primary-bright"
   # can be light or dark
   attr :arrow_theme, :string, default: "dark"
   attr :layout, :string, default: "content-area"
   attr :rest, :global
-  attr :current_scope, :map, required: false, default: nil
-  attr :current_path, :string, required: true
 
-  attr :show_images, :list,
-    default: [],
-    doc: "the list of images stored in session that should not be obfuscated"
+  slot :inner_block,
+    required: true,
+    doc: "the item components to go inside the row; they'll be placed inside a ul element"
 
-  slot :inner_block, doc: "the optional inner block that renders above the images"
+  slot :intro, doc: "the optional inner block that renders above the images"
 
   def browse_item_row(assigns) do
     ~H"""
@@ -31,19 +27,12 @@ defmodule DpulCollectionsWeb.BrowseItem do
       <div class={@layout}>
         <div class="page-t-padding" />
         <h2>{@title}</h2>
-        {render_slot(@inner_block)}
+        {render_slot(@intro)}
         <div class="flex gap-6 justify-stretch page-t-padding">
           <!-- cards -->
+          <!-- TODO maybe rename this recent-container class? -->
           <ul class="w-full recent-container">
-            <.browse_li
-              :for={item <- @items}
-              show_images={@show_images}
-              item={item}
-              added?={@added?}
-              likeable?={false}
-              current_scope={@current_scope}
-              current_path={@current_path}
-            />
+            {render_slot(@inner_block)}
           </ul>
           <div :if={@more_link} class="w-12 flex-none content-center">
             <.transparent_button
@@ -88,7 +77,7 @@ defmodule DpulCollectionsWeb.BrowseItem do
   slot :card_buttons, required: false
 
   # make sure to wrap these in a ul
-  def card_li(assigns) do
+  def item_card_li(assigns = %{thumb_source: %Item{}}) do
     ~H"""
     <li
       id={"#{@id_prefix}-#{@target_item.id}"}
@@ -199,9 +188,9 @@ defmodule DpulCollectionsWeb.BrowseItem do
   attr :heading_level, :string, default: "h3"
 
   # make sure to wrap these in a ul
-  def browse_li(assigns) do
+  def item_browse_li(assigns) do
     ~H"""
-    <.card_li
+    <.item_card_li
       target_item={@item}
       thumb_source={@item}
       id_prefix={@id_prefix}
@@ -250,7 +239,7 @@ defmodule DpulCollectionsWeb.BrowseItem do
           current_path={@current_path}
         />
       </:card_buttons>
-    </.card_li>
+    </.item_card_li>
     """
   end
 

--- a/lib/dpul_collections_web/live/browse_live.ex
+++ b/lib/dpul_collections_web/live/browse_live.ex
@@ -104,7 +104,7 @@ defmodule DpulCollectionsWeb.BrowseLive do
     <div>
       <.liked_items {assigns} />
       <ul id="browse-items" class="grid grid-cols-[repeat(auto-fit,minmax(300px,_1fr))] gap-6 pt-5">
-        <.browse_li
+        <.item_browse_li
           :if={@focused_item}
           item={@focused_item}
           likeable?={false}
@@ -115,7 +115,7 @@ defmodule DpulCollectionsWeb.BrowseLive do
           current_path={@current_path}
           heading_level="h2"
         />
-        <.browse_li
+        <.item_browse_li
           :for={item <- @items}
           item={item}
           target="_blank"

--- a/lib/dpul_collections_web/live/browse_live.ex
+++ b/lib/dpul_collections_web/live/browse_live.ex
@@ -104,7 +104,7 @@ defmodule DpulCollectionsWeb.BrowseLive do
     <div>
       <.liked_items {assigns} />
       <ul id="browse-items" class="grid grid-cols-[repeat(auto-fit,minmax(300px,_1fr))] gap-6 pt-5">
-        <.item_browse_li
+        <.item_browse_card_li
           :if={@focused_item}
           item={@focused_item}
           likeable?={false}
@@ -115,7 +115,7 @@ defmodule DpulCollectionsWeb.BrowseLive do
           current_path={@current_path}
           heading_level="h2"
         />
-        <.item_browse_li
+        <.item_browse_card_li
           :for={item <- @items}
           item={item}
           target="_blank"

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -181,21 +181,21 @@ defmodule DpulCollectionsWeb.CollectionsLive do
           class="grid-flow auto-rows-max"
         >
           <.content_separator />
-          <.browse_item_row
+          <.card_row
             id="featured-items"
             layout="content-area"
             title={gettext("Featured Highlights")}
             color=""
             arrow_theme="light"
           >
-            <.item_browse_li
+            <.item_browse_card_li
               :for={item <- @collection.featured_items}
               show_images={[]}
               item={item}
               current_scope={@current_scope}
               current_path={@current_path}
             />
-          </.browse_item_row>
+          </.card_row>
         </div>
         <!-- Learn More -->
         <div id="learn-more" class="grid-flow-row text-dark-text auto-rows-max page-b-padding">
@@ -250,7 +250,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
         <!-- Recently Updated Items -->
         <div :if={length(@collection.recently_added) > 0}>
           <.content_separator />
-          <.browse_item_row
+          <.card_row
             id="recent-items"
             layout="content-area"
             title={gettext("Recently Added Items")}
@@ -265,14 +265,14 @@ defmodule DpulCollectionsWeb.CollectionsLive do
                 {gettext("Explore the latest additions to")} {@collection.title |> hd}.
               </p>
             </:intro>
-            <.item_browse_li
+            <.item_browse_card_li
               :for={item <- @collection.recently_added}
               show_images={[]}
               item={item}
               added?={true}
               current_path={@current_path}
             />
-          </.browse_item_row>
+          </.card_row>
         </div>
         <!-- Contributors -->
         <div

--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -184,14 +184,17 @@ defmodule DpulCollectionsWeb.CollectionsLive do
           <.browse_item_row
             id="featured-items"
             layout="content-area"
-            items={@collection.featured_items}
             title={gettext("Featured Highlights")}
-            show_images={[]}
-            current_path={@current_path}
-            current_scope={@current_scope}
             color=""
             arrow_theme="light"
           >
+            <.item_browse_li
+              :for={item <- @collection.featured_items}
+              show_images={[]}
+              item={item}
+              current_scope={@current_scope}
+              current_path={@current_path}
+            />
           </.browse_item_row>
         </div>
         <!-- Learn More -->
@@ -250,21 +253,25 @@ defmodule DpulCollectionsWeb.CollectionsLive do
           <.browse_item_row
             id="recent-items"
             layout="content-area"
-            items={@collection.recently_added}
             title={gettext("Recently Added Items")}
             more_link={
               ~p"/search?#{%{filter: %{collection: [@collection.title |> hd]}, sort_by: "recently_added"}}"
             }
-            show_images={[]}
-            added?={true}
-            current_path={@current_path}
             color=""
             arrow_theme="light"
           >
-            <p class="my-2">
-              {gettext("Explore the latest additions to our growing collection for")} {@collection.title
-              |> hd}.
-            </p>
+            <:intro>
+              <p class="my-2">
+                {gettext("Explore the latest additions to")} {@collection.title |> hd}.
+              </p>
+            </:intro>
+            <.item_browse_li
+              :for={item <- @collection.recently_added}
+              show_images={[]}
+              item={item}
+              added?={true}
+              current_path={@current_path}
+            />
           </.browse_item_row>
         </div>
         <!-- Contributors -->

--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -90,17 +90,23 @@ defmodule DpulCollectionsWeb.HomeLive do
           id="recent-items"
           layout="home-content-area"
           color="bg-background"
-          items={@recent_items}
           title={gettext("Recently Added Items")}
           more_link={~p"/search?sort_by=recently_added"}
-          show_images={@show_images}
-          current_scope={@current_scope}
-          current_path={@current_path}
-          added?={true}
         >
-          <p class="my-2 font-regular">
-            {gettext("Our collections are constantly growing. Discover something new!")}
-          </p>
+          <:intro>
+            <p class="my-2 font-regular">
+              {gettext("Our collections are constantly growing. Discover something new!")}
+            </p>
+          </:intro>
+          <.item_browse_li
+            :for={item <- @recent_items}
+            show_images={@show_images}
+            item={item}
+            added?={true}
+            likeable?={false}
+            current_scope={@current_scope}
+            current_path={@current_path}
+          />
         </.browse_item_row>
       </div>
     </Layouts.app>

--- a/lib/dpul_collections_web/live/home_live.ex
+++ b/lib/dpul_collections_web/live/home_live.ex
@@ -86,7 +86,7 @@ defmodule DpulCollectionsWeb.HomeLive do
         </div>
         <.content_separator />
 
-        <.browse_item_row
+        <.card_row
           id="recent-items"
           layout="home-content-area"
           color="bg-background"
@@ -98,7 +98,7 @@ defmodule DpulCollectionsWeb.HomeLive do
               {gettext("Our collections are constantly growing. Discover something new!")}
             </p>
           </:intro>
-          <.item_browse_li
+          <.item_browse_card_li
             :for={item <- @recent_items}
             show_images={@show_images}
             item={item}
@@ -107,7 +107,7 @@ defmodule DpulCollectionsWeb.HomeLive do
             current_scope={@current_scope}
             current_path={@current_path}
           />
-        </.browse_item_row>
+        </.card_row>
       </div>
     </Layouts.app>
     """

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -275,22 +275,30 @@ defmodule DpulCollectionsWeb.ItemLive do
       <.browse_item_row
         :if={@item.collections != []}
         id="related-same-collection"
-        items={@related_items}
         title={gettext("Similar Items in this Collection")}
         more_link={more_similar_link(@item)}
-        show_images={@show_images}
-        current_path={@current_path}
-      />
+      >
+        <.item_browse_li
+          :for={item <- @related_items}
+          show_images={@show_images}
+          item={item}
+          current_path={@current_path}
+        />
+      </.browse_item_row>
       <.browse_item_row
         :if={@item.collections != []}
         id="related-different-collection"
-        items={@different_collections_related_items}
         title={gettext("Similar Items outside this Collection")}
         color="bg-background"
         more_link={more_different_link(@item)}
-        show_images={@show_images}
-        current_path={@current_path}
-      />
+      >
+        <.item_browse_li
+          :for={item <- @different_collections_related_items}
+          show_images={@show_images}
+          item={item}
+          current_path={@current_path}
+        />
+      </.browse_item_row>
     </div>
     <.correction_form_modal
       correction_form={@correction_form}

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -272,33 +272,33 @@ defmodule DpulCollectionsWeb.ItemLive do
       <.share_modal path={@item.url} id="share-modal" heading={gettext("Share this item")} />
     </div>
     <div id="similar-items">
-      <.browse_item_row
+      <.card_row
         :if={@item.collections != []}
         id="related-same-collection"
         title={gettext("Similar Items in this Collection")}
         more_link={more_similar_link(@item)}
       >
-        <.item_browse_li
+        <.item_browse_card_li
           :for={item <- @related_items}
           show_images={@show_images}
           item={item}
           current_path={@current_path}
         />
-      </.browse_item_row>
-      <.browse_item_row
+      </.card_row>
+      <.card_row
         :if={@item.collections != []}
         id="related-different-collection"
         title={gettext("Similar Items outside this Collection")}
         color="bg-background"
         more_link={more_different_link(@item)}
       >
-        <.item_browse_li
+        <.item_browse_card_li
           :for={item <- @different_collections_related_items}
           show_images={@show_images}
           item={item}
           current_path={@current_path}
         />
-      </.browse_item_row>
+      </.card_row>
     </div>
     <.correction_form_modal
       correction_form={@correction_form}

--- a/lib/dpul_collections_web/live/user_sets_live.ex
+++ b/lib/dpul_collections_web/live/user_sets_live.ex
@@ -50,7 +50,7 @@ defmodule DpulCollectionsWeb.UserSetsLive do
       <div id="browse" class="content-area">
         <h1>{gettext("My Sets")}</h1>
         <ul class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 pt-5">
-          <.card_li
+          <.item_card_li
             :for={{set, item} <- @sets_with_items}
             id_prefix="set"
             target_item={set}
@@ -73,7 +73,7 @@ defmodule DpulCollectionsWeb.UserSetsLive do
             <:extra_info>
               {set.description}
             </:extra_info>
-          </.card_li>
+          </.item_card_li>
         </ul>
       </div>
     </Layouts.app>

--- a/lib/dpul_collections_web/live/user_sets_live/show.ex
+++ b/lib/dpul_collections_web/live/user_sets_live/show.ex
@@ -71,7 +71,7 @@ defmodule DpulCollectionsWeb.UserSetsLive.Show do
           )}
         </h2>
         <ul id="set-items" class="grid grid-cols-[repeat(auto-fill,minmax(300px,_1fr))] gap-12 pt-5">
-          <.browse_li
+          <.item_browse_li
             :for={item <- @items}
             show_images={@show_images}
             item={item}

--- a/lib/dpul_collections_web/live/user_sets_live/show.ex
+++ b/lib/dpul_collections_web/live/user_sets_live/show.ex
@@ -71,7 +71,7 @@ defmodule DpulCollectionsWeb.UserSetsLive.Show do
           )}
         </h2>
         <ul id="set-items" class="grid grid-cols-[repeat(auto-fill,minmax(300px,_1fr))] gap-12 pt-5">
-          <.item_browse_li
+          <.item_browse_card_li
             :for={item <- @items}
             show_images={@show_images}
             item={item}

--- a/test/dpul_collections_web/features/collection_test.exs
+++ b/test/dpul_collections_web/features/collection_test.exs
@@ -5,46 +5,43 @@ defmodule DpulCollectionsWeb.Features.CollectionViewTest do
   import SolrTestSupport
 
   setup_all do
-    sae_ids = [
-      "01c4dc49-2ff9-49f6-98ce-fb6ca1c8ddcc",
-      "d5610085-745c-46f2-b344-8bc5f6dd3dfb",
-      "e906307b-2475-499f-80b7-194b6e0ae74e",
-      "cb88573a-9091-411c-a366-f1747d76aca7",
-      "8b6f89a7-984c-4a83-85a5-fdfba899e0c3",
-      "1e86cab8-69c0-4e1f-8cf7-c11f274b657f",
-      "666fcfd1-dda7-4603-82d1-1863dc97ffc3",
-      "8ac0a23b-8c51-4e1c-8bc0-ae307264b895",
-      "5f78bc1d-940d-4628-9421-98818e3dea35",
-      # the project
-      "f99af4de-fed4-4baa-82b1-6e857b230306",
-      "e8abfa75-253f-428a-b3df-0e83ff2b20f9",
-      "e379b822-27cc-4d0e-bca7-6096ac38f1e6",
-      "1e5ae074-3a6e-494e-9889-6cd01f7f0621",
-      "036b86bf-28b0-4157-8912-6d3d9eeaa5a8",
-      "d82efa97-c69b-424c-83c2-c461baae8307",
-      "39a1a1a0-7ba6-4de9-8a44-f081811c2b34"
-    ]
-
-    # Add another ID so we know it doesn't include counts from other collections.
-    other_ids = ["3da68e1c-06af-4d17-8603-fc73152e1ef7", "118983a5-dd6b-4d7a-bb8c-93fb08248cac"]
-
-    # IDs for a collection with scanned resources, manuscripts of the islamic world
-    sr_col_ids = [
-      # collection
-      "52abe8f7-e2a1-46e9-9d13-3dc4fbc0bf0a",
-      # featured item
-      "159ba3f9-feab-49dd-bc71-ca08995006d9"
-    ]
-
-    (sae_ids ++ other_ids ++ sr_col_ids)
-    |> Enum.each(&FiggyTestSupport.index_record_id_directly/1)
-
-    Solr.soft_commit(active_collection())
     on_exit(fn -> Solr.delete_all(active_collection()) end)
     :ok
   end
 
   describe "the collection page content for an EphemeraProject" do
+    setup do
+      sae_ids = [
+        "01c4dc49-2ff9-49f6-98ce-fb6ca1c8ddcc",
+        "d5610085-745c-46f2-b344-8bc5f6dd3dfb",
+        "e906307b-2475-499f-80b7-194b6e0ae74e",
+        "cb88573a-9091-411c-a366-f1747d76aca7",
+        "8b6f89a7-984c-4a83-85a5-fdfba899e0c3",
+        "1e86cab8-69c0-4e1f-8cf7-c11f274b657f",
+        "666fcfd1-dda7-4603-82d1-1863dc97ffc3",
+        "8ac0a23b-8c51-4e1c-8bc0-ae307264b895",
+        "5f78bc1d-940d-4628-9421-98818e3dea35",
+        # the project
+        "f99af4de-fed4-4baa-82b1-6e857b230306",
+        "e8abfa75-253f-428a-b3df-0e83ff2b20f9",
+        "e379b822-27cc-4d0e-bca7-6096ac38f1e6",
+        "1e5ae074-3a6e-494e-9889-6cd01f7f0621",
+        "036b86bf-28b0-4157-8912-6d3d9eeaa5a8",
+        "d82efa97-c69b-424c-83c2-c461baae8307",
+        "39a1a1a0-7ba6-4de9-8a44-f081811c2b34"
+      ]
+
+      # Add another ID so we know it doesn't include counts from other collections.
+      other_ids = ["3da68e1c-06af-4d17-8603-fc73152e1ef7", "118983a5-dd6b-4d7a-bb8c-93fb08248cac"]
+
+      (sae_ids ++ other_ids)
+      |> Enum.each(&FiggyTestSupport.index_record_id_directly/1)
+
+      Solr.soft_commit(active_collection())
+      on_exit(fn -> Solr.delete_all(active_collection()) end)
+      :ok
+    end
+
     test "it has content for the collection", %{conn: conn} do
       conn
       |> visit("/collections/sae")
@@ -165,6 +162,21 @@ defmodule DpulCollectionsWeb.Features.CollectionViewTest do
   end
 
   describe "the collection page content for a Figgy Collection" do
+    setup do
+      [
+        # Manuscripts of the islamic world collection
+        "52abe8f7-e2a1-46e9-9d13-3dc4fbc0bf0a",
+        # featured item
+        "159ba3f9-feab-49dd-bc71-ca08995006d9"
+      ]
+      |> Enum.each(&FiggyTestSupport.index_record_id_directly/1)
+
+      Solr.soft_commit(active_collection())
+
+      on_exit(fn -> Solr.delete_all(active_collection()) end)
+      :ok
+    end
+
     test "it has content for the collection", %{conn: conn} do
       conn
       |> visit("/collections/islamicmss")


### PR DESCRIPTION
commits should be atomic, readable
- **Move collection feature setup into each test**
- **Small fixes to md formatting for readability in editor**
- **Extract browse_li from the browse row, make it use a slot**
- **Rename some row and card components**

Moving the item cards themselves out of the row and into a slot will allow us to use the row for different kinds of cards. The cards we have (for items) are already sort of complex and they're strictly tied to the structure and data fields of an item -- e.g. the data values on an item, the creation of the image and link from the thumbnail. Trying to generalize those cards further wasn't an option.

Moving the cards out of the wrapper also allowed the wrapper to take attributes that are specific to its functionality, rather than having to take a bunch of attributes just to pass them through.

work towards #1252