### PR TITLE
Only escape quotes for non-q params.

### DIFF
--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -69,6 +69,9 @@ defmodule DpulCollections.Solr do
         mm: "2<-1 5<-2 6<90%",
         sow: "true",
         fl: fl,
+        # Boost when an exact phrase match hits these fields - added to ensure
+        # when searching for exact titles of provenance without quotes that the
+        # exact matches sort first.
         pf: "title_txtm^10 summary_txtm^10 provenance_txtm^10",
         sort: sort_param(search_state),
         rows: search_state[:per_page],

--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -69,6 +69,7 @@ defmodule DpulCollections.Solr do
         mm: "2<-1 5<-2 6<90%",
         sow: "true",
         fl: fl,
+        pf: "title_txtm^10 summary_txtm^10 provenance_txtm^10",
         sort: sort_param(search_state),
         rows: search_state[:per_page],
         start: pagination_offset(search_state),

--- a/lib/dpul_collections/solr.ex
+++ b/lib/dpul_collections/solr.ex
@@ -246,17 +246,28 @@ defmodule DpulCollections.Solr do
   end
 
   defp query_param(search_state) do
-    [mlt_focus(search_state), search_state[:q] |> escape_query]
+    [mlt_focus(search_state), search_state[:q] |> escape_query(escape_quotes: false)]
     |> Enum.reject(&is_nil/1)
     |> Enum.join(" ")
   end
 
   # Escape solr characters: https://doc.lucidworks.com/docs/5/fusion/getting-data-out/query-basics/query-language-cheat-sheet
-  defp escape_query(q) when is_binary(q) do
-    Regex.replace(~r/[?*\\\/"]/, q, fn char -> "\\" <> char end)
+  defp escape_query(q, opts \\ [])
+
+  defp escape_query(q, opts) when is_binary(q) do
+    validated_opts =
+      Keyword.validate!(opts,
+        escape_quotes: true
+      )
+
+    if validated_opts[:escape_quotes] do
+      Regex.replace(~r/[?*\\\/"]/, q, fn char -> "\\" <> char end)
+    else
+      Regex.replace(~r/[?*\\\/]/, q, fn char -> "\\" <> char end)
+    end
   end
 
-  defp escape_query(q), do: q
+  defp escape_query(q, _opts), do: q
 
   def mlt_focus(%{filter: %{"similar" => id}}) do
     "{!mlt qf=format_txt_sort,subject_txt_sort,geo_subject_txt_sort,geographic_origin_txt_sort,language_txt_sort,keywords_txt_sort,summary_txtm mintf=1 mindf=1}#{id}"

--- a/test/dpul_collections/solr_test.exs
+++ b/test/dpul_collections/solr_test.exs
@@ -260,6 +260,42 @@ defmodule DpulCollections.SolrTest do
       assert hd(result.results).id == "english-example"
     end
 
+    test "searching with quotes provides more precise matching" do
+      Solr.add(
+        [
+          %{
+            id: "texas",
+            title_txtm: ["texas item"],
+            provenance_txtm: ["Gift of University of Texas Libraries"]
+          },
+          %{
+            id: "duke",
+            title_txtm: ["duke item"],
+            provenance_txtm: ["Gift of Duke University Libraries"]
+          }
+        ],
+        active_collection()
+      )
+
+      Solr.soft_commit(active_collection())
+
+      search_state = SearchState.from_params(%{"q" => "Gift of University of Texas Libraries"})
+      result = Solr.search(search_state)
+
+      # This is 2 because no quotes hits mm and matches 'gift university
+      # libraries' tokens in both. Texas should be first because of phrase
+      # boosting.
+      assert length(result.results) == 2
+
+      search_state =
+        SearchState.from_params(%{"q" => "\"Gift of University of Texas Libraries\""})
+
+      result = Solr.search(search_state)
+
+      # This should be 1, because the quotes require the phrase.
+      assert length(result.results) == 1
+    end
+
     test "can filter by two facets" do
       Solr.add(SolrTestSupport.mock_solr_documents(10), active_collection())
       Solr.soft_commit(active_collection())

--- a/test/dpul_collections_web/features/indexing_test.exs
+++ b/test/dpul_collections_web/features/indexing_test.exs
@@ -13,5 +13,6 @@ defmodule DpulCollectionsWeb.Features.IndexingTest do
     |> assert_has(".phx-connected")
     |> click_link("Издательство")
     |> assert_path("/search")
+    |> assert_has("li.item")
   end
 end


### PR DESCRIPTION
Closes #1315

This also adds a phrase boost on a couple fields because in staging searching without quotes was bringing up an LAE item as the first result despite not having that phrase in it, which is obviously silly. I'm really looking forward to measuring search relevance over time.