### PR TITLE
Update Erlang/Debian

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.19.5
-erlang 27.3.4.11 # renovate: datasource=github-tags depName=erlang packageName=erlang/otp
+erlang 27.3.4.13 # renovate: datasource=github-tags depName=erlang packageName=erlang/otp
 nodejs 24.17.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@
 # renovate: datasource=hexpm-bob depName=elixir
 ARG ELIXIR_VERSION=1.19.5
 # renovate: datasource=github-tags depName=erlang packageName=erlang/otp
-ARG OTP_VERSION=27.3.4.11
+ARG OTP_VERSION=27.3.4.13
 # renovate: datasource=docker depName=debian packageName=debian
-ARG DEBIAN_VERSION=trixie-20260518-slim
+ARG DEBIAN_VERSION=trixie-20260610-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"


### PR DESCRIPTION
There are a bunch of security warnings from the scanner about OpenSSL
that we should be able to get past with this.

Normally https://github.com/pulibrary/dpul-collections/pull/1325 would
handle this, but CircleCI does not have Elixir 1.20 images right now.
