### PR TITLE
Make descriptive metadata fields searchable

### DIFF
--- a/lib/dpul_collections/indexing_pipeline/figgy/solr_document.ex
+++ b/lib/dpul_collections/indexing_pipeline/figgy/solr_document.ex
@@ -16,7 +16,7 @@ defmodule DpulCollections.IndexingPipeline.Figgy.SolrDocument do
         data: data,
         related_data: related_data
       }) do
-    build(data, related_data)
+    build(data, related_data) |> add_searchable_field()
   end
 
   @doc """
@@ -30,6 +30,45 @@ defmodule DpulCollections.IndexingPipeline.Figgy.SolrDocument do
       data |> JSON.encode!() |> JSON.decode!(),
       related_data |> JSON.encode!() |> JSON.decode!()
     )
+    |> add_searchable_field()
+  end
+
+  # Add descriptive fields to the searchable_metadata solr field.
+  # Searchable via `qf` but not stored or faceted on.
+  defp add_searchable_field(document) do
+    values =
+      document
+      |> Enum.filter(fn {field, _value} -> searchable_field(field) end)
+      |> Enum.flat_map(fn {_field, value} -> List.wrap(value) end)
+      |> Enum.filter(&is_binary/1)
+      |> Enum.uniq()
+
+    case values do
+      [] -> document
+      _ -> Map.put(document, :searchable_metadata, values)
+    end
+  end
+
+  # Fields with these suffixes are used to populate searchable_metadata
+  @searchable_field_suffixes ~w(_txtm _txt_sort _ss _txt)
+
+  # Fields not to add to searchable_metadata
+  @non_searchable_fields [
+    :authoritative_slug_s,
+    :collection_ids_ss,
+    :featurable_ss,
+    :iiif_manifest_url_s,
+    :image_canvas_ids_ss,
+    :image_service_urls_ss,
+    :pdf_url_s,
+    :primary_thumbnail_service_url_s
+  ]
+
+  defp searchable_field(field) when field in @non_searchable_fields, do: false
+
+  defp searchable_field(field) do
+    field = Atom.to_string(field)
+    Enum.any?(@searchable_field_suffixes, &String.ends_with?(field, &1))
   end
 
   defp build(%{"id" => id, "metadata" => %{"deleted" => true}}, _related_data) do

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -127,7 +127,7 @@
     <!-- <copyField source="*" dest="_text_"/> -->
 
     <!-- Field to hold descriptive metadata values for search -->
-    <field name="searchable_metadata" type="text_general" indexed="true" stored="false" multiValued="true"/>
+    <field name="searchable_metadata" type="text_en" indexed="true" stored="false" multiValued="true"/>
 
     <!-- Dynamic field definitions allow using convention over configuration
        for fields via the specification of patterns to match field names.

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -126,6 +126,9 @@
          because it's very expensive to index everything twice. -->
     <!-- <copyField source="*" dest="_text_"/> -->
 
+    <!-- Field to hold descriptive metadata values for search -->
+    <field name="searchable_metadata" type="text_general" indexed="true" stored="false" multiValued="true"/>
+
     <!-- Dynamic field definitions allow using convention over configuration
        for fields via the specification of patterns to match field names.
        EXAMPLE:  name="*_i" will match any field ending in _i (like myid_i, z_i)

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -694,6 +694,8 @@
       <str name="defType">edismax</str>
       <str name="q.alt">*:*</str>
       <str name="qf">
+        searchable_metadata
+
         id
         years_is
 

--- a/test/dpul_collections/indexing_pipeline/figgy/solr_document_test.exs
+++ b/test/dpul_collections/indexing_pipeline/figgy/solr_document_test.exs
@@ -1066,5 +1066,52 @@ defmodule DpulCollections.IndexingPipeline.Figgy.SolrDocumentTest do
 
       assert doc[:language_txt_sort] == "Klingon"
     end
+
+    test "copies descriptive field values into the searchable_metadata field" do
+      {:ok, entry} =
+        IndexingPipeline.write_hydration_cache_entry(%{
+          cache_version: 0,
+          record_id: "0cff895a-01ea-4895-9c3d-a8c6eaab4013",
+          related_ids: [],
+          source_cache_order: ~U[2023-05-11 18:45:18.994187Z],
+          source_cache_order_record_id: "kw-bbb",
+          data: %{
+            "id" => "0cff895a-01ea-4895-9c3d-a8c6eaab4013",
+            "internal_resource" => "ScannedResource",
+            "metadata" => %{
+              "title" => ["A Manuscript"],
+              "imported_metadata" => [
+                %{
+                  "binding_note" => ["a binding note"],
+                  "description" => ["a description"],
+                  "references" => ["cited in Smith"]
+                }
+              ]
+            }
+          }
+        })
+
+      doc = Figgy.SolrDocument.from_cache_entry(entry)
+
+      assert "a binding note" in doc[:searchable_metadata]
+      assert "a description" in doc[:searchable_metadata]
+      assert "cited in Smith" in doc[:searchable_metadata]
+      assert "A Manuscript" in doc[:searchable_metadata]
+    end
+
+    test "some fields are not included in searchable metadata" do
+      doc =
+        IndexingPipeline.get_figgy_resource!("27fd4d29-1170-47a5-891b-f2743873bcef")
+        |> Figgy.Resource.to_combined()
+        |> Figgy.SolrDocument.from_combined_figgy_resource()
+
+      # Ensure that the document does contain service fields
+      assert doc[:image_service_urls_ss] != []
+      assert doc[:iiif_manifest_url_s] != nil
+
+      # Those field values are not searchable
+      refute doc[:iiif_manifest_url_s] in doc[:searchable_metadata]
+      refute Enum.any?(doc[:searchable_metadata], &String.contains?(&1, "iiif"))
+    end
   end
 end

--- a/test/dpul_collections/solr_test.exs
+++ b/test/dpul_collections/solr_test.exs
@@ -932,4 +932,55 @@ defmodule DpulCollections.SolrTest do
       assert Solr.find_by_slug("empty") == nil
     end
   end
+
+  describe "searchable_metadata" do
+    test "finds values not in qf but indexed in searchable field" do
+      Solr.add(
+        [
+          %{
+            "id" => "searchable-metadata-doc",
+            "title_txtm" => ["A Title"],
+            "binding_note_ss" => ["a bindingnote"],
+            "notes_ss" => ["a generalnote"],
+            "references_ss" => ["cited in Smith"],
+            "searchable_metadata" => [
+              "A Title",
+              "a bindingnote",
+              "a generalnote",
+              "cited in Smith"
+            ]
+          }
+        ],
+        active_collection()
+      )
+
+      Solr.soft_commit(active_collection())
+
+      for term <- ["bindingnote", "generalnote", "Smith"] do
+        ids =
+          Solr.query(SearchState.from_params(%{"q" => term}))["docs"]
+          |> Enum.map(& &1["id"])
+
+        assert "searchable-metadata-doc" in ids
+      end
+    end
+
+    test "the field is searchable but not returned" do
+      Solr.add(
+        [
+          %{
+            "id" => "not-returned",
+            "title_txtm" => ["A Title"],
+            "binding_note_ss" => ["a bindingnote"],
+            "searchable_metadata" => ["A Title", "a bindingnote"]
+          }
+        ],
+        active_collection()
+      )
+
+      Solr.soft_commit(active_collection())
+
+      refute Map.has_key?(Solr.find_by_id("not-returned"), "searchable_metadata")
+    end
+  end
 end


### PR DESCRIPTION
Closes #1107 

Deployed and re-transformed records in staging.

**Staging** search from value in `notes_ss`:
<img width="1270" height="822" alt="image" src="https://github.com/user-attachments/assets/693420bd-b70d-4309-8c0a-f5575c2c6b42" />


**Production**:
<img width="1374" height="244" alt="image" src="https://github.com/user-attachments/assets/5f917513-202f-443a-b695-4242d83251a3" />