### PR TITLE
Underline related tab labels on hover

### DIFF
--- a/lib/dpul_collections_web/live/collections_live.ex
+++ b/lib/dpul_collections_web/live/collections_live.ex
@@ -226,6 +226,7 @@ defmodule DpulCollectionsWeb.CollectionsLive do
         "tab",
         @active? && "active-tab",
         "btn-base px-4 normal-case",
+        "no-underline hover:underline",
         "text-wrap"
       ]}
     >


### PR DESCRIPTION
Closes #1317

Simplest way to indicate interactivity is to underline the label text. Changing the button background might be confusing because the background color is used to indicate the active panel.

<img width="444" height="683" alt="image" src="https://github.com/user-attachments/assets/bcc15338-ea2e-483d-a4ea-a336e9eaf0b7" />

<img width="414" height="677" alt="image" src="https://github.com/user-attachments/assets/51f4bb89-9883-48ec-971d-dd0249f66857" />
