### PR TITLE
1235 publisher

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -321,6 +321,22 @@
   }
 }
 
+/* Wrapping variant of brief-metadata. Applies the flex-wrap class and makes it so
+ * that a separator border line at the end of a line is not rendered when the text
+ * wraps to a new line.
+ */
+@utility brief-metadata-wrap {
+  @apply flex-auto overflow-hidden;
+
+  > div {
+    @apply flex flex-row flex-wrap gap-y-4 -ms-4;
+  }
+
+  > div > div {
+    @apply flex flex-col gap-0 px-4 py-0 h-min border-s-1 border-search;
+  }
+}
+
 /* Helper class for the default table component style that adds
  * rounded corners to the table rows.
  */

--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -53,7 +53,8 @@ defmodule DpulCollections.Solr do
     "updated_at_dt",
     "content_warning_s",
     "geographic_origin_txt_sort",
-    "tagline_txtm"
+    "tagline_txtm",
+    "publisher_txt_sort"
   ]
 
   def raw_query(search_state, index \\ Index.read_index()) do

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -38,8 +38,8 @@ defmodule DpulCollectionsWeb.SearchItem do
           class="metadata sm:col-span-3 flex flex-col gap-2 sm:gap-4 p-4"
           id={"item-metadata-#{@item.id}"}
         >
-          <div class="flex flex-wrap flex-row sm:flex-row justify-between">
-            <h2 dir="auto" class="w-full flex-grow sm:w-fit">
+          <div class="flex flex-wrap sm:flex-nowrap flex-row justify-between">
+            <h2 dir="auto" class="w-full flex-grow sm:w-auto sm:min-w-0">
               <.link
                 navigate={@item.url}
                 class="card-link"
@@ -119,8 +119,8 @@ defmodule DpulCollectionsWeb.SearchItem do
           class="metadata sm:col-span-3 sm:col-start-2 flex flex-col gap-2 sm:gap-4 p-4"
           id={"item-metadata-#{@item.id}"}
         >
-          <div class="flex flex-wrap flex-row sm:flex-row justify-between">
-            <h2 dir="auto" class="w-full flex-grow sm:w-fit pr-3">
+          <div class="flex flex-wrap sm:flex-nowrap flex-row justify-between">
+            <h2 dir="auto" class="w-full flex-grow sm:w-auto sm:min-w-0 pr-3">
               <.link
                 navigate={@item.url}
                 class="card-link"

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -132,7 +132,7 @@ defmodule DpulCollectionsWeb.SearchItem do
             <span
               aria-label={gettext("format")}
               data-field="format"
-              class="w-full sm:w-fit flex-grow sm:flex-none text-gray-600 font-bold text-base uppercase sm:text-right"
+              class="w-full sm:w-fit flex-grow sm:flex-none order-first sm:order-none text-gray-600 font-bold text-base uppercase sm:text-right"
             >
               {@item.format}
             </span>

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -265,27 +265,29 @@ defmodule DpulCollectionsWeb.SearchItem do
 
   defp search_brief_metadata(assigns) do
     ~H"""
-    <div class="brief-metadata flex-wrap">
-      <div
-        :if={length(@item.publisher) > 0}
-        class="publisher"
-      >
-        <div class="text-base">{gettext("Publisher")}</div>
-        <div class="text-lg font-semibold">{@item.publisher}</div>
-      </div>
-      <div
-        :if={@item.date}
-        class="date"
-      >
-        <div class="text-base">{gettext("Date")}</div>
-        <div class="text-lg font-semibold">{@item.date}</div>
-      </div>
-      <div
-        :if={length(@item.geographic_origin) > 0}
-        class="origin"
-      >
-        <div class="text-base">{gettext("Origin")}</div>
-        <div class="text-lg font-semibold">{@item.geographic_origin}</div>
+    <div class="brief-metadata-wrap">
+      <div>
+        <div
+          :if={length(@item.publisher) > 0}
+          class="publisher"
+        >
+          <div class="text-base">{gettext("Publisher")}</div>
+          <div class="text-lg font-semibold">{@item.publisher}</div>
+        </div>
+        <div
+          :if={@item.date}
+          class="date"
+        >
+          <div class="text-base">{gettext("Date")}</div>
+          <div class="text-lg font-semibold">{@item.date}</div>
+        </div>
+        <div
+          :if={length(@item.geographic_origin) > 0}
+          class="origin"
+        >
+          <div class="text-base">{gettext("Origin")}</div>
+          <div class="text-lg font-semibold">{@item.geographic_origin}</div>
+        </div>
       </div>
     </div>
     """

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -96,13 +96,25 @@ defmodule DpulCollectionsWeb.SearchItem do
         />
       </div>
       <div class="grid-rows-2 bg-sage-100 grid sm:grid-rows-1 sm:grid-cols-4 gap-0">
-        <.large_thumb
+        <div
           :if={@item.file_count && length(@item.image_service_urls) > 0}
-          thumb={elem(hd(thumbnail_service_urls(0, 1, @item)), 0)}
-          thumb_num={0}
-          item={@item}
-          show_images={@show_images}
-        />
+          class="row-span-2 col-span-1 relative"
+        >
+          <.large_thumb
+            thumb={elem(hd(thumbnail_service_urls(0, 1, @item)), 0)}
+            thumb_num={0}
+            item={@item}
+            show_images={@show_images}
+          />
+          <%!-- Mobile-only --%>
+          <div class="absolute right-0 top-0 p-2 z-10 sm:hidden">
+            <UserSets.AddToSetComponent.add_button
+              current_scope={@current_scope}
+              item_id={@item.id}
+              current_path={@current_path}
+            />
+          </div>
+        </div>
         <div
           class="metadata sm:col-span-3 sm:col-start-2 flex flex-col gap-2 sm:gap-4 p-4"
           id={"item-metadata-#{@item.id}"}
@@ -142,11 +154,13 @@ defmodule DpulCollectionsWeb.SearchItem do
             <div class="grow">
               <.search_brief_metadata item={@item} />
             </div>
-            <UserSets.AddToSetComponent.add_button
-              current_scope={@current_scope}
-              item_id={@item.id}
-              current_path={@current_path}
-            />
+            <div class="hidden sm:flex">
+              <UserSets.AddToSetComponent.add_button
+                current_scope={@current_scope}
+                item_id={@item.id}
+                current_path={@current_path}
+              />
+            </div>
           </div>
           <div class="small-thumbnails hidden sm:flex flex-row flex-wrap gap-5 max-h-[125px] justify-start overflow-hidden">
             <.thumbs
@@ -264,6 +278,13 @@ defmodule DpulCollectionsWeb.SearchItem do
       >
         <div class="text-base">{gettext("Origin")}</div>
         <div class="text-lg">{@item.geographic_origin}</div>
+      </div>
+      <div
+        :if={length(@item.publisher) > 0}
+        class="publisher"
+      >
+        <div class="text-base">{gettext("Publisher")}</div>
+        <div class="text-lg">{@item.publisher}</div>
       </div>
     </div>
     """

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -267,6 +267,13 @@ defmodule DpulCollectionsWeb.SearchItem do
     ~H"""
     <div class="brief-metadata flex-wrap">
       <div
+        :if={length(@item.publisher) > 0}
+        class="publisher"
+      >
+        <div class="text-base">{gettext("Publisher")}</div>
+        <div class="text-lg font-semibold">{@item.publisher}</div>
+      </div>
+      <div
         :if={@item.date}
         class="date"
       >
@@ -279,13 +286,6 @@ defmodule DpulCollectionsWeb.SearchItem do
       >
         <div class="text-base">{gettext("Origin")}</div>
         <div class="text-lg font-semibold">{@item.geographic_origin}</div>
-      </div>
-      <div
-        :if={length(@item.publisher) > 0}
-        class="publisher"
-      >
-        <div class="text-base">{gettext("Publisher")}</div>
-        <div class="text-lg font-semibold">{@item.publisher}</div>
       </div>
     </div>
     """

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -119,47 +119,49 @@ defmodule DpulCollectionsWeb.SearchItem do
           class="metadata sm:col-span-3 sm:col-start-2 flex flex-col gap-2 sm:gap-4 p-4"
           id={"item-metadata-#{@item.id}"}
         >
-          <div class="flex flex-wrap sm:flex-nowrap flex-row justify-between">
-            <h2 dir="auto" class="w-full flex-grow sm:w-auto sm:min-w-0 pr-3">
-              <.link
-                navigate={@item.url}
-                class="card-link"
-                id={"item-title-#{@item.id}"}
-              >
-                {@item.title}
-              </.link>
-            </h2>
-            <span
-              aria-label={gettext("format")}
-              data-field="format"
-              class="w-full sm:w-fit flex-grow sm:flex-none order-first sm:order-none text-gray-600 font-bold text-base uppercase sm:text-right"
-            >
-              {@item.format}
-            </span>
-          </div>
-          <div :if={!Enum.empty?(@item.transliterated_title) || !Enum.empty?(@item.alternative_title)}>
-            <h3
-              :for={ttitle <- @item.transliterated_title}
-              dir="auto"
-              class="mt-[-1rem] font-medium text-gray-500"
-              id={"item-translit-title-#{@item.id}"}
-            >
-              {ttitle}
-            </h3>
-          </div>
-          <div :if={@sort_by == :recently_added && @item.updated_at} class="updated-at w-full">
-            {gettext("Added")} {DpulCollectionsWeb.BrowseItem.time_ago(@item.updated_at)}
-          </div>
-          <div class="flex">
-            <div class="grow">
+          <div class="flex flex-col sm:flex-row gap-2 sm:gap-4">
+            <div class="flex flex-col gap-2 sm:gap-4 grow min-w-0">
+              <h2 dir="auto" class="w-full min-w-0">
+                <.link
+                  navigate={@item.url}
+                  class="card-link"
+                  id={"item-title-#{@item.id}"}
+                >
+                  {@item.title}
+                </.link>
+              </h2>
+              <div :if={
+                !Enum.empty?(@item.transliterated_title) || !Enum.empty?(@item.alternative_title)
+              }>
+                <h3
+                  :for={ttitle <- @item.transliterated_title}
+                  dir="auto"
+                  class="mt-[-1rem] font-medium text-gray-500"
+                  id={"item-translit-title-#{@item.id}"}
+                >
+                  {ttitle}
+                </h3>
+              </div>
+              <div :if={@sort_by == :recently_added && @item.updated_at} class="updated-at w-full">
+                {gettext("Added")} {DpulCollectionsWeb.BrowseItem.time_ago(@item.updated_at)}
+              </div>
               <.search_brief_metadata item={@item} />
             </div>
-            <div class="hidden sm:flex">
-              <UserSets.AddToSetComponent.add_button
-                current_scope={@current_scope}
-                item_id={@item.id}
-                current_path={@current_path}
-              />
+            <div class="flex flex-col gap-2 sm:gap-4 shrink-0 order-first sm:order-none sm:items-end">
+              <span
+                aria-label={gettext("format")}
+                data-field="format"
+                class="w-full sm:w-auto text-gray-600 font-bold text-base uppercase sm:text-right"
+              >
+                {@item.format}
+              </span>
+              <div class="hidden sm:flex">
+                <UserSets.AddToSetComponent.add_button
+                  current_scope={@current_scope}
+                  item_id={@item.id}
+                  current_path={@current_path}
+                />
+              </div>
             </div>
           </div>
           <div class="small-thumbnails hidden sm:flex flex-row flex-wrap gap-5 max-h-[125px] justify-start overflow-hidden">

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -264,7 +264,7 @@ defmodule DpulCollectionsWeb.SearchItem do
 
   defp search_brief_metadata(assigns) do
     ~H"""
-    <div class="brief-metadata">
+    <div class="brief-metadata flex-wrap">
       <div
         :if={@item.date}
         class="date"

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -270,21 +270,21 @@ defmodule DpulCollectionsWeb.SearchItem do
         class="date"
       >
         <div class="text-base">{gettext("Date")}</div>
-        <div class="text-lg">{@item.date}</div>
+        <div class="text-lg font-semibold">{@item.date}</div>
       </div>
       <div
         :if={length(@item.geographic_origin) > 0}
         class="origin"
       >
         <div class="text-base">{gettext("Origin")}</div>
-        <div class="text-lg">{@item.geographic_origin}</div>
+        <div class="text-lg font-semibold">{@item.geographic_origin}</div>
       </div>
       <div
         :if={length(@item.publisher) > 0}
         class="publisher"
       >
         <div class="text-base">{gettext("Publisher")}</div>
-        <div class="text-lg">{@item.publisher}</div>
+        <div class="text-lg font-semibold">{@item.publisher}</div>
       </div>
     </div>
     """

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -21,7 +21,7 @@ defmodule DpulCollectionsWeb.SearchItem do
           "search-thumbnail",
           "row-span-2 col-span-1",
           "bg-search flex justify-center relative",
-          "h-[350px]"
+          "h-full"
         ]}>
           <div class="grid grid-cols-2 w-full gap-2 h-[350px] p-2">
             <img
@@ -190,7 +190,8 @@ defmodule DpulCollectionsWeb.SearchItem do
       "search-thumbnail",
       "row-span-2 col-span-1",
       "grid grid-cols-1 auto-rows-auto gap-2",
-      "bg-search flex justify-center relative p-2"
+      "bg-search flex justify-center relative p-2",
+      "h-full"
     ]}>
       <img
         class={[

--- a/test/dpul_collections_web/features/search_test.exs
+++ b/test/dpul_collections_web/features/search_test.exs
@@ -49,7 +49,13 @@ defmodule DpulCollectionsWeb.Features.SearchTest do
 
     conn
     |> visit("/search?q=")
+    # Has Date label and value
     |> assert_has("#item-1 .date")
+    |> assert_has("#item-1", text: "2024")
+    # Has Publisher label and value
+    |> assert_has("#item-1 .publisher")
+    |> assert_has("#item-1", text: "PublisherInc")
+    # Does not display orgin if item does not have geographic_orgin
     |> refute_has("#item-1 .origin")
   end
 

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -20,7 +20,7 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
 
       # Open dialog
       view
-      |> element("li:first-child button", "Save")
+      |> element("li:first-child .metadata button", "Save")
       |> render_click()
 
       # Create new set

--- a/test/support/solr_test_support.ex
+++ b/test/support/solr_test_support.ex
@@ -61,6 +61,7 @@ if Mix.env() == :test do
           primary_thumbnail_service_url_s: thumbnail_url,
           iiif_manifest_url_s: manifest_url,
           collection_titles_ss: ["Amazing Project"],
+          publisher_txt_sort: ["PublisherInc"],
           updated_at_dt:
             DateTime.utc_now() |> DateTime.add(-100 + 1 * n, :day) |> DateTime.to_iso8601()
         }


### PR DESCRIPTION
Closes #1235 

- **Add publisher to search result item card**
  - Moves the "Save" button to the thumbnail only in mobile view
  - Upper right side to mirror the layout in the browse cards
- **Allow the metadata elements to wrap**
- **Move genre label above title in mobile view**
- **Bold search item metadata values**

<img width="1283" height="425" alt="Screenshot 2026-06-17 at 4 53 37 PM" src="https://github.com/user-attachments/assets/4b3d9f8a-85e3-40f9-b52b-a831d4bb9b5e" />
<img width="448" height="756" alt="Screenshot 2026-06-17 at 4 53 15 PM" src="https://github.com/user-attachments/assets/4746028d-4994-4d8d-90cf-a4069d21f34e" />
