### PR TITLE
Brief metadata as list

### DIFF
--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -264,24 +264,24 @@ defmodule DpulCollectionsWeb.SearchItem do
 
   defp search_brief_metadata(assigns) do
     ~H"""
-    <div class="brief-metadata flex-wrap">
+    <div class="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-2">
       <div
         :if={@item.date}
-        class="date"
+        class="date grid grid-cols-subgrid col-span-2"
       >
         <div class="text-base">{gettext("Date")}</div>
         <div class="text-lg font-semibold">{@item.date}</div>
       </div>
       <div
         :if={length(@item.geographic_origin) > 0}
-        class="origin"
+        class="origin grid grid-cols-subgrid col-span-2"
       >
         <div class="text-base">{gettext("Origin")}</div>
         <div class="text-lg font-semibold">{@item.geographic_origin}</div>
       </div>
       <div
         :if={length(@item.publisher) > 0}
-        class="publisher"
+        class="publisher grid grid-cols-subgrid col-span-2"
       >
         <div class="text-base">{gettext("Publisher")}</div>
         <div class="text-lg font-semibold">{@item.publisher}</div>


### PR DESCRIPTION
Reformats the search results card metadata vertically. Horizontal works for a small number of short metadata fields, but got crowded once we added the publisher field with long values.

<img width="1259" height="379" alt="image" src="https://github.com/user-attachments/assets/c76a1863-da09-4b6a-98e3-5d47edc61637" />

<img width="418" height="771" alt="image" src="https://github.com/user-attachments/assets/6f768813-5c46-41f8-a25b-bb3dae95adc0" />
