### PR TITLE
Use Digital Collections as the filter for recent collections.

### DIFF
--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -215,19 +215,14 @@ defmodule DpulCollections.Solr do
 
   def recent_collections(
         count,
-        search_state \\ SearchState.from_params(%{}),
         index \\ Index.read_index()
       ) do
     search_state =
       SearchState.from_params(%{
-        "filter" =>
-          Map.merge(
-            search_state.filter,
-            %{"resource_type" => "collection"}
-          ),
-        "sort_by" => "recently_added",
-        "per_page" => "#{count}"
+        "per_page" => "#{count}",
+        "sort_by" => "recently_added"
       })
+      |> SearchState.set_filter("format", "Digital Collection")
 
     query(search_state, index)
   end

--- a/test/dpul_collections/solr_test.exs
+++ b/test/dpul_collections/solr_test.exs
@@ -607,7 +607,8 @@ defmodule DpulCollections.SolrTest do
       collection = %{
         "id" => "coll1",
         "title_txtm" => "Collection-1",
-        "resource_type_s" => "collection"
+        "resource_type_s" => "collection",
+        "format_txt_sort" => ["Digital Collection"]
       }
 
       document = %{
@@ -620,7 +621,7 @@ defmodule DpulCollections.SolrTest do
       Solr.soft_commit(active_collection())
 
       records =
-        Solr.recent_collections(2, SearchState.from_params(%{}))
+        Solr.recent_collections(2)
         |> Map.get("docs")
 
       assert [%{"id" => "coll1"}] = records


### PR DESCRIPTION
I'm not sure why this works? Maybe because it's a txt_sort field? I just
changed it because it seemed nice to use the same filter for where the
link goes to.

Closes #1310
