### PR TITLE
Lower required Renovate cooldown.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     "mix",
     "renovate-config"
   ],
-  "minimumReleaseAge": "14 days",
+  "minimumReleaseAge": "5 days",
   "packageRules": [
     {
       "matchDatasources": [


### PR DESCRIPTION
Hex enforces the 14 day cooldown, unless there's a security issue, then
it loosens that restriction so you're not stuck on an insecure version.
The way Hex/Renovate do that are a little bit not the same, so sometimes
we get failures right now. By reducing the cooldown in Renovate the Hex
requirement is still enforced at two weeks, but Renovate will be
inactive a much smaller amount of time.

Refs #1353
