### PR TITLE
Cache primary thumbnail and refactor

### DIFF
--- a/lib/dpul_collections/collection.ex
+++ b/lib/dpul_collections/collection.ex
@@ -1,4 +1,5 @@
 defmodule DpulCollections.Collection do
+  alias DpulCollections.IIIF
   alias DpulCollections.Item
   alias DpulCollectionsWeb.Live.Helpers
   alias DpulCollections.Search.SearchState
@@ -107,7 +108,7 @@ defmodule DpulCollections.Collection do
         nil
 
       _ ->
-        "#{banner_item.primary_thumbnail_service_url}/full/!#{banner_item.primary_thumbnail_width},#{banner_item.primary_thumbnail_height}/0/default.jpg"
+        "#{banner_item.primary_thumbnail_service_url}/#{IIIF.primary_thumbnail_parameters(banner_item.primary_thumbnail_width, banner_item.primary_thumbnail_height)}"
     end
   end
 

--- a/lib/dpul_collections/iiif.ex
+++ b/lib/dpul_collections/iiif.ex
@@ -1,0 +1,31 @@
+defmodule DpulCollections.IIIF do
+  @moduledoc """
+  Centralized IIIF Image API request parameters.
+  Returns service path using this template:
+    `{region}/{size}/{rotation}/{quality}.{format}`
+  """
+
+  # Small browse thumbnails
+  def small_browse_thumbnail_parameters, do: image_parameters("square", "!100,100")
+
+  # Browse and search results thumbnails
+  def result_thumbnail_parameters, do: image_parameters("square", "!350,350")
+
+  # Search results primary thumbnails
+  def primary_search_thumbnail_parameters, do: image_parameters("full", "!350,350")
+
+  # Item page thumbnails
+  def item_thumbnail_parameters, do: image_parameters("square", "!350,465")
+
+  # Clover thumbnails
+  def clover_thumbnail_parameters, do: image_parameters("full", "!200,150")
+
+  # Thumbnails based on specific width and height
+  def primary_thumbnail_parameters(width, height) do
+    image_parameters("full", "!#{width},#{height}")
+  end
+
+  defp image_parameters(region, size) do
+    "#{region}/#{size}/0/default.jpg"
+  end
+end

--- a/lib/dpul_collections/item.ex
+++ b/lib/dpul_collections/item.ex
@@ -1,5 +1,6 @@
 defmodule DpulCollections.Item do
   alias DpulCollections.Collection
+  alias DpulCollections.IIIF
   alias DpulCollectionsWeb.Live.Helpers
   alias DpulCollections.IndexingPipeline.Figgy
   require Figgy.ImportedCatalogSchema
@@ -228,7 +229,7 @@ defmodule DpulCollections.Item do
       "description" => meta_description(summary),
       "og:description" => meta_description(summary),
       "og:image" =>
-        "#{item.primary_thumbnail_service_url}/full/!#{item.primary_thumbnail_width},#{item.primary_thumbnail_height}/0/default.jpg",
+        "#{item.primary_thumbnail_service_url}/#{IIIF.primary_thumbnail_parameters(item.primary_thumbnail_width, item.primary_thumbnail_height)}",
       "og:url" => url(~p"/item/#{item.id}")
     }
     |> Helpers.clean_params()

--- a/lib/dpul_collections/workers/cache_thumbnails.ex
+++ b/lib/dpul_collections/workers/cache_thumbnails.ex
@@ -1,5 +1,6 @@
 defmodule DpulCollections.Workers.CacheThumbnails do
   use Oban.Worker, queue: :cache
+  alias DpulCollections.IIIF
   alias DpulCollections.Utilities
   require Logger
 
@@ -17,21 +18,16 @@ defmodule DpulCollections.Workers.CacheThumbnails do
 
   defp thumbnail_configurations do
     [
-      # Small browse thumbnails
-      {"square", "!100", "100"},
-      # Browse and search results thumbnails
-      {"square", "!350", "350"},
-      # Search results primary thumbnails
-      {"full", "!350", "350"},
-      # Item page thumbnails
-      {"square", "!350", "465"},
-      # Clover thumbnails
-      {"full", "!200", "150"}
+      IIIF.small_browse_thumbnail_parameters(),
+      IIIF.result_thumbnail_parameters(),
+      IIIF.primary_search_thumbnail_parameters(),
+      IIIF.item_thumbnail_parameters(),
+      IIIF.clover_thumbnail_parameters()
     ]
   end
 
   defp primary_thumbnail_configuration(item) do
-    {"full", "!#{item.primary_thumbnail_width}", "#{item.primary_thumbnail_height}"}
+    IIIF.primary_thumbnail_parameters(item.primary_thumbnail_width, item.primary_thumbnail_height)
   end
 
   # Don't attempt to cache deleted records, or collections
@@ -96,10 +92,8 @@ defmodule DpulCollections.Workers.CacheThumbnails do
     thumbnail_configurations() |> Enum.each(&cache_iiif_item_image(base_url, &1))
   end
 
-  def cache_iiif_item_image(base_url, configuration) do
-    {region, width, height} = configuration
-    path = "/#{region}/#{width},#{height}/0/default.jpg"
-    cache_iiif_image(base_url <> path)
+  def cache_iiif_item_image(base_url, parameters) do
+    cache_iiif_image("#{base_url}/#{parameters}")
   end
 
   def cache_iiif_image(url) when is_binary(url) do

--- a/lib/dpul_collections/workers/cache_thumbnails.ex
+++ b/lib/dpul_collections/workers/cache_thumbnails.ex
@@ -21,6 +21,8 @@ defmodule DpulCollections.Workers.CacheThumbnails do
       {"square", "!100", "100"},
       # Browse and search results thumbnails
       {"square", "!350", "350"},
+      # Search results primary thumbnails
+      {"full", "!350", "350"},
       # Item page thumbnails
       {"square", "!350", "465"},
       # Clover thumbnails

--- a/lib/dpul_collections_web/components/browse_item.ex
+++ b/lib/dpul_collections_web/components/browse_item.ex
@@ -3,6 +3,7 @@ defmodule DpulCollectionsWeb.BrowseItem do
   use DpulCollectionsWeb, :html
   use Phoenix.Component
   use Gettext, backend: DpulCollectionsWeb.Gettext
+  alias DpulCollections.IIIF
   alias DpulCollections.Item
   alias DpulCollections.Collection
   alias DpulCollectionsWeb.Live.Helpers
@@ -412,11 +413,11 @@ defmodule DpulCollectionsWeb.BrowseItem do
   end
 
   def thumbnail_url(%{thumb: thumb, thumb_num: thumb_num}) when is_number(thumb_num) do
-    "#{thumb}/square/!100,100/0/default.jpg"
+    "#{thumb}/#{IIIF.small_browse_thumbnail_parameters()}"
   end
 
   def thumbnail_url(%{thumb: thumb}) do
-    "#{thumb}/square/!350,350/0/default.jpg"
+    "#{thumb}/#{IIIF.result_thumbnail_parameters()}"
   end
 
   def thumbnail_service_url(%{primary_thumbnail_service_url: thumbnail_url})

--- a/lib/dpul_collections_web/components/search_item.ex
+++ b/lib/dpul_collections_web/components/search_item.ex
@@ -1,5 +1,6 @@
 defmodule DpulCollectionsWeb.SearchItem do
   alias DpulCollections.Collection
+  alias DpulCollections.IIIF
   alias DpulCollections.Item
   alias DpulCollectionsWeb.Live.Helpers
   alias DpulCollectionsWeb.UserSets
@@ -26,7 +27,7 @@ defmodule DpulCollectionsWeb.SearchItem do
           <div class="grid grid-cols-2 w-full gap-2 h-[350px] p-2">
             <img
               :for={item <- @item.banner_items}
-              src={"#{item.primary_thumbnail_service_url}/full/!#{item.primary_thumbnail_width},#{item.primary_thumbnail_height}/0/default.jpg"}
+              src={"#{item.primary_thumbnail_service_url}/#{IIIF.primary_thumbnail_parameters(item.primary_thumbnail_width, item.primary_thumbnail_height)}"}
               width={item.primary_thumbnail_width}
               height={item.primary_thumbnail_height}
               class="min-h-0 min-w-0 object-cover object-top h-full w-full max-h-full"
@@ -208,7 +209,7 @@ defmodule DpulCollectionsWeb.SearchItem do
           "thumbnail-#{@item.id}",
           "place-self-center"
         ]}
-        src={"#{@thumb}/full/!350,350/0/default.jpg"}
+        src={"#{@thumb}/#{IIIF.primary_search_thumbnail_parameters()}"}
         alt=""
       />
       <div class={[
@@ -308,7 +309,7 @@ defmodule DpulCollectionsWeb.SearchItem do
           Helpers.obfuscate_item?(assigns) && "obfuscate",
           "thumbnail-#{@item.id}"
         ]}
-        src={"#{@thumb}/square/!350,350/0/default.jpg"}
+        src={"#{@thumb}/#{IIIF.result_thumbnail_parameters()}"}
         alt=""
         style="background-color: lightgray;"
         width="125"

--- a/lib/dpul_collections_web/live/item_live.ex
+++ b/lib/dpul_collections_web/live/item_live.ex
@@ -7,6 +7,7 @@ defmodule DpulCollectionsWeb.ItemLive do
   use DpulCollectionsWeb, :live_view
   use Gettext, backend: DpulCollectionsWeb.Gettext
   alias DpulCollections.{Item, Solr, Correction}
+  alias DpulCollections.IIIF
   alias DpulCollectionsWeb.ContentWarnings
 
   def mount(_params, _session, socket) do
@@ -714,7 +715,7 @@ defmodule DpulCollectionsWeb.ItemLive do
           />
           <.link patch={"#{@item.viewer_url}/#{primary_thumbnail_idx(@item)}"} replace>
             <img
-              src={"#{@item.primary_thumbnail_service_url}/full/!#{@item.primary_thumbnail_width},#{@item.primary_thumbnail_height}/0/default.jpg"}
+              src={"#{@item.primary_thumbnail_service_url}/#{IIIF.primary_thumbnail_parameters(@item.primary_thumbnail_width, @item.primary_thumbnail_height)}"}
               alt={gettext("main image display")}
               style="
               background-color: lightgray;"
@@ -1075,7 +1076,7 @@ defmodule DpulCollectionsWeb.ItemLive do
             Helpers.obfuscate_item?(assigns) && "obfuscate",
             "thumbnail-#{@item.id}"
           ]}
-          src={"#{@thumb}/square/!350,465/0/default.jpg"}
+          src={"#{@thumb}/#{IIIF.item_thumbnail_parameters()}"}
           alt={"image #{@thumb_num}"}
           style="
             background-color: lightgray;"

--- a/test/dpul_collections/iiif_test.exs
+++ b/test/dpul_collections/iiif_test.exs
@@ -1,0 +1,28 @@
+defmodule DpulCollections.IIIFTest do
+  use ExUnit.Case, async: true
+  alias DpulCollections.IIIF
+
+  test "small_browse_thumbnail_parameters/0" do
+    assert IIIF.small_browse_thumbnail_parameters() == "square/!100,100/0/default.jpg"
+  end
+
+  test "result_thumbnail_parameters/0" do
+    assert IIIF.result_thumbnail_parameters() == "square/!350,350/0/default.jpg"
+  end
+
+  test "primary_search_thumbnail_parameters/0" do
+    assert IIIF.primary_search_thumbnail_parameters() == "full/!350,350/0/default.jpg"
+  end
+
+  test "item_thumbnail_parameters/0" do
+    assert IIIF.item_thumbnail_parameters() == "square/!350,465/0/default.jpg"
+  end
+
+  test "clover_thumbnail_parameters/0" do
+    assert IIIF.clover_thumbnail_parameters() == "full/!200,150/0/default.jpg"
+  end
+
+  test "primary_thumbnail_parameters/2" do
+    assert IIIF.primary_thumbnail_parameters(453, 800) == "full/!453,800/0/default.jpg"
+  end
+end

--- a/test/dpul_collections/workers/cache_thumbnails_test.exs
+++ b/test/dpul_collections/workers/cache_thumbnails_test.exs
@@ -52,6 +52,8 @@ defmodule DpulCollections.Workers.CacheThumbnailsTest do
         assert cached_paths |> Enum.member?("/iiif/2/image1/square/!350,465/0/default.jpg")
         # Browse and search results thumbnails
         assert cached_paths |> Enum.member?("/iiif/2/image2/square/!350,350/0/default.jpg")
+        # Search results primary thumbnails
+        assert cached_paths |> Enum.member?("/iiif/2/image2/full/!350,350/0/default.jpg")
         # Small browse thumbnails
         assert cached_paths |> Enum.member?("/iiif/2/image7/square/!100,100/0/default.jpg")
         # Clover thumbnails


### PR DESCRIPTION
Closes #1350

- Caches primary search result thumbnail
- Refactors IIIF thumbnail definitions so the views and the cache stays in sync
