### PR TITLE
Revert "Lower required Renovate cooldown."

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     "mix",
     "renovate-config"
   ],
-  "minimumReleaseAge": "5 days",
+  "minimumReleaseAge": "14 days",
   "packageRules": [
     {
       "matchDatasources": [


### PR DESCRIPTION
This reverts commit 519b16daf315853b603c1784135ffc01ea048b74.

It made things worse, because Renovate would try to upgrade to more recent versions than hex would allow.