### PR TITLE
If there's only featured items or related collections, don't use tabs

### DIFF
--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -43,7 +43,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
       >
         <.collection_hero collection={@collection} banner_item={@banner_item} />
         <.featured_and_related
-          :if={length(@collection.featured_items) > 0 || length(@collection.related_collections) > 0}
+          :if={has_featured?(@collection) || has_related?(@collection)}
           collection={@collection}
           current_scope={@current_scope}
           current_path={@current_path}
@@ -147,12 +147,14 @@ defmodule DpulCollectionsWeb.CollectionsLive do
       <.content_separator />
       <div class="tab-list content-area flex flex-row" role="tablist">
         <.tab_button
+          :if={has_featured?(@collection) && has_related?(@collection)}
           id="featured-items-tab"
           label="Featured Highlights"
           pane="featured-items-container"
           active?={true}
         />
         <.tab_button
+          :if={has_featured?(@collection) && has_related?(@collection)}
           id="related-collections-tab"
           label="Related Collections"
           pane="related-collections-container"
@@ -160,7 +162,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
         />
       </div>
       <div
-        :if={length(@collection.featured_items) > 0}
+        :if={has_featured?(@collection)}
         id="featured-items-container"
         phx-update="ignore"
         role="tabpanel"
@@ -169,7 +171,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
         <.card_row
           id="featured-items"
           title={gettext("Featured Highlights")}
-          hide_title?={true}
+          hide_title?={has_related?(@collection)}
           layout="content-area"
           color=""
           arrow_theme="light"
@@ -184,17 +186,20 @@ defmodule DpulCollectionsWeb.CollectionsLive do
         </.card_row>
       </div>
       <div
-        :if={length(@collection.related_collections) > 0}
+        :if={has_related?(@collection)}
         id="related-collections-container"
         role="tabpanel"
         phx-update="ignore"
-        class="grid-flow auto-rows-max tab-content hidden"
+        class={[
+          "grid-flow auto-rows-max tab-content",
+          has_featured?(@collection) && "hidden"
+        ]}
       >
         <.card_row
           id="related-collections"
           layout="content-area"
           title={gettext("Related Collections")}
-          hide_title?={true}
+          hide_title?={has_featured?(@collection)}
           color=""
           arrow_theme="light"
         >
@@ -239,6 +244,14 @@ defmodule DpulCollectionsWeb.CollectionsLive do
     js
     |> JS.hide(to: "div.tab-content")
     |> JS.show(to: to)
+  end
+
+  defp has_featured?(collection) do
+    length(collection.featured_items) > 0
+  end
+
+  defp has_related?(collection) do
+    length(collection.related_collections) > 0
   end
 
   def learn_more(assigns) do

--- a/test/dpul_collections_web/features/collection_test.exs
+++ b/test/dpul_collections_web/features/collection_test.exs
@@ -306,7 +306,7 @@ defmodule DpulCollectionsWeb.Features.CollectionViewTest do
     end
   end
 
-  describe "a collection whose related collection has neither banner nor featured items" do
+  describe "a collection (with no featured items) whose related collection has neither banner nor featured items" do
     setup do
       with_mock DpulCollections.IndexingPipeline.Figgy.ResourceTypeRegistry, [:passthrough],
         allowed_collection?: fn _ -> true end do
@@ -330,14 +330,43 @@ defmodule DpulCollectionsWeb.Features.CollectionViewTest do
       conn
       |> visit("/collections/islamicmss")
       |> assert_has(".phx-connected")
-      |> Playwright.click("#related-collections-tab")
-      # Now Related collections are visible
-      |> refute_has("#featured-items .browse-item")
+      # It has a title instead of a tab
+      |> assert_has("h2", text: "Related Collections")
+      |> refute_has("h2.sr-only", text: "Related Collections")
+      |> refute_has("#featured-items-tab")
+      |> refute_has("#related-collections-tab")
       # Related Collections card with banner in fixture has an image
       |> within("#related-collection-3bab572e-6603-4abf-8305-16ce6fe3ac5c", fn session ->
         session
         |> assert_has("div", text: "Middle East Manuscripts")
       end)
+    end
+  end
+
+  describe "a collection with no related collections" do
+    setup do
+      [
+        # SAE and one featured folder not in any other collections
+        "f99af4de-fed4-4baa-82b1-6e857b230306",
+        "036b86bf-28b0-4157-8912-6d3d9eeaa5a8"
+      ]
+      |> Enum.each(&FiggyTestSupport.index_record_id_directly/1)
+
+      Solr.soft_commit(active_collection())
+
+      on_exit(fn -> Solr.delete_all(active_collection()) end)
+      :ok
+    end
+
+    test "does not show the related_collections tab", %{conn: conn} do
+      conn
+      |> visit("/collections/sae")
+      |> assert_has(".phx-connected")
+      # It has a title instead of a tab
+      |> assert_has("h2", text: "Featured Highlights")
+      |> refute_has("h2.sr-only", text: "Featured Highlights")
+      |> refute_has("#featured-items-tab")
+      |> refute_has("#related-collections-tab")
     end
   end
 end


### PR DESCRIPTION
Just show the heading and div for the section we have

closes #1306
