### PR TITLE
Display one publisher on search item card

### DIFF
--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -274,7 +274,7 @@ defmodule DpulCollectionsWeb.SearchItem do
           class="publisher"
         >
           <div class="text-base text-gray-600">{gettext("Publisher")}</div>
-          <div class="text-lg">{@item.publisher}</div>
+          <div class="text-lg">{@item.publisher |> Enum.at(0)}</div>
         </div>
         <div
           :if={@item.date}

--- a/test/dpul_collections_web/live/search_live_test.exs
+++ b/test/dpul_collections_web/live/search_live_test.exs
@@ -951,4 +951,24 @@ defmodule DpulCollectionsWeb.SearchLiveTest do
              )
     end
   end
+
+  test "only one publisher is displayed on item card", %{conn: conn} do
+    Solr.add(
+      [
+        %{
+          id: 999,
+          title_txtm: ["An Item Title"],
+          publisher_txt_sort: ["Publisher1", "Publisher2"]
+        }
+      ],
+      active_collection()
+    )
+
+    Solr.soft_commit(active_collection())
+
+    {:ok, view, _html} = live(conn, "/search?q=999")
+
+    refute view |> has_element?(".publisher div", "Publisher1Publisher2")
+    assert view |> has_element?(".publisher div", "Publisher1")
+  end
 end


### PR DESCRIPTION
Closes #1289 

Before:
<img width="1259" height="552" alt="image" src="https://github.com/user-attachments/assets/a2c09e42-ca08-4879-b299-be02fbf1f20b" />

After:
<img width="1290" height="569" alt="image" src="https://github.com/user-attachments/assets/85974a09-d235-4f0d-b843-5fd2915db849" />