### PR TITLE
Collection banner images fall back to recent items.

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -137,7 +137,8 @@ config :phoenix_test,
     ],
     js_logger: false,
     screenshot: System.get_env("PW_SCREENSHOT", "false") in ~w(t true),
-    trace: System.get_env("PW_TRACE", "false") in ~w(t true)
+    trace: System.get_env("PW_TRACE", "false") in ~w(t true),
+    timeout: :timer.seconds(4)
   ]
 
 config :honeybadger, api_key: ""

--- a/lib/dpul_collections/collection.ex
+++ b/lib/dpul_collections/collection.ex
@@ -17,6 +17,7 @@ defmodule DpulCollections.Collection do
     :banner_image,
     :banner_image_id,
     :banner_item,
+    :banner_items,
     format: ["Digital Collections"],
     categories: [],
     formats: [],
@@ -45,6 +46,7 @@ defmodule DpulCollections.Collection do
   def from_solr(doc = %{}) do
     title = Map.get(doc, "title_ss") || Map.get(doc, "title_txtm") || []
     summary = collection_summary(title |> hd)
+    featured_items = get_featured_items(title |> hd)
 
     %__MODULE__{
       id: doc["id"],
@@ -59,10 +61,22 @@ defmodule DpulCollections.Collection do
       formats: summary.formats,
       languages: summary.languages,
       geographic_origins: summary.geographic_origins,
-      featured_items: get_featured_items(title |> hd),
+      featured_items: featured_items,
       url: "/collections/#{doc["authoritative_slug_s"]}",
-      contributors: get_contributors(doc["authoritative_slug_s"])
+      contributors: get_contributors(doc["authoritative_slug_s"]),
+      banner_items: banner_items(title, featured_items)
     }
+  end
+
+  defp banner_items(_title, featured_items) when length(featured_items) >= 4 do
+    featured_items
+  end
+
+  defp banner_items(title, featured_items) do
+    featured_items
+    |> Enum.concat(get_recent_items(title |> hd))
+    |> Enum.uniq()
+    |> Enum.take(4)
   end
 
   def load_related_records(nil), do: nil
@@ -102,9 +116,17 @@ defmodule DpulCollections.Collection do
     Solr.find_by_id(banner_image_id) |> Item.from_solr()
   end
 
-  defp get_banner_item(collection) do
+  defp get_banner_item(collection = %{featured_items: featured_items})
+       when length(featured_items) > 0 do
     collection.featured_items |> then(&if &1 != [], do: Enum.random(&1))
   end
+
+  defp get_banner_item(collection = %{banner_items: banner_items})
+       when length(banner_items) > 0 do
+    collection.banner_items |> Enum.random()
+  end
+
+  defp get_banner_item(_), do: nil
 
   def get_related_collections(label) do
     Solr.related_collections(label)

--- a/lib/dpul_collections_web/components/browse_item.ex
+++ b/lib/dpul_collections_web/components/browse_item.ex
@@ -335,7 +335,7 @@ defmodule DpulCollectionsWeb.BrowseItem do
       <:thumbnail>
         <div class="grid grid-cols-2 grid-rows-2 gap-2 h-full">
           <.thumb
-            :for={item <- Enum.take(@collection.featured_items, 4)}
+            :for={item <- Enum.take(@collection.banner_items, 4)}
             thumb={thumbnail_service_url(item)}
             item={item}
             show_images={@show_images}

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -25,7 +25,7 @@ defmodule DpulCollectionsWeb.SearchItem do
         ]}>
           <div class="grid grid-cols-2 w-full gap-2 h-[350px] p-2">
             <img
-              :for={item <- @item.featured_items}
+              :for={item <- @item.banner_items}
               src={"#{item.primary_thumbnail_service_url}/full/!#{item.primary_thumbnail_width},#{item.primary_thumbnail_height}/0/default.jpg"}
               width={item.primary_thumbnail_width}
               height={item.primary_thumbnail_height}

--- a/test/dpul_collections/collection_test.exs
+++ b/test/dpul_collections/collection_test.exs
@@ -38,6 +38,26 @@ defmodule DpulCollections.CollectionTest do
 
       assert length(collection.banner_items) == 2
     end
+
+    test "if there are no items, banner_item is nil" do
+      sae_ids = [
+        # Project
+        "f99af4de-fed4-4baa-82b1-6e857b230306"
+      ]
+
+      # Add another ID so we know it doesn't include related items from other collections.
+      other_ids = ["3da68e1c-06af-4d17-8603-fc73152e1ef7"]
+
+      (sae_ids ++ other_ids)
+      |> Enum.each(&FiggyTestSupport.index_record_id_directly/1)
+
+      Solr.soft_commit()
+
+      collection = Collection.from_slug("sae")
+
+      assert length(collection.banner_items) == 0
+      assert collection.banner_item == nil
+    end
   end
 
   describe ".load_related_records" do

--- a/test/dpul_collections/collection_test.exs
+++ b/test/dpul_collections/collection_test.exs
@@ -15,6 +15,29 @@ defmodule DpulCollections.CollectionTest do
       assert collection.summary =~ "</h3"
       refute collection.summary =~ "<br>"
     end
+
+    test "if there are not enough featured items, it gets recent items" do
+      sae_ids = [
+        # Project
+        "f99af4de-fed4-4baa-82b1-6e857b230306",
+        # Highlighted item
+        "d82efa97-c69b-424c-83c2-c461baae8307",
+        # Non-highlighted item
+        "31aafb19-eaca-4d02-9780-2ee76b146663"
+      ]
+
+      # Add another ID so we know it doesn't include related items from other collections.
+      other_ids = ["3da68e1c-06af-4d17-8603-fc73152e1ef7"]
+
+      (sae_ids ++ other_ids)
+      |> Enum.each(&FiggyTestSupport.index_record_id_directly/1)
+
+      Solr.soft_commit()
+
+      collection = Collection.from_slug("sae")
+
+      assert length(collection.banner_items) == 2
+    end
   end
 
   describe ".load_related_records" do

--- a/test/dpul_collections/collection_test.exs
+++ b/test/dpul_collections/collection_test.exs
@@ -40,23 +40,24 @@ defmodule DpulCollections.CollectionTest do
     end
 
     test "if there are no items, banner_item is nil" do
-      sae_ids = [
-        # Project
-        "f99af4de-fed4-4baa-82b1-6e857b230306"
+      coll_ids = [
+        # Middle East Manuscripts
+        "3bab572e-6603-4abf-8305-16ce6fe3ac5c"
       ]
 
       # Add another ID so we know it doesn't include related items from other collections.
       other_ids = ["3da68e1c-06af-4d17-8603-fc73152e1ef7"]
 
-      (sae_ids ++ other_ids)
+      (coll_ids ++ other_ids)
       |> Enum.each(&FiggyTestSupport.index_record_id_directly/1)
 
       Solr.soft_commit()
 
-      collection = Collection.from_slug("sae")
+      collection = Collection.from_slug("middle-east-mss") |> Collection.load_related_records()
 
       assert length(collection.banner_items) == 0
       assert collection.banner_item == nil
+      assert Collection.banner_source(collection) == nil
     end
   end
 

--- a/test/dpul_collections_web/features/collection_test.exs
+++ b/test/dpul_collections_web/features/collection_test.exs
@@ -245,6 +245,43 @@ defmodule DpulCollectionsWeb.Features.CollectionViewTest do
     end
   end
 
+  describe "A collection with no banner image or featured items selected" do
+    setup do
+      with_mock DpulCollections.IndexingPipeline.Figgy.HydrationConsumer, [:passthrough],
+        process?: fn _ -> true end do
+        [
+          # Middle East Manuscripts collection
+          "3bab572e-6603-4abf-8305-16ce6fe3ac5c",
+          # non-featured item
+          "1a8c14ca-060c-434f-b999-6191db4c336c"
+        ]
+        |> Enum.each(&FiggyTestSupport.index_record_id_directly/1)
+      end
+
+      Solr.soft_commit(active_collection())
+      on_exit(fn -> Solr.delete_all(active_collection()) end)
+      :ok
+    end
+
+    test "it uses a recent item banner image fallback", %{conn: conn} do
+      conn
+      |> visit("/collections/middle-east-mss")
+      |> assert_has(".phx-connected")
+      # Title
+      |> assert_has("h1", text: "Middle East Manuscripts")
+      # Banner image area
+      |> assert_has("#collection-banner", count: 1)
+      # Banner item link
+      |> assert_has(
+        "#collection-banner a[href='/i/شاهنامه/item/1a8c14ca-060c-434f-b999-6191db4c336c']"
+      )
+      # Banner image
+      |> assert_has(
+        "#collection-banner img[src='https://iiif-cloud.princeton.edu/iiif/2/7c%2Fba%2F20%2F7cba206f6a894421ae7a32a7cab9e371%2Fintermediate_file/full/!453,800/0/default.jpg']"
+      )
+    end
+  end
+
   describe "a collection with related collections" do
     setup do
       with_mock DpulCollections.IndexingPipeline.Figgy.HydrationConsumer, [:passthrough],


### PR DESCRIPTION
Closes #1305

I think this significantly improves the display when collections don't have highlights:
<img width="1312" height="921" alt="Screenshot 2026-06-26 at 3 12 09 PM" src="https://github.com/user-attachments/assets/86c68e3a-c672-487d-84f3-d043c3458e19" />

