### PR TITLE
Renovate should isolate erlang/elixir/debian updates into its own PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,12 @@
       "extractVersion": "^OTP-(?<version>\\S+)"
     },
     {
+      "matchPackageNames": ["erlang/otp", "elixir", "debian"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "erlang/elixir/debian",
+      "groupSlug": "erlang-elixir-debian"
+    },
+    {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["debian"],
       "versioning": "regex:^(?<compatibility>.*)-(?<minor>\\d+)-slim$"


### PR DESCRIPTION
Often times we can update packages safely, but there's a new erlang, elixir, or debian version which breaks the build until it gets through to Docker Hub. This'll isolate that scenario into its own PR.
