### PR TITLE
Handle nil banner item in collection card

### DIFF
--- a/lib/dpul_collections/collection.ex
+++ b/lib/dpul_collections/collection.ex
@@ -87,7 +87,13 @@ defmodule DpulCollections.Collection do
   def banner_source(collection = %__MODULE__{}) do
     banner_item = get_banner_item(collection)
 
-    "#{banner_item.primary_thumbnail_service_url}/full/!#{banner_item.primary_thumbnail_width},#{banner_item.primary_thumbnail_height}/0/default.jpg"
+    case banner_item do
+      nil ->
+        nil
+
+      _ ->
+        "#{banner_item.primary_thumbnail_service_url}/full/!#{banner_item.primary_thumbnail_width},#{banner_item.primary_thumbnail_height}/0/default.jpg"
+    end
   end
 
   defp get_banner_item(%{banner_image: banner_image, banner_image_id: banner_image_id})

--- a/test/dpul_collections_web/features/collection_test.exs
+++ b/test/dpul_collections_web/features/collection_test.exs
@@ -272,7 +272,6 @@ defmodule DpulCollectionsWeb.Features.CollectionViewTest do
 
     test "it has content for the collection", %{conn: conn} do
       conn
-      # |> visit("/collections/princetoncollectors")
       |> visit("/collections/islamicmss")
       |> assert_has(".phx-connected")
       # Featured Highlights are initially visible
@@ -304,6 +303,41 @@ defmodule DpulCollectionsWeb.Features.CollectionViewTest do
       # |> assert_has(
       #   "a[href='search?filter[related_collections][]=Russian+and+East+European+Posters']"
       # )
+    end
+  end
+
+  describe "a collection whose related collection has neither banner nor featured items" do
+    setup do
+      with_mock DpulCollections.IndexingPipeline.Figgy.ResourceTypeRegistry, [:passthrough],
+        allowed_collection?: fn _ -> true end do
+        [
+          # Manuscripts of the Islamic World collection
+          "52abe8f7-e2a1-46e9-9d13-3dc4fbc0bf0a",
+          # Middle East Manuscripts collection
+          "3bab572e-6603-4abf-8305-16ce6fe3ac5c",
+          # an item they have in common that's not featured
+          "2cc9b5cf-8d33-4f1b-b53f-fcc658770458"
+        ]
+        |> Enum.each(&FiggyTestSupport.index_record_id_directly/1)
+      end
+
+      Solr.soft_commit(active_collection())
+      on_exit(fn -> Solr.delete_all(active_collection()) end)
+      :ok
+    end
+
+    test "the related collection card renders", %{conn: conn} do
+      conn
+      |> visit("/collections/islamicmss")
+      |> assert_has(".phx-connected")
+      |> Playwright.click("#related-collections-tab")
+      # Now Related collections are visible
+      |> refute_has("#featured-items .browse-item")
+      # Related Collections card with banner in fixture has an image
+      |> within("#related-collection-3bab572e-6603-4abf-8305-16ce6fe3ac5c", fn session ->
+        session
+        |> assert_has("div", text: "Middle East Manuscripts")
+      end)
     end
   end
 end


### PR DESCRIPTION
closes #1303

There's no image, but the page loads again. it looks like this
<img width="1328" height="843" alt="Screenshot 2026-06-25 at 1 19 01 PM" src="https://github.com/user-attachments/assets/26cb17a0-6f93-4a1b-9d93-f8ee4698803e" />

